### PR TITLE
airoha: lro: use order2 page by default

### DIFF
--- a/target/linux/airoha/patches-6.6/999-51-lro.patch
+++ b/target/linux/airoha/patches-6.6/999-51-lro.patch
@@ -49,7 +49,7 @@
  static int airoha_fe_init(struct airoha_eth *eth)
  {
  	airoha_fe_maccr_init(eth);
-@@ -641,9 +676,87 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -622,9 +657,87 @@ static int airoha_qdma_get_gdm_port(stru
  	return port >= ARRAY_SIZE(eth->ports) ? -EINVAL : port;
  }
  
@@ -137,7 +137,7 @@
  	struct airoha_qdma *qdma = q->qdma;
  	struct airoha_eth *eth = qdma->eth;
  	int qid = q - &qdma->q_rx[0];
-@@ -686,9 +799,14 @@ static int airoha_qdma_rx_process(struct
+@@ -667,9 +780,14 @@ static int airoha_qdma_rx_process(struct
  			__skb_put(q->skb, len);
  			skb_mark_for_recycle(q->skb);
  			q->skb->dev = port->dev;
@@ -153,7 +153,7 @@
  		} else { /* scattered frame */
  			struct skb_shared_info *shinfo = skb_shinfo(q->skb);
  			int nr_frags = shinfo->nr_frags;
-@@ -775,15 +893,17 @@ static int airoha_qdma_rx_napi_poll(stru
+@@ -756,15 +874,17 @@ static int airoha_qdma_rx_napi_poll(stru
  }
  
  static int airoha_qdma_init_rx_queue(struct airoha_queue *q,
@@ -161,7 +161,7 @@
 +				     struct airoha_qdma *qdma,
 +				     int ndesc, bool lro_queue)
  {
-+	int pp_order = lro_queue ? 5 : 0;
++	int pp_order = lro_queue ? AIROHA_LRO_PAGE_ORDER : 0;
  	const struct page_pool_params pp_params = {
 -		.order = 0,
 -		.pool_size = 256,
@@ -175,7 +175,7 @@
  		.nid = NUMA_NO_NODE,
  		.dev = qdma->eth->dev,
  		.napi = &q->napi,
-@@ -792,7 +912,7 @@ static int airoha_qdma_init_rx_queue(str
+@@ -773,7 +893,7 @@ static int airoha_qdma_init_rx_queue(str
  	int qid = q - &qdma->q_rx[0], thr;
  	dma_addr_t dma_addr;
  
@@ -184,7 +184,7 @@
  	q->ndesc = ndesc;
  	q->qdma = qdma;
  
-@@ -854,15 +974,18 @@ static int airoha_qdma_init_rx(struct ai
+@@ -835,15 +955,18 @@ static int airoha_qdma_init_rx(struct ai
  	int i;
  
  	for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
@@ -206,7 +206,7 @@
  		if (err)
  			return err;
  	}
-@@ -1938,6 +2061,47 @@ static int airoha_get_fe_port(struct air
+@@ -1928,6 +2051,47 @@ static int airoha_get_fe_port(struct air
  	}
  }
  
@@ -254,7 +254,7 @@
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
-@@ -2821,6 +2985,7 @@ static const struct net_device_ops airoh
+@@ -2811,6 +2975,7 @@ static const struct net_device_ops airoh
  	.ndo_stop		= airoha_dev_stop,
  	.ndo_change_mtu		= airoha_dev_change_mtu,
  	.ndo_select_queue	= airoha_dev_select_queue,
@@ -262,7 +262,7 @@
  	.ndo_start_xmit		= airoha_dev_xmit,
  	.ndo_get_stats64        = airoha_dev_get_stats64,
  	.ndo_set_mac_address	= airoha_dev_set_macaddr,
-@@ -3021,6 +3186,31 @@ static int airoha_xmit_rings_show(struct
+@@ -3011,6 +3176,31 @@ static int airoha_xmit_rings_show(struct
  }
  DEFINE_SHOW_ATTRIBUTE(airoha_xmit_rings);
  
@@ -294,7 +294,7 @@
  static int airoha_tx_meter_show(struct seq_file *s, void *data)
  {
  	struct airoha_gdm_port *port = s->private;
-@@ -3103,6 +3293,8 @@ static int airoha_register_port_debugfs(
+@@ -3093,6 +3283,8 @@ static int airoha_register_port_debugfs(
  			    &airoha_tx_meter_fops);
  	debugfs_create_file("xmit-rings", 0400, root, port,
  			    &airoha_xmit_rings_fops);
@@ -303,7 +303,7 @@
  
  	return 0;
  }
-@@ -3146,12 +3338,9 @@ static int airoha_alloc_gdm_port(struct
+@@ -3136,12 +3328,9 @@ static int airoha_alloc_gdm_port(struct
  	dev->ethtool_ops = &airoha_ethtool_ops;
  	dev->max_mtu = AIROHA_MAX_MTU;
  	dev->watchdog_timeo = 5 * HZ;
@@ -321,12 +321,13 @@
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -41,6 +41,16 @@
+@@ -41,6 +41,17 @@
  	 (_n) == 15 ? 128 :		\
  	 (_n) ==  0 ? 1024 : 16)
  
++#define AIROHA_LRO_PAGE_ORDER		2
 +#define AIROHA_MAX_NUM_LRO_QUEUES	8
-+#define AIROHA_RXQ_LRO_EN_MASK		0xff000000
++#define AIROHA_RXQ_LRO_EN_MASK		0xff
 +#define AIROHA_RXQ_LRO_MAX_AGG_TIME	100
 +#define AIROHA_RXQ_LRO_MAX_AGE_TIME	2000 /* 1ms */
 +
@@ -371,7 +372,7 @@
  #define REG_GDM_FWD_CFG(_n)		GDM_BASE(_n)
  #define GDM_PAD_EN			BIT(28)
  #define GDM_DROP_CRC_ERR		BIT(23)
-@@ -903,9 +920,15 @@
+@@ -900,9 +917,15 @@
  #define QDMA_ETH_RXMSG_SPORT_MASK	GENMASK(25, 21)
  #define QDMA_ETH_RXMSG_CRSN_MASK	GENMASK(20, 16)
  #define QDMA_ETH_RXMSG_PPE_ENTRY_MASK	GENMASK(15, 0)


### PR DESCRIPTION
Use queue [0-7] as LRO queues.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
