### PR TITLE
CI: generate concurrency group from github sha

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.event.after }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.event.after }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.event.after }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.event.after }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
There is currently a problem when a pull request is synchronized, merged in master and flagged as merged.

When a pull request is synchronized to be rebased on top of main a pull_request event is fired triggering new actions. Then the openwrt-bot push the just merged commit from the pull_request, from our git server back to github.
This push fire a push event and the same actions gets triggered again.

This results in double action runs and wasted resource and time that could be used on other runs.

To fix thing, change the concurrency group generation logic and base it on the workflow name + the github sha.
It is assumed that github sha is unique for push runs and for pull request runs with the only exception of merge scenario where a pull request is rebased and merged resulting in having the same sha for the pull request and the push event.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
