### PR TITLE
airoha: fix mt76 compilation error caused by airoha_npu_get API change

### DIFF
--- a/package/kernel/mt76/patches/0148-mt76-npu-add-wlan-offload.patch
+++ b/package/kernel/mt76/patches/0148-mt76-npu-add-wlan-offload.patch
@@ -2224,7 +2224,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +
 +	mutex_lock(&dev->mutex);
 +
-+	npu = airoha_npu_get(dev->dev;
++	npu = airoha_npu_get(dev->dev);
 +	if (IS_ERR(npu)) {
 +		request_module("airoha-npu");
 +		npu = airoha_npu_get(dev->dev);


### PR DESCRIPTION
fix [issue#133](https://github.com/Ansuel/openwrt/issues/133) that may introduced from this airoha_npu_get API definition change: https://lore.kernel.org/all/20250924-airoha-npu-init-stats-callback-v1-1-88bdf3c941b2@kernel.org/
