### PR TITLE
Update 999-44-net-airoha-Enable-multiple-irq-line-support-in-airoh.patch

### DIFF
--- a/target/linux/airoha/patches-6.6/999-44-net-airoha-Enable-multiple-irq-line-support-in-airoh.patch
+++ b/target/linux/airoha/patches-6.6/999-44-net-airoha-Enable-multiple-irq-line-support-in-airoh.patch
@@ -302,7 +302,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +	 RX19_DONE_INT_MASK | RX18_DONE_INT_MASK |	\
 +	 RX17_DONE_INT_MASK | RX16_DONE_INT_MASK)
 +
-+#define RX_DONE_INT_MASK	(RX_DONE_HIGH_INT_MASK | RX_DONE_LOW_INT_MASK)
++#define RX_DONE_INT_MASK	(0xFFFFFFFF)
 +#define RX_DONE_HIGH_OFFSET	fls(RX_DONE_HIGH_INT_MASK)
 +
 +#define INT_RX2_MASK(_n)				\


### PR DESCRIPTION
enable all the queues for supporting LRO~24-31

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
