### PR TITLE
Openwrt 24.10 airoha an7581 stable fixes

### DIFF
--- a/package/boot/uboot-airoha/patches/002-clk-airoha-Add-support-for-Airoha-AN7581-SoC-clock.patch
+++ b/package/boot/uboot-airoha/patches/002-clk-airoha-Add-support-for-Airoha-AN7581-SoC-clock.patch
@@ -1,7 +1,7 @@
-From 865e93a1f89fa5382b0e4c1d4076f6bb9d43ebba Mon Sep 17 00:00:00 2001
+From 5491ab2075ad8831bac451340284ab8a5a4faab0 Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Thu, 6 Mar 2025 10:26:17 +0100
-Subject: [PATCH 2/6] clk: airoha: Add support for Airoha AN7581 SoC clock
+Subject: [PATCH] clk: airoha: Add support for Airoha AN7581 SoC clock
 
 Add support for Airoha AN7581 SoC clock driver. This mainly needed for
 eMMC support to correctly get the current clock applied.
@@ -22,11 +22,11 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  create mode 100644 drivers/clk/airoha/clk-airoha.c
 
 diff --git a/drivers/clk/Makefile b/drivers/clk/Makefile
-index fe0e49f6112..8411205ee04 100644
+index 7f84f22d4b1..9a0fc536e25 100644
 --- a/drivers/clk/Makefile
 +++ b/drivers/clk/Makefile
-@@ -14,6 +14,7 @@ obj-$(CONFIG_$(PHASE_)CLK_GPIO) += clk-gpio.o
- obj-$(CONFIG_$(PHASE_)CLK_STUB) += clk-stub.o
+@@ -13,6 +13,7 @@ obj-$(CONFIG_$(PHASE_)CLK_COMPOSITE_CCF) += clk-composite.o
+ obj-$(CONFIG_$(PHASE_)CLK_GPIO) += clk-gpio.o
  
  obj-y += adi/
 +obj-y += airoha/
@@ -487,5 +487,5 @@ index 00000000000..96d120feba7
 +	.ops = &airoha_clk_ops,
 +};
 -- 
-2.48.1
+2.51.0
 

--- a/package/boot/uboot-airoha/patches/103-01-mtd-spinand-Use-the-spi-mem-dirmap-API.patch
+++ b/package/boot/uboot-airoha/patches/103-01-mtd-spinand-Use-the-spi-mem-dirmap-API.patch
@@ -1,0 +1,320 @@
+From 3abe3e9f55bf4a0aa5902beca021601484c03923 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sun, 12 Nov 2023 20:57:52 +0300
+Subject: [PATCH 074/102] mtd: spinand: Use the spi-mem dirmap API
+
+Make use of the spi-mem direct mapping API to let advanced controllers
+optimize read/write operations when they support direct mapping.
+
+Based on a linux commit 981d1aa0697c ("mtd: spinand: Use the spi-mem dirmap API")
+created by Boris Brezillon <bbrezillon@kernel.org> with additional
+fixes taken from Linux 6.10.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: Frieder Schrempf <frieder.schrempf@kontron.de>
+---
+ drivers/mtd/nand/spi/core.c | 185 +++++++++++++++++-------------------
+ include/linux/mtd/spinand.h |   7 ++
+ 2 files changed, 95 insertions(+), 97 deletions(-)
+
+diff --git a/drivers/mtd/nand/spi/core.c b/drivers/mtd/nand/spi/core.c
+index 3a1e7e18736..c1b8b9627f2 100644
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -41,21 +41,6 @@ struct spinand_plat {
+ /* SPI NAND index visible in MTD names */
+ static int spi_nand_idx;
+ 
+-static void spinand_cache_op_adjust_colum(struct spinand_device *spinand,
+-					  const struct nand_page_io_req *req,
+-					  u16 *column)
+-{
+-	struct nand_device *nand = spinand_to_nand(spinand);
+-	unsigned int shift;
+-
+-	if (nand->memorg.planes_per_lun < 2)
+-		return;
+-
+-	/* The plane number is passed in MSB just above the column address */
+-	shift = fls(nand->memorg.pagesize);
+-	*column |= req->pos.plane << shift;
+-}
+-
+ static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
+ {
+ 	struct spi_mem_op op = SPINAND_GET_FEATURE_OP(reg,
+@@ -249,27 +234,21 @@ static int spinand_load_page_op(struct spinand_device *spinand,
+ static int spinand_read_from_cache_op(struct spinand_device *spinand,
+ 				      const struct nand_page_io_req *req)
+ {
+-	struct spi_mem_op op = *spinand->op_templates.read_cache;
+ 	struct nand_device *nand = spinand_to_nand(spinand);
+ 	struct mtd_info *mtd = nanddev_to_mtd(nand);
+-	struct nand_page_io_req adjreq = *req;
++	struct spi_mem_dirmap_desc *rdesc;
+ 	unsigned int nbytes = 0;
+ 	void *buf = NULL;
+ 	u16 column = 0;
+-	int ret;
++	ssize_t ret;
+ 
+ 	if (req->datalen) {
+-		adjreq.datalen = nanddev_page_size(nand);
+-		adjreq.dataoffs = 0;
+-		adjreq.databuf.in = spinand->databuf;
+ 		buf = spinand->databuf;
+-		nbytes = adjreq.datalen;
++		nbytes = nanddev_page_size(nand);
++		column = 0;
+ 	}
+ 
+ 	if (req->ooblen) {
+-		adjreq.ooblen = nanddev_per_page_oobsize(nand);
+-		adjreq.ooboffs = 0;
+-		adjreq.oobbuf.in = spinand->oobbuf;
+ 		nbytes += nanddev_per_page_oobsize(nand);
+ 		if (!buf) {
+ 			buf = spinand->oobbuf;
+@@ -277,28 +256,19 @@ static int spinand_read_from_cache_op(struct spinand_device *spinand,
+ 		}
+ 	}
+ 
+-	spinand_cache_op_adjust_colum(spinand, &adjreq, &column);
+-	op.addr.val = column;
++	rdesc = spinand->dirmaps[req->pos.plane].rdesc;
+ 
+-	/*
+-	 * Some controllers are limited in term of max RX data size. In this
+-	 * case, just repeat the READ_CACHE operation after updating the
+-	 * column.
+-	 */
+ 	while (nbytes) {
+-		op.data.buf.in = buf;
+-		op.data.nbytes = nbytes;
+-		ret = spi_mem_adjust_op_size(spinand->slave, &op);
+-		if (ret)
++		ret = spi_mem_dirmap_read(rdesc, column, nbytes, buf);
++		if (ret < 0)
+ 			return ret;
+ 
+-		ret = spi_mem_exec_op(spinand->slave, &op);
+-		if (ret)
+-			return ret;
++		if (!ret || ret > nbytes)
++			return -EIO;
+ 
+-		buf += op.data.nbytes;
+-		nbytes -= op.data.nbytes;
+-		op.addr.val += op.data.nbytes;
++		nbytes -= ret;
++		column += ret;
++		buf += ret;
+ 	}
+ 
+ 	if (req->datalen)
+@@ -322,14 +292,12 @@ static int spinand_read_from_cache_op(struct spinand_device *spinand,
+ static int spinand_write_to_cache_op(struct spinand_device *spinand,
+ 				     const struct nand_page_io_req *req)
+ {
+-	struct spi_mem_op op = *spinand->op_templates.write_cache;
+ 	struct nand_device *nand = spinand_to_nand(spinand);
+ 	struct mtd_info *mtd = nanddev_to_mtd(nand);
+-	struct nand_page_io_req adjreq = *req;
+-	unsigned int nbytes = 0;
+-	void *buf = NULL;
+-	u16 column = 0;
+-	int ret;
++	struct spi_mem_dirmap_desc *wdesc;
++	unsigned int nbytes, column = 0;
++	void *buf = spinand->databuf;
++	ssize_t ret;
+ 
+ 	/*
+ 	 * Looks like PROGRAM LOAD (AKA write cache) does not necessarily reset
+@@ -338,19 +306,12 @@ static int spinand_write_to_cache_op(struct spinand_device *spinand,
+ 	 * the data portion of the page, otherwise we might corrupt the BBM or
+ 	 * user data previously programmed in OOB area.
+ 	 */
+-	memset(spinand->databuf, 0xff,
+-	       nanddev_page_size(nand) +
+-	       nanddev_per_page_oobsize(nand));
++	nbytes = nanddev_page_size(nand) + nanddev_per_page_oobsize(nand);
++	memset(spinand->databuf, 0xff, nbytes);
+ 
+-	if (req->datalen) {
++	if (req->datalen)
+ 		memcpy(spinand->databuf + req->dataoffs, req->databuf.out,
+ 		       req->datalen);
+-		adjreq.dataoffs = 0;
+-		adjreq.datalen = nanddev_page_size(nand);
+-		adjreq.databuf.out = spinand->databuf;
+-		nbytes = adjreq.datalen;
+-		buf = spinand->databuf;
+-	}
+ 
+ 	if (req->ooblen) {
+ 		if (req->mode == MTD_OPS_AUTO_OOB)
+@@ -361,52 +322,21 @@ static int spinand_write_to_cache_op(struct spinand_device *spinand,
+ 		else
+ 			memcpy(spinand->oobbuf + req->ooboffs, req->oobbuf.out,
+ 			       req->ooblen);
+-
+-		adjreq.ooblen = nanddev_per_page_oobsize(nand);
+-		adjreq.ooboffs = 0;
+-		nbytes += nanddev_per_page_oobsize(nand);
+-		if (!buf) {
+-			buf = spinand->oobbuf;
+-			column = nanddev_page_size(nand);
+-		}
+ 	}
+ 
+-	spinand_cache_op_adjust_colum(spinand, &adjreq, &column);
+-
+-	op = *spinand->op_templates.write_cache;
+-	op.addr.val = column;
++	wdesc = spinand->dirmaps[req->pos.plane].wdesc;
+ 
+-	/*
+-	 * Some controllers are limited in term of max TX data size. In this
+-	 * case, split the operation into one LOAD CACHE and one or more
+-	 * LOAD RANDOM CACHE.
+-	 */
+ 	while (nbytes) {
+-		op.data.buf.out = buf;
+-		op.data.nbytes = nbytes;
+-
+-		ret = spi_mem_adjust_op_size(spinand->slave, &op);
+-		if (ret)
+-			return ret;
+-
+-		ret = spi_mem_exec_op(spinand->slave, &op);
+-		if (ret)
++		ret = spi_mem_dirmap_write(wdesc, column, nbytes, buf);
++		if (ret < 0)
+ 			return ret;
+ 
+-		buf += op.data.nbytes;
+-		nbytes -= op.data.nbytes;
+-		op.addr.val += op.data.nbytes;
++		if (!ret || ret > nbytes)
++			return -EIO;
+ 
+-		/*
+-		 * We need to use the RANDOM LOAD CACHE operation if there's
+-		 * more than one iteration, because the LOAD operation resets
+-		 * the cache to 0xff.
+-		 */
+-		if (nbytes) {
+-			column = op.addr.val;
+-			op = *spinand->op_templates.update_cache;
+-			op.addr.val = column;
+-		}
++		nbytes -= ret;
++		column += ret;
++		buf += ret;
+ 	}
+ 
+ 	return 0;
+@@ -819,6 +749,59 @@ static int spinand_mtd_block_isreserved(struct mtd_info *mtd, loff_t offs)
+ 	return ret;
+ }
+ 
++static int spinand_create_dirmap(struct spinand_device *spinand,
++				 unsigned int plane)
++{
++	struct nand_device *nand = spinand_to_nand(spinand);
++	struct spi_mem_dirmap_info info = {
++		.length = nanddev_page_size(nand) +
++			  nanddev_per_page_oobsize(nand),
++	};
++	struct spi_mem_dirmap_desc *desc;
++
++	/* The plane number is passed in MSB just above the column address */
++	info.offset = plane << fls(nand->memorg.pagesize);
++
++	info.op_tmpl = *spinand->op_templates.update_cache;
++	desc = spi_mem_dirmap_create(spinand->slave, &info);
++	if (IS_ERR(desc))
++		return PTR_ERR(desc);
++
++	spinand->dirmaps[plane].wdesc = desc;
++
++	info.op_tmpl = *spinand->op_templates.read_cache;
++	desc = spi_mem_dirmap_create(spinand->slave, &info);
++	if (IS_ERR(desc)) {
++		spi_mem_dirmap_destroy(spinand->dirmaps[plane].wdesc);
++		return PTR_ERR(desc);
++	}
++
++	spinand->dirmaps[plane].rdesc = desc;
++
++	return 0;
++}
++
++static int spinand_create_dirmaps(struct spinand_device *spinand)
++{
++	struct nand_device *nand = spinand_to_nand(spinand);
++	int i, ret;
++
++	spinand->dirmaps = devm_kzalloc(spinand->slave->dev,
++					sizeof(*spinand->dirmaps) *
++					nand->memorg.planes_per_lun,
++					GFP_KERNEL);
++	if (!spinand->dirmaps)
++		return -ENOMEM;
++
++	for (i = 0; i < nand->memorg.planes_per_lun; i++) {
++		ret = spinand_create_dirmap(spinand, i);
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++
+ static const struct nand_ops spinand_ops = {
+ 	.erase = spinand_erase,
+ 	.markbad = spinand_markbad,
+@@ -1134,6 +1117,14 @@ static int spinand_init(struct spinand_device *spinand)
+ 		goto err_free_bufs;
+ 	}
+ 
++	ret = spinand_create_dirmaps(spinand);
++	if (ret) {
++		dev_err(spinand->slave->dev,
++			"Failed to create direct mappings for read/write operations (err = %d)\n",
++			ret);
++		goto err_manuf_cleanup;
++	}
++
+ 	/* After power up, all blocks are locked, so unlock them here. */
+ 	for (i = 0; i < nand->memorg.ntargets; i++) {
+ 		ret = spinand_select_target(spinand, i);
+diff --git a/include/linux/mtd/spinand.h b/include/linux/mtd/spinand.h
+index 6fe6fd520a4..163269313f6 100644
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -363,6 +363,11 @@ struct spinand_info {
+ 		__VA_ARGS__						\
+ 	}
+ 
++struct spinand_dirmap {
++	struct spi_mem_dirmap_desc *wdesc;
++	struct spi_mem_dirmap_desc *rdesc;
++};
++
+ /**
+  * struct spinand_device - SPI NAND device instance
+  * @base: NAND device instance
+@@ -406,6 +411,8 @@ struct spinand_device {
+ 		const struct spi_mem_op *update_cache;
+ 	} op_templates;
+ 
++	struct spinand_dirmap *dirmaps;
++
+ 	int (*select_target)(struct spinand_device *spinand,
+ 			     unsigned int target);
+ 	unsigned int cur_target;
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/103-02-spi-airoha-remove-unnecessary-operation-adjust_op_si.patch
+++ b/package/boot/uboot-airoha/patches/103-02-spi-airoha-remove-unnecessary-operation-adjust_op_si.patch
@@ -1,0 +1,53 @@
+From f4efc4b03001076e175042fdc2d2805e1c0babc7 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sat, 7 Jun 2025 07:18:12 +0300
+Subject: [PATCH 075/102] spi: airoha: remove unnecessary operation
+ adjust_op_size
+
+This operation is not needed because airoha_snand_write_data() and
+airoha_snand_read_data() will properly handle data transfers above
+SPI_MAX_TRANSFER_SIZE.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 61d4e194677..68598e8b8e8 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -524,22 +524,6 @@ static int airoha_snand_nfi_config(struct airoha_snand_priv *priv)
+ 				  SPI_NFI_CUS_SEC_SIZE, val);
+ }
+ 
+-static int airoha_snand_adjust_op_size(struct spi_slave *slave,
+-				       struct spi_mem_op *op)
+-{
+-
+-	size_t max_len;
+-
+-	max_len = 1 + op->addr.nbytes + op->dummy.nbytes;
+-	if (max_len >= 160)
+-		return -EOPNOTSUPP;
+-
+-	if (op->data.nbytes > 160 - max_len)
+-		op->data.nbytes = 160 - max_len;
+-
+-	return 0;
+-}
+-
+ static bool airoha_snand_supports_op(struct spi_slave *slave,
+ 				     const struct spi_mem_op *op)
+ {
+@@ -692,7 +676,6 @@ static int airoha_snand_nfi_setup(struct spi_slave *slave,
+ }
+ 
+ static const struct spi_controller_mem_ops airoha_snand_mem_ops = {
+-	.adjust_op_size = airoha_snand_adjust_op_size,
+ 	.supports_op = airoha_snand_supports_op,
+ 	.exec_op = airoha_snand_exec_op,
+ };
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/103-03-spi-airoha-add-support-of-dual-quad-wires-spi-modes-.patch
+++ b/package/boot/uboot-airoha/patches/103-03-spi-airoha-add-support-of-dual-quad-wires-spi-modes-.patch
@@ -1,0 +1,262 @@
+From fbd729560db4174e46ba7624b579deff64e6b3e8 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sat, 7 Jun 2025 09:09:38 +0300
+Subject: [PATCH 076/102] spi: airoha: add support of dual/quad wires spi modes
+ to exec_op() handler
+
+Booting without this patch and disabled dirmap support results in
+
+[    2.980719] spi-nand spi0.0: Micron SPI NAND was found.
+[    2.986040] spi-nand spi0.0: 256 MiB, block size: 128 KiB, page size: 2048, OOB size: 128
+[    2.994709] 2 fixed-partitions partitions found on MTD device spi0.0
+[    3.001075] Creating 2 MTD partitions on "spi0.0":
+[    3.005862] 0x000000000000-0x000000020000 : "bl2"
+[    3.011272] 0x000000020000-0x000010000000 : "ubi"
+...
+[    6.195594] ubi0: attaching mtd1
+[   13.338398] ubi0: scanning is finished
+[   13.342188] ubi0 error: ubi_read_volume_table: the layout volume was not found
+[   13.349784] ubi0 error: ubi_attach_mtd_dev: failed to attach mtd1, error -22
+[   13.356897] UBI error: cannot attach mtd1
+
+If dirmap is disabled or not supported in the spi driver, the dirmap requests
+will be executed via exec_op() handler. Thus, if the hardware supports
+dual/quad spi modes, then corresponding requests will be sent to exec_op()
+handler. Current driver does not support such requests, so error is arrised.
+As result the flash can't be read/write.
+
+This patch adds support of dual and quad wires spi modes to exec_op() handler.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 143 +++++++++++++++++++++++++++-------
+ 1 file changed, 117 insertions(+), 26 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 68598e8b8e8..dedcd8e28dc 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -185,6 +185,14 @@
+ #define SPI_NAND_OP_RESET			0xff
+ #define SPI_NAND_OP_DIE_SELECT			0xc2
+ 
++/* SNAND FIFO commands */
++#define SNAND_FIFO_TX_BUSWIDTH_SINGLE		0x08
++#define SNAND_FIFO_TX_BUSWIDTH_DUAL		0x09
++#define SNAND_FIFO_TX_BUSWIDTH_QUAD		0x0a
++#define SNAND_FIFO_RX_BUSWIDTH_SINGLE		0x0c
++#define SNAND_FIFO_RX_BUSWIDTH_DUAL		0x0e
++#define SNAND_FIFO_RX_BUSWIDTH_QUAD		0x0f
++
+ #define SPI_NAND_CACHE_SIZE			(SZ_4K + SZ_256)
+ #define SPI_MAX_TRANSFER_SIZE			511
+ 
+@@ -379,10 +387,26 @@ static int airoha_snand_set_mode(struct airoha_snand_priv *priv,
+ 	return regmap_write(priv->regmap_ctrl, REG_SPI_CTRL_DUMMY, 0);
+ }
+ 
+-static int airoha_snand_write_data(struct airoha_snand_priv *priv, u8 cmd,
+-				   const u8 *data, int len)
++static int airoha_snand_write_data(struct airoha_snand_priv *priv,
++				   const u8 *data, int len, int buswidth)
+ {
+ 	int i, data_len;
++	u8 cmd;
++
++	switch (buswidth) {
++	case 0:
++	case 1:
++		cmd = SNAND_FIFO_TX_BUSWIDTH_SINGLE;
++		break;
++	case 2:
++		cmd = SNAND_FIFO_TX_BUSWIDTH_DUAL;
++		break;
++	case 4:
++		cmd = SNAND_FIFO_TX_BUSWIDTH_QUAD;
++		break;
++	default:
++		return -EINVAL;
++	}
+ 
+ 	for (i = 0; i < len; i += data_len) {
+ 		int err;
+@@ -401,16 +425,32 @@ static int airoha_snand_write_data(struct airoha_snand_priv *priv, u8 cmd,
+ 	return 0;
+ }
+ 
+-static int airoha_snand_read_data(struct airoha_snand_priv *priv, u8 *data,
+-				  int len)
++static int airoha_snand_read_data(struct airoha_snand_priv *priv,
++				  u8 *data, int len, int buswidth)
+ {
+ 	int i, data_len;
++	u8 cmd;
++
++	switch (buswidth) {
++	case 0:
++	case 1:
++		cmd = SNAND_FIFO_RX_BUSWIDTH_SINGLE;
++		break;
++	case 2:
++		cmd = SNAND_FIFO_RX_BUSWIDTH_DUAL;
++		break;
++	case 4:
++		cmd = SNAND_FIFO_RX_BUSWIDTH_QUAD;
++		break;
++	default:
++		return -EINVAL;
++	}
+ 
+ 	for (i = 0; i < len; i += data_len) {
+ 		int err;
+ 
+ 		data_len = min(len - i, SPI_MAX_TRANSFER_SIZE);
+-		err = airoha_snand_set_fifo_op(priv, 0xc, data_len);
++		err = airoha_snand_set_fifo_op(priv, cmd, data_len);
+ 		if (err)
+ 			return err;
+ 
+@@ -524,6 +564,38 @@ static int airoha_snand_nfi_config(struct airoha_snand_priv *priv)
+ 				  SPI_NFI_CUS_SEC_SIZE, val);
+ }
+ 
++static bool airoha_snand_is_page_ops(const struct spi_mem_op *op)
++{
++	if (op->addr.nbytes != 2)
++		return false;
++
++	if (op->addr.buswidth != 1 && op->addr.buswidth != 2 &&
++	    op->addr.buswidth != 4)
++		return false;
++
++	switch (op->data.dir) {
++	case SPI_MEM_DATA_IN:
++		if (op->dummy.nbytes * BITS_PER_BYTE / op->dummy.buswidth > 0xf)
++			return false;
++
++		/* quad in / quad out */
++		if (op->addr.buswidth == 4)
++			return op->data.buswidth == 4;
++
++		if (op->addr.buswidth == 2)
++			return op->data.buswidth == 2;
++
++		/* standard spi */
++		return op->data.buswidth == 4 || op->data.buswidth == 2 ||
++		       op->data.buswidth == 1;
++	case SPI_MEM_DATA_OUT:
++		return !op->dummy.nbytes && op->addr.buswidth == 1 &&
++		       (op->data.buswidth == 4 || op->data.buswidth == 1);
++	default:
++		return false;
++	}
++}
++
+ static bool airoha_snand_supports_op(struct spi_slave *slave,
+ 				     const struct spi_mem_op *op)
+ {
+@@ -533,6 +605,9 @@ static bool airoha_snand_supports_op(struct spi_slave *slave,
+ 	if (op->cmd.buswidth != 1)
+ 		return false;
+ 
++	if (airoha_snand_is_page_ops(op))
++		return true;
++
+ 	return (!op->addr.nbytes || op->addr.buswidth == 1) &&
+ 	       (!op->dummy.nbytes || op->dummy.buswidth == 1) &&
+ 	       (!op->data.nbytes || op->data.buswidth == 1);
+@@ -541,13 +616,29 @@ static bool airoha_snand_supports_op(struct spi_slave *slave,
+ static int airoha_snand_exec_op(struct spi_slave *slave,
+ 				const struct spi_mem_op *op)
+ {
+-	u8 data[8], cmd, opcode = op->cmd.opcode;
+ 	struct udevice *bus = slave->dev->parent;
+ 	struct airoha_snand_priv *priv;
++	int op_len, addr_len, dummy_len;
++	u8 buf[20], *data;
+ 	int i, err;
+ 
+ 	priv = dev_get_priv(bus);
+ 
++	op_len = op->cmd.nbytes;
++	addr_len = op->addr.nbytes;
++	dummy_len = op->dummy.nbytes;
++
++	if (op_len + dummy_len + addr_len > sizeof(buf))
++		return -EIO;
++
++	data = buf;
++	for (i = 0; i < op_len; i++)
++		*data++ = op->cmd.opcode >> (8 * (op_len - i - 1));
++	for (i = 0; i < addr_len; i++)
++		*data++ = op->addr.val >> (8 * (addr_len - i - 1));
++	for (i = 0; i < dummy_len; i++)
++		*data++ = 0xff;
++
+ 	/* switch to manual mode */
+ 	err = airoha_snand_set_mode(priv, SPI_MODE_MANUAL);
+ 	if (err < 0)
+@@ -558,40 +649,40 @@ static int airoha_snand_exec_op(struct spi_slave *slave,
+ 		return err;
+ 
+ 	/* opcode */
+-	err = airoha_snand_write_data(priv, 0x8, &opcode, sizeof(opcode));
++	data = buf;
++	err = airoha_snand_write_data(priv, data, op_len,
++				      op->cmd.buswidth);
+ 	if (err)
+ 		return err;
+ 
+ 	/* addr part */
+-	cmd = opcode == SPI_NAND_OP_GET_FEATURE ? 0x11 : 0x8;
+-	put_unaligned_be64(op->addr.val, data);
+-
+-	for (i = ARRAY_SIZE(data) - op->addr.nbytes;
+-	     i < ARRAY_SIZE(data); i++) {
+-		err = airoha_snand_write_data(priv, cmd, &data[i],
+-					      sizeof(data[0]));
++	data += op_len;
++	if (addr_len) {
++		err = airoha_snand_write_data(priv, data, addr_len,
++					      op->addr.buswidth);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+ 	/* dummy */
+-	data[0] = 0xff;
+-	for (i = 0; i < op->dummy.nbytes; i++) {
+-		err = airoha_snand_write_data(priv, 0x8, &data[0],
+-					      sizeof(data[0]));
++	data += addr_len;
++	if (dummy_len) {
++		err = airoha_snand_write_data(priv, data, dummy_len,
++					      op->dummy.buswidth);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+ 	/* data */
+-	if (op->data.dir == SPI_MEM_DATA_IN) {
+-		err = airoha_snand_read_data(priv, op->data.buf.in,
+-					     op->data.nbytes);
+-		if (err)
+-			return err;
+-	} else {
+-		err = airoha_snand_write_data(priv, 0x8, op->data.buf.out,
+-					      op->data.nbytes);
++	if (op->data.nbytes) {
++		if (op->data.dir == SPI_MEM_DATA_IN)
++			err = airoha_snand_read_data(priv, op->data.buf.in,
++						     op->data.nbytes,
++						     op->data.buswidth);
++		else
++			err = airoha_snand_write_data(priv, op->data.buf.out,
++						      op->data.nbytes,
++						      op->data.buswidth);
+ 		if (err)
+ 			return err;
+ 	}
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/103-04-spi-airoha-add-dma-support.patch
+++ b/package/boot/uboot-airoha/patches/103-04-spi-airoha-add-dma-support.patch
@@ -1,0 +1,378 @@
+From 3ad92b3fd8217c99ab1bb00457c5a0da40189993 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sun, 8 Jun 2025 05:30:22 +0300
+Subject: [PATCH 077/102] spi: airoha: add dma support
+
+This patch speed up cache reading/writing/updating opearions.
+It was tested on en7523/an7581 and some other Airoha chips.
+
+It will speed up
+ * page reading/writing without oob
+ * page reading/writing with oob
+ * oob reading/writing (significant for UBI scanning)
+
+The only know issue appears in a very specific conditions for en7523 family
+chips only.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 309 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 309 insertions(+)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index dedcd8e28dc..9c05f576dfb 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -140,12 +140,14 @@
+ #define SPI_NFI_CUS_SEC_SIZE_EN			BIT(16)
+ 
+ #define REG_SPI_NFI_RD_CTL2			0x0510
++
+ #define REG_SPI_NFI_RD_CTL3			0x0514
+ 
+ #define REG_SPI_NFI_PG_CTL1			0x0524
+ #define SPI_NFI_PG_LOAD_CMD			GENMASK(15, 8)
+ 
+ #define REG_SPI_NFI_PG_CTL2			0x0528
++
+ #define REG_SPI_NFI_NOR_PROG_ADDR		0x052c
+ #define REG_SPI_NFI_NOR_RD_ADDR			0x0534
+ 
+@@ -218,6 +220,8 @@ struct airoha_snand_priv {
+ 		u8 sec_num;
+ 		u8 spare_size;
+ 	} nfi_cfg;
++
++	u8 *txrx_buf;
+ };
+ 
+ static int airoha_snand_set_fifo_op(struct airoha_snand_priv *priv,
+@@ -613,6 +617,302 @@ static bool airoha_snand_supports_op(struct spi_slave *slave,
+ 	       (!op->data.nbytes || op->data.buswidth == 1);
+ }
+ 
++static int airoha_snand_dirmap_create(struct spi_mem_dirmap_desc *desc)
++{
++	struct spi_slave *slave = desc->slave;
++	struct udevice *bus = slave->dev->parent;
++	struct airoha_snand_priv *priv = dev_get_priv(bus);
++
++	if (!priv->txrx_buf)
++		return -EINVAL;
++
++	if (desc->info.offset + desc->info.length > U32_MAX)
++		return -EINVAL;
++
++	if (!airoha_snand_supports_op(desc->slave, &desc->info.op_tmpl))
++		return -EOPNOTSUPP;
++
++	return 0;
++}
++
++static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
++					u64 offs, size_t len, void *buf)
++{
++	struct spi_mem_op *op = &desc->info.op_tmpl;
++	struct spi_slave *slave = desc->slave;
++	struct udevice *bus = slave->dev->parent;
++	struct airoha_snand_priv *priv = dev_get_priv(bus);
++	u8 *txrx_buf = priv->txrx_buf;
++	dma_addr_t dma_addr;
++	u32 val, rd_mode;
++	int err;
++
++	switch (op->cmd.opcode) {
++	case SPI_NAND_OP_READ_FROM_CACHE_DUAL:
++		rd_mode = 1;
++		break;
++	case SPI_NAND_OP_READ_FROM_CACHE_QUAD:
++		rd_mode = 2;
++		break;
++	default:
++		rd_mode = 0;
++		break;
++	}
++
++	err = airoha_snand_set_mode(priv, SPI_MODE_DMA);
++	if (err < 0)
++		return err;
++
++	err = airoha_snand_nfi_config(priv);
++	if (err)
++		goto error_dma_mode_off;
++
++	dma_addr = dma_map_single(txrx_buf, SPI_NAND_CACHE_SIZE,
++				  DMA_FROM_DEVICE);
++
++	/* set dma addr */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_STRADDR,
++			   dma_addr);
++	if (err)
++		goto error_dma_unmap;
++
++	/* set cust sec size */
++	val = priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num;
++	val = FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, val);
++	err = regmap_update_bits(priv->regmap_nfi,
++				 REG_SPI_NFI_SNF_MISC_CTL2,
++				 SPI_NFI_READ_DATA_BYTE_NUM, val);
++	if (err)
++		goto error_dma_unmap;
++
++	/* set read command */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_RD_CTL2,
++			   op->cmd.opcode);
++	if (err)
++		goto error_dma_unmap;
++
++	/* set read mode */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_SNF_MISC_CTL,
++			   FIELD_PREP(SPI_NFI_DATA_READ_WR_MODE, rd_mode));
++	if (err)
++		goto error_dma_unmap;
++
++	/* set read addr: zero page offset + descriptor read offset */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_RD_CTL3,
++			   desc->info.offset);
++	if (err)
++		goto error_dma_unmap;
++
++	/* set nfi read */
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++				 SPI_NFI_OPMODE,
++				 FIELD_PREP(SPI_NFI_OPMODE, 6));
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++			      SPI_NFI_READ_MODE | SPI_NFI_DMA_MODE);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CMD, 0x0);
++	if (err)
++		goto error_dma_unmap;
++
++	/* trigger dma reading */
++	err = regmap_clear_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
++				SPI_NFI_RD_TRIG);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
++			      SPI_NFI_RD_TRIG);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_read_poll_timeout(priv->regmap_nfi,
++				       REG_SPI_NFI_SNF_STA_CTL1, val,
++				       (val & SPI_NFI_READ_FROM_CACHE_DONE),
++				       0, 1 * MSEC_PER_SEC);
++	if (err)
++		goto error_dma_unmap;
++
++	/*
++	 * SPI_NFI_READ_FROM_CACHE_DONE bit must be written at the end
++	 * of dirmap_read operation even if it is already set.
++	 */
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_SNF_STA_CTL1,
++				 SPI_NFI_READ_FROM_CACHE_DONE,
++				 SPI_NFI_READ_FROM_CACHE_DONE);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_read_poll_timeout(priv->regmap_nfi, REG_SPI_NFI_INTR,
++				       val, (val & SPI_NFI_AHB_DONE), 0,
++				       1 * MSEC_PER_SEC);
++	if (err)
++		goto error_dma_unmap;
++
++	/* DMA read need delay for data ready from controller to DRAM */
++	udelay(1);
++
++	dma_unmap_single(dma_addr, SPI_NAND_CACHE_SIZE, DMA_FROM_DEVICE);
++
++	err = airoha_snand_set_mode(priv, SPI_MODE_MANUAL);
++	if (err < 0)
++		return err;
++
++	memcpy(buf, txrx_buf + offs, len);
++
++	return len;
++
++error_dma_unmap:
++	dma_unmap_single(dma_addr, SPI_NAND_CACHE_SIZE, DMA_FROM_DEVICE);
++error_dma_mode_off:
++	airoha_snand_set_mode(priv, SPI_MODE_MANUAL);
++	return err;
++}
++
++static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
++					 u64 offs, size_t len, const void *buf)
++{
++	struct spi_slave *slave = desc->slave;
++	struct udevice *bus = slave->dev->parent;
++	struct airoha_snand_priv *priv = dev_get_priv(bus);
++	u8 *txrx_buf = priv->txrx_buf;
++	dma_addr_t dma_addr;
++	u32 wr_mode, val, opcode;
++	int err;
++
++	opcode = desc->info.op_tmpl.cmd.opcode;
++	switch (opcode) {
++	case SPI_NAND_OP_PROGRAM_LOAD_SINGLE:
++	case SPI_NAND_OP_PROGRAM_LOAD_RAMDOM_SINGLE:
++		wr_mode = 0;
++		break;
++	case SPI_NAND_OP_PROGRAM_LOAD_QUAD:
++	case SPI_NAND_OP_PROGRAM_LOAD_RAMDON_QUAD:
++		wr_mode = 2;
++		break;
++	default:
++		/* unknown opcode */
++		return -EOPNOTSUPP;
++	}
++
++	memcpy(txrx_buf + offs, buf, len);
++
++	err = airoha_snand_set_mode(priv, SPI_MODE_DMA);
++	if (err < 0)
++		return err;
++
++	err = airoha_snand_nfi_config(priv);
++	if (err)
++		goto error_dma_mode_off;
++
++	dma_addr = dma_map_single(txrx_buf, SPI_NAND_CACHE_SIZE,
++				  DMA_TO_DEVICE);
++
++	/* set dma addr */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_STRADDR,
++			   dma_addr);
++	if (err)
++		goto error_dma_unmap;
++
++	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM,
++			 priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num);
++	err = regmap_update_bits(priv->regmap_nfi,
++				 REG_SPI_NFI_SNF_MISC_CTL2,
++				 SPI_NFI_PROG_LOAD_BYTE_NUM, val);
++	if (err)
++		goto error_dma_unmap;
++
++	/* set write command */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_PG_CTL1,
++			   FIELD_PREP(SPI_NFI_PG_LOAD_CMD, opcode));
++	if (err)
++		goto error_dma_unmap;
++
++	/* set write mode */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_SNF_MISC_CTL,
++			   FIELD_PREP(SPI_NFI_DATA_READ_WR_MODE, wr_mode));
++	if (err)
++		goto error_dma_unmap;
++
++	/* set write addr: zero page offset + descriptor write offset */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_PG_CTL2,
++			   desc->info.offset);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_clear_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++				SPI_NFI_READ_MODE);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++				 SPI_NFI_OPMODE,
++				 FIELD_PREP(SPI_NFI_OPMODE, 3));
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++			      SPI_NFI_DMA_MODE);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CMD, 0x80);
++	if (err)
++		goto error_dma_unmap;
++
++	/* trigger dma writing */
++	err = regmap_clear_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
++				SPI_NFI_WR_TRIG);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
++			      SPI_NFI_WR_TRIG);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_read_poll_timeout(priv->regmap_nfi, REG_SPI_NFI_INTR,
++				       val, (val & SPI_NFI_AHB_DONE), 0,
++				       1 * MSEC_PER_SEC);
++	if (err)
++		goto error_dma_unmap;
++
++	err = regmap_read_poll_timeout(priv->regmap_nfi,
++				       REG_SPI_NFI_SNF_STA_CTL1, val,
++				       (val & SPI_NFI_LOAD_TO_CACHE_DONE),
++				       0, 1 * MSEC_PER_SEC);
++	if (err)
++		goto error_dma_unmap;
++
++	/*
++	 * SPI_NFI_LOAD_TO_CACHE_DONE bit must be written at the end
++	 * of dirmap_write operation even if it is already set.
++	 */
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_SNF_STA_CTL1,
++				 SPI_NFI_LOAD_TO_CACHE_DONE,
++				 SPI_NFI_LOAD_TO_CACHE_DONE);
++	if (err)
++		goto error_dma_unmap;
++
++	dma_unmap_single(dma_addr, SPI_NAND_CACHE_SIZE, DMA_TO_DEVICE);
++
++	err = airoha_snand_set_mode(priv, SPI_MODE_MANUAL);
++	if (err < 0)
++		return err;
++
++	return len;
++
++error_dma_unmap:
++	dma_unmap_single(dma_addr, SPI_NAND_CACHE_SIZE, DMA_TO_DEVICE);
++error_dma_mode_off:
++	airoha_snand_set_mode(priv, SPI_MODE_MANUAL);
++	return err;
++}
++
+ static int airoha_snand_exec_op(struct spi_slave *slave,
+ 				const struct spi_mem_op *op)
+ {
+@@ -695,6 +995,12 @@ static int airoha_snand_probe(struct udevice *dev)
+ 	struct airoha_snand_priv *priv = dev_get_priv(dev);
+ 	int ret;
+ 
++	priv->txrx_buf = memalign(ARCH_DMA_MINALIGN, SPI_NAND_CACHE_SIZE);
++	if (!priv->txrx_buf) {
++		dev_err(dev, "failed to alloacate memory for dirmap\n");
++		return -ENOMEM;
++	}
++
+ 	ret = regmap_init_mem_index(dev_ofnode(dev), &priv->regmap_ctrl, 0);
+ 	if (ret) {
+ 		dev_err(dev, "failed to init spi ctrl regmap\n");
+@@ -769,6 +1075,9 @@ static int airoha_snand_nfi_setup(struct spi_slave *slave,
+ static const struct spi_controller_mem_ops airoha_snand_mem_ops = {
+ 	.supports_op = airoha_snand_supports_op,
+ 	.exec_op = airoha_snand_exec_op,
++	.dirmap_create = airoha_snand_dirmap_create,
++	.dirmap_read = airoha_snand_dirmap_read,
++	.dirmap_write = airoha_snand_dirmap_write,
+ };
+ 
+ static const struct dm_spi_ops airoha_snfi_spi_ops = {
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/103-05-spi-airoha-support-of-dualio-quadio-flash-reading-co.patch
+++ b/package/boot/uboot-airoha/patches/103-05-spi-airoha-support-of-dualio-quadio-flash-reading-co.patch
@@ -1,0 +1,94 @@
+From 120cde965e4afcf1c4117031d557efa6287c99d0 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sun, 8 Jun 2025 05:30:22 +0300
+Subject: [PATCH 078/102] spi: airoha: support of dualio/quadio flash reading
+ commands
+
+Airoha snfi spi controller supports acceleration of DUAL/QUAD
+operations, but does not supports DUAL_IO/QUAD_IO operations.
+Luckily DUAL/QUAD operations do the same as DUAL_IO/QUAD_IO ones,
+so we can issue corresponding DUAL/QUAD operation instead of
+DUAL_IO/QUAD_IO one.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 27 +++++++++++++++++++++------
+ 1 file changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 9c05f576dfb..afbd9c46bf5 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -140,6 +140,7 @@
+ #define SPI_NFI_CUS_SEC_SIZE_EN			BIT(16)
+ 
+ #define REG_SPI_NFI_RD_CTL2			0x0510
++#define SPI_NFI_DATA_READ_CMD			GENMASK(7, 0)
+ 
+ #define REG_SPI_NFI_RD_CTL3			0x0514
+ 
+@@ -174,7 +175,9 @@
+ #define SPI_NAND_OP_READ_FROM_CACHE_SINGLE	0x03
+ #define SPI_NAND_OP_READ_FROM_CACHE_SINGLE_FAST	0x0b
+ #define SPI_NAND_OP_READ_FROM_CACHE_DUAL	0x3b
++#define SPI_NAND_OP_READ_FROM_CACHE_DUALIO	0xbb
+ #define SPI_NAND_OP_READ_FROM_CACHE_QUAD	0x6b
++#define SPI_NAND_OP_READ_FROM_CACHE_QUADIO	0xeb
+ #define SPI_NAND_OP_WRITE_ENABLE		0x06
+ #define SPI_NAND_OP_WRITE_DISABLE		0x04
+ #define SPI_NAND_OP_PROGRAM_LOAD_SINGLE		0x02
+@@ -638,25 +641,37 @@ static int airoha_snand_dirmap_create(struct spi_mem_dirmap_desc *desc)
+ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 					u64 offs, size_t len, void *buf)
+ {
+-	struct spi_mem_op *op = &desc->info.op_tmpl;
+ 	struct spi_slave *slave = desc->slave;
+ 	struct udevice *bus = slave->dev->parent;
+ 	struct airoha_snand_priv *priv = dev_get_priv(bus);
+ 	u8 *txrx_buf = priv->txrx_buf;
+ 	dma_addr_t dma_addr;
+-	u32 val, rd_mode;
++	u32 val, rd_mode, opcode;
+ 	int err;
+ 
+-	switch (op->cmd.opcode) {
++	/*
++	 * DUALIO and QUADIO opcodes are not supported by the spi controller,
++	 * replace them with supported opcodes.
++	 */
++	opcode = desc->info.op_tmpl.cmd.opcode;
++	switch (opcode) {
++	case SPI_NAND_OP_READ_FROM_CACHE_SINGLE:
++	case SPI_NAND_OP_READ_FROM_CACHE_SINGLE_FAST:
++		rd_mode = 0;
++		break;
+ 	case SPI_NAND_OP_READ_FROM_CACHE_DUAL:
++	case SPI_NAND_OP_READ_FROM_CACHE_DUALIO:
++		opcode = SPI_NAND_OP_READ_FROM_CACHE_DUAL;
+ 		rd_mode = 1;
+ 		break;
+ 	case SPI_NAND_OP_READ_FROM_CACHE_QUAD:
++	case SPI_NAND_OP_READ_FROM_CACHE_QUADIO:
++		opcode = SPI_NAND_OP_READ_FROM_CACHE_QUAD;
+ 		rd_mode = 2;
+ 		break;
+ 	default:
+-		rd_mode = 0;
+-		break;
++		/* unknown opcode */
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	err = airoha_snand_set_mode(priv, SPI_MODE_DMA);
+@@ -687,7 +702,7 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 
+ 	/* set read command */
+ 	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_RD_CTL2,
+-			   op->cmd.opcode);
++			   FIELD_PREP(SPI_NFI_DATA_READ_CMD, opcode));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/104-01-spi-airoha-avoid-setting-of-page-oob-sizes-in-REG_SP.patch
+++ b/package/boot/uboot-airoha/patches/104-01-spi-airoha-avoid-setting-of-page-oob-sizes-in-REG_SP.patch
@@ -1,0 +1,67 @@
+From 04c891516d2115f6f3b86b5d44ff2f34dad4d2a4 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 18:00:32 +0300
+Subject: [PATCH 079/102] spi: airoha: avoid setting of page/oob sizes in
+ REG_SPI_NFI_PAGEFMT
+
+spi-airoha-snfi uses custom sector size in REG_SPI_NFI_SECCUS_SIZE
+register, so setting of page/oob sizes in REG_SPI_NFI_PAGEFMT is not
+required.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 38 -----------------------------------
+ 1 file changed, 38 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index afbd9c46bf5..8aaa01e66a3 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -513,44 +513,6 @@ static int airoha_snand_nfi_config(struct airoha_snand_priv *priv)
+ 	if (err)
+ 		return err;
+ 
+-	/* page format */
+-	switch (priv->nfi_cfg.spare_size) {
+-	case 26:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x1);
+-		break;
+-	case 27:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x2);
+-		break;
+-	case 28:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x3);
+-		break;
+-	default:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x0);
+-		break;
+-	}
+-
+-	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_PAGEFMT,
+-				 SPI_NFI_SPARE_SIZE, val);
+-	if (err)
+-		return err;
+-
+-	switch (priv->nfi_cfg.page_size) {
+-	case 2048:
+-		val = FIELD_PREP(SPI_NFI_PAGE_SIZE, 0x1);
+-		break;
+-	case 4096:
+-		val = FIELD_PREP(SPI_NFI_PAGE_SIZE, 0x2);
+-		break;
+-	default:
+-		val = FIELD_PREP(SPI_NFI_PAGE_SIZE, 0x0);
+-		break;
+-	}
+-
+-	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_PAGEFMT,
+-				 SPI_NFI_PAGE_SIZE, val);
+-	if (err)
+-		return err;
+-
+ 	/* sec num */
+ 	val = FIELD_PREP(SPI_NFI_SEC_NUM, priv->nfi_cfg.sec_num);
+ 	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/104-02-spi-airoha-reduce-the-number-of-modification-of-REG_.patch
+++ b/package/boot/uboot-airoha/patches/104-02-spi-airoha-reduce-the-number-of-modification-of-REG_.patch
@@ -1,0 +1,201 @@
+From 964c0177ab42f0fbe68702d796daa227ba30ec75 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 18:49:34 +0300
+Subject: [PATCH 080/102] spi: airoha: reduce the number of modification of
+ REG_SPI_NFI_CNFG and REG_SPI_NFI_SECCUS_SIZE registers
+
+This just reduce the number of modification of REG_SPI_NFI_CNFG and
+REG_SPI_NFI_SECCUS_SIZE registers during dirmap operation.
+
+This patch is a necessary step to avoid usage of flash specific
+parameters.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 135 +++++++++++++++++++++++++---------
+ 1 file changed, 102 insertions(+), 33 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 8aaa01e66a3..2b7ec13bdcc 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -640,7 +640,48 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 	if (err < 0)
+ 		return err;
+ 
+-	err = airoha_snand_nfi_config(priv);
++	/* NFI reset */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CON,
++			   SPI_NFI_FIFO_FLUSH | SPI_NFI_RST);
++	if (err)
++		goto error_dma_mode_off;
++
++	/* NFI configure:
++	 *   - No AutoFDM (custom sector size (SECCUS) register will be used)
++	 *   - No SoC's hardware ECC (flash internal ECC will be used)
++	 *   - Use burst mode (faster, but requires 16 byte alignment for addresses)
++	 *   - Setup for reading (SPI_NFI_READ_MODE)
++	 *   - Setup reading command: FIELD_PREP(SPI_NFI_OPMODE, 6)
++	 *   - Use DMA instead of PIO for data reading
++	 */
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_READ_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 SPI_NFI_HW_ECC_EN |
++				 SPI_NFI_AUTO_FDM_EN |
++				 SPI_NFI_OPMODE,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_READ_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 FIELD_PREP(SPI_NFI_OPMODE, 6));
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set number of sector will be read */
++	val = FIELD_PREP(SPI_NFI_SEC_NUM, priv->nfi_cfg.sec_num);
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
++				 SPI_NFI_SEC_NUM, val);
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set custom sector size */
++	val = priv->nfi_cfg.sec_size;
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
++				 SPI_NFI_CUS_SEC_SIZE |
++				 SPI_NFI_CUS_SEC_SIZE_EN,
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+@@ -653,7 +694,14 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	/* set cust sec size */
++	/*
++	 * Setup transfer length
++	 * ---------------------
++	 * The following rule MUST be met:
++	 *     transfer_length =
++	 *        = NFI_SNF_MISC_CTL2.read_data_byte_number =
++	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
++	 */
+ 	val = priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num;
+ 	val = FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, val);
+ 	err = regmap_update_bits(priv->regmap_nfi,
+@@ -680,18 +728,6 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	/* set nfi read */
+-	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-				 SPI_NFI_OPMODE,
+-				 FIELD_PREP(SPI_NFI_OPMODE, 6));
+-	if (err)
+-		goto error_dma_unmap;
+-
+-	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-			      SPI_NFI_READ_MODE | SPI_NFI_DMA_MODE);
+-	if (err)
+-		goto error_dma_unmap;
+-
+ 	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CMD, 0x0);
+ 	if (err)
+ 		goto error_dma_unmap;
+@@ -782,7 +818,48 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 	if (err < 0)
+ 		return err;
+ 
+-	err = airoha_snand_nfi_config(priv);
++	/* NFI reset */
++	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CON,
++			   SPI_NFI_FIFO_FLUSH | SPI_NFI_RST);
++	if (err)
++		goto error_dma_mode_off;
++
++	/*
++	 * NFI configure:
++	 *   - No AutoFDM (custom sector size (SECCUS) register will be used)
++	 *   - No SoC's hardware ECC (flash internal ECC will be used)
++	 *   - Use burst mode (faster, but requires 16 byte alignment for addresses)
++	 *   - Setup for writing (SPI_NFI_READ_MODE bit is cleared)
++	 *   - Setup writing command: FIELD_PREP(SPI_NFI_OPMODE, 3)
++	 *   - Use DMA instead of PIO for data writing
++	 */
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_READ_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 SPI_NFI_HW_ECC_EN |
++				 SPI_NFI_AUTO_FDM_EN |
++				 SPI_NFI_OPMODE,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 FIELD_PREP(SPI_NFI_OPMODE, 3));
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set number of sector will be written */
++	val = FIELD_PREP(SPI_NFI_SEC_NUM, priv->nfi_cfg.sec_num);
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
++				 SPI_NFI_SEC_NUM, val);
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set custom sector size */
++	val = priv->nfi_cfg.sec_size;
++	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
++				 SPI_NFI_CUS_SEC_SIZE |
++				 SPI_NFI_CUS_SEC_SIZE_EN,
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+@@ -795,8 +872,16 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM,
+-			 priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num);
++	/*
++	 * Setup transfer length
++	 * ---------------------
++	 * The following rule MUST be met:
++	 *     transfer_length =
++	 *        = NFI_SNF_MISC_CTL2.write_data_byte_number =
++	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
++	 */
++	val = priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num;
++	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM, val);
+ 	err = regmap_update_bits(priv->regmap_nfi,
+ 				 REG_SPI_NFI_SNF_MISC_CTL2,
+ 				 SPI_NFI_PROG_LOAD_BYTE_NUM, val);
+@@ -821,22 +906,6 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	err = regmap_clear_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-				SPI_NFI_READ_MODE);
+-	if (err)
+-		goto error_dma_unmap;
+-
+-	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-				 SPI_NFI_OPMODE,
+-				 FIELD_PREP(SPI_NFI_OPMODE, 3));
+-	if (err)
+-		goto error_dma_unmap;
+-
+-	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-			      SPI_NFI_DMA_MODE);
+-	if (err)
+-		goto error_dma_unmap;
+-
+ 	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CMD, 0x80);
+ 	if (err)
+ 		goto error_dma_unmap;
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/104-03-spi-airoha-set-custom-sector-size-equal-to-flash-pag.patch
+++ b/package/boot/uboot-airoha/patches/104-03-spi-airoha-set-custom-sector-size-equal-to-flash-pag.patch
@@ -1,0 +1,140 @@
+From 90d1abaa3dd4c7f80581cb6943be257c3d72cb75 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 22:47:17 +0300
+Subject: [PATCH 081/102] spi: airoha: set custom sector size equal to flash
+ page size
+
+Set custom sector size equal to flash page size including oob. Thus we
+will always read a single sector. The maximum custom sector size is
+8187, so all possible flash sector sizes are supported.
+
+This patch is a necessary step to avoid usage of flash specific
+parameters.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 35 +++++++++++++++++++----------------
+ 1 file changed, 19 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 2b7ec13bdcc..0b21e16a69c 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -514,7 +514,7 @@ static int airoha_snand_nfi_config(struct airoha_snand_priv *priv)
+ 		return err;
+ 
+ 	/* sec num */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, priv->nfi_cfg.sec_num);
++	val = FIELD_PREP(SPI_NFI_SEC_NUM, 1);
+ 	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
+ 				 SPI_NFI_SEC_NUM, val);
+ 	if (err)
+@@ -527,7 +527,8 @@ static int airoha_snand_nfi_config(struct airoha_snand_priv *priv)
+ 		return err;
+ 
+ 	/* set cust sec size */
+-	val = FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, priv->nfi_cfg.sec_size);
++	val = FIELD_PREP(SPI_NFI_CUS_SEC_SIZE,
++			 priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num);
+ 	return regmap_update_bits(priv->regmap_nfi,
+ 				  REG_SPI_NFI_SECCUS_SIZE,
+ 				  SPI_NFI_CUS_SEC_SIZE, val);
+@@ -609,8 +610,11 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 	u8 *txrx_buf = priv->txrx_buf;
+ 	dma_addr_t dma_addr;
+ 	u32 val, rd_mode, opcode;
++	size_t bytes;
+ 	int err;
+ 
++	bytes = priv->nfi_cfg.sec_num * priv->nfi_cfg.sec_size;
++
+ 	/*
+ 	 * DUALIO and QUADIO opcodes are not supported by the spi controller,
+ 	 * replace them with supported opcodes.
+@@ -669,18 +673,17 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set number of sector will be read */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, priv->nfi_cfg.sec_num);
+ 	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
+-				 SPI_NFI_SEC_NUM, val);
++				 SPI_NFI_SEC_NUM,
++				 FIELD_PREP(SPI_NFI_SEC_NUM, 1));
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set custom sector size */
+-	val = priv->nfi_cfg.sec_size;
+ 	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
+ 				 SPI_NFI_CUS_SEC_SIZE |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN,
+-				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, bytes) |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+@@ -702,11 +705,10 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 	 *        = NFI_SNF_MISC_CTL2.read_data_byte_number =
+ 	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
+ 	 */
+-	val = priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num;
+-	val = FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, val);
+ 	err = regmap_update_bits(priv->regmap_nfi,
+ 				 REG_SPI_NFI_SNF_MISC_CTL2,
+-				 SPI_NFI_READ_DATA_BYTE_NUM, val);
++				 SPI_NFI_READ_DATA_BYTE_NUM,
++				 FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, bytes));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+@@ -795,8 +797,11 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 	u8 *txrx_buf = priv->txrx_buf;
+ 	dma_addr_t dma_addr;
+ 	u32 wr_mode, val, opcode;
++	size_t bytes;
+ 	int err;
+ 
++	bytes = priv->nfi_cfg.sec_num * priv->nfi_cfg.sec_size;
++
+ 	opcode = desc->info.op_tmpl.cmd.opcode;
+ 	switch (opcode) {
+ 	case SPI_NAND_OP_PROGRAM_LOAD_SINGLE:
+@@ -847,18 +852,17 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set number of sector will be written */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, priv->nfi_cfg.sec_num);
+ 	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
+-				 SPI_NFI_SEC_NUM, val);
++				 SPI_NFI_SEC_NUM,
++				 FIELD_PREP(SPI_NFI_SEC_NUM, 1));
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set custom sector size */
+-	val = priv->nfi_cfg.sec_size;
+ 	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
+ 				 SPI_NFI_CUS_SEC_SIZE |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN,
+-				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, bytes) |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+@@ -880,11 +884,10 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 	 *        = NFI_SNF_MISC_CTL2.write_data_byte_number =
+ 	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
+ 	 */
+-	val = priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num;
+-	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM, val);
+ 	err = regmap_update_bits(priv->regmap_nfi,
+ 				 REG_SPI_NFI_SNF_MISC_CTL2,
+-				 SPI_NFI_PROG_LOAD_BYTE_NUM, val);
++				 SPI_NFI_PROG_LOAD_BYTE_NUM,
++				 FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM, bytes));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/104-04-spi-airoha-avoid-usage-of-flash-specific-parameters.patch
+++ b/package/boot/uboot-airoha/patches/104-04-spi-airoha-avoid-usage-of-flash-specific-parameters.patch
@@ -1,0 +1,176 @@
+From a3f492f7083c016b85bd2f3fa8b116fcbe6f7559 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 23:56:24 +0300
+Subject: [PATCH 082/102] spi: airoha: avoid usage of flash specific parameters
+
+The spinand driver do 3 type of dirmap requests:
+ * read/write whole flash page without oob
+   (offs = 0, len = page_size)
+ * read/write whole flash page including oob
+   (offs = 0, len = page_size + oob_size)
+ * read/write oob area only
+   (offs = page_size, len = oob_size)
+
+The trick is:
+ * read/write a single "sector"
+ * set a custom sector size equal to offs + len. It's a bit safer to
+   round up "sector size" value 64.
+ * set the transfer length equal to custom sector size
+
+And it works!
+
+Thus we can find all data directly from dirmap request, so flash specific
+parameters is not needed anymore. Also
+ * airoha_snand_nfi_config(),
+ * airoha_snand_nfi_setup()
+functions becomes unnecessary.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 95 ++---------------------------------
+ 1 file changed, 4 insertions(+), 91 deletions(-)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 0b21e16a69c..5238f539150 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -217,13 +217,6 @@ struct airoha_snand_priv {
+ 	struct regmap *regmap_nfi;
+ 	struct clk *spi_clk;
+ 
+-	struct {
+-		size_t page_size;
+-		size_t sec_size;
+-		u8 sec_num;
+-		u8 spare_size;
+-	} nfi_cfg;
+-
+ 	u8 *txrx_buf;
+ };
+ 
+@@ -485,55 +478,6 @@ static int airoha_snand_nfi_init(struct airoha_snand_priv *priv)
+ 				  SPI_NFI_ALL_IRQ_EN, SPI_NFI_AHB_DONE_EN);
+ }
+ 
+-static int airoha_snand_nfi_config(struct airoha_snand_priv *priv)
+-{
+-	int err;
+-	u32 val;
+-
+-	err = regmap_write(priv->regmap_nfi, REG_SPI_NFI_CON,
+-			   SPI_NFI_FIFO_FLUSH | SPI_NFI_RST);
+-	if (err)
+-		return err;
+-
+-	/* auto FDM */
+-	err = regmap_clear_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-				SPI_NFI_AUTO_FDM_EN);
+-	if (err)
+-		return err;
+-
+-	/* HW ECC */
+-	err = regmap_clear_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-				SPI_NFI_HW_ECC_EN);
+-	if (err)
+-		return err;
+-
+-	/* DMA Burst */
+-	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_CNFG,
+-			      SPI_NFI_DMA_BURST_EN);
+-	if (err)
+-		return err;
+-
+-	/* sec num */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, 1);
+-	err = regmap_update_bits(priv->regmap_nfi, REG_SPI_NFI_CON,
+-				 SPI_NFI_SEC_NUM, val);
+-	if (err)
+-		return err;
+-
+-	/* enable cust sec size */
+-	err = regmap_set_bits(priv->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
+-			      SPI_NFI_CUS_SEC_SIZE_EN);
+-	if (err)
+-		return err;
+-
+-	/* set cust sec size */
+-	val = FIELD_PREP(SPI_NFI_CUS_SEC_SIZE,
+-			 priv->nfi_cfg.sec_size * priv->nfi_cfg.sec_num);
+-	return regmap_update_bits(priv->regmap_nfi,
+-				  REG_SPI_NFI_SECCUS_SIZE,
+-				  SPI_NFI_CUS_SEC_SIZE, val);
+-}
+-
+ static bool airoha_snand_is_page_ops(const struct spi_mem_op *op)
+ {
+ 	if (op->addr.nbytes != 2)
+@@ -613,7 +557,8 @@ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 	size_t bytes;
+ 	int err;
+ 
+-	bytes = priv->nfi_cfg.sec_num * priv->nfi_cfg.sec_size;
++	/* minimum oob size is 64 */
++	bytes = round_up(offs + len, 64);
+ 
+ 	/*
+ 	 * DUALIO and QUADIO opcodes are not supported by the spi controller,
+@@ -800,7 +745,8 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 	size_t bytes;
+ 	int err;
+ 
+-	bytes = priv->nfi_cfg.sec_num * priv->nfi_cfg.sec_size;
++	/* minimum oob size is 64 */
++	bytes = round_up(offs + len, 64);
+ 
+ 	opcode = desc->info.op_tmpl.cmd.opcode;
+ 	switch (opcode) {
+@@ -1089,38 +1035,6 @@ static int airoha_snand_nfi_set_mode(struct udevice *bus, uint mode)
+ 	return 0;
+ }
+ 
+-static int airoha_snand_nfi_setup(struct spi_slave *slave,
+-				  const struct spinand_info *spinand_info)
+-{
+-	struct udevice *bus = slave->dev->parent;
+-	struct airoha_snand_priv *priv;
+-	u32 sec_size, sec_num;
+-	int pagesize, oobsize;
+-
+-	priv = dev_get_priv(bus);
+-
+-	pagesize = spinand_info->memorg.pagesize;
+-	oobsize = spinand_info->memorg.oobsize;
+-
+-	if (pagesize == 2 * 1024 ) {
+-		sec_num = 4;
+-	} else if (pagesize == 4 * 1024 ) {
+-		sec_num = 8;
+-	} else {
+-		sec_num = 1;
+-	}
+-
+-	sec_size = (pagesize + oobsize) / sec_num ;
+-
+-	/* init default value */
+-	priv->nfi_cfg.sec_size = sec_size;
+-	priv->nfi_cfg.sec_num = sec_num;
+-	priv->nfi_cfg.page_size = round_down(sec_size * sec_num, 1024);
+-	priv->nfi_cfg.spare_size = 16;
+-
+-	return airoha_snand_nfi_config(priv);
+-}
+-
+ static const struct spi_controller_mem_ops airoha_snand_mem_ops = {
+ 	.supports_op = airoha_snand_supports_op,
+ 	.exec_op = airoha_snand_exec_op,
+@@ -1133,7 +1047,6 @@ static const struct dm_spi_ops airoha_snfi_spi_ops = {
+ 	.mem_ops = &airoha_snand_mem_ops,
+ 	.set_speed = airoha_snand_nfi_set_speed,
+ 	.set_mode = airoha_snand_nfi_set_mode,
+-	.setup_for_spinand = airoha_snand_nfi_setup,
+ };
+ 
+ static const struct udevice_id airoha_snand_ids[] = {
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/105-01-spi-airoha-buffer-must-be-0xff-ed-before-writing.patch
+++ b/package/boot/uboot-airoha/patches/105-01-spi-airoha-buffer-must-be-0xff-ed-before-writing.patch
@@ -1,0 +1,34 @@
+From 881aafa664ff0b160b3be77ad13f38fe0fb3b9cd Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 25 Aug 2025 15:25:14 +0300
+Subject: [PATCH 083/102] spi: airoha: buffer must be 0xff-ed before writing
+
+During writing, the entire flash page (including OOB) will be updated
+with the values from the temporary buffer, so we need to fill the
+untouched areas of the buffer with 0xff value to prevent accidental
+data overwriting.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index 5238f539150..f66dfd524f6 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -763,7 +763,11 @@ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 		return -EOPNOTSUPP;
+ 	}
+ 
++	if (offs > 0)
++		memset(txrx_buf, 0xff, offs);
+ 	memcpy(txrx_buf + offs, buf, len);
++	if (bytes > offs + len)
++		memset(txrx_buf + offs + len, 0xff, bytes - offs - len);
+ 
+ 	err = airoha_snand_set_mode(priv, SPI_MODE_DMA);
+ 	if (err < 0)
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/105-02-spi-airoha-return-an-error-for-continuous-mode-dirma.patch
+++ b/package/boot/uboot-airoha/patches/105-02-spi-airoha-return-an-error-for-continuous-mode-dirma.patch
@@ -1,0 +1,36 @@
+From c381833f1c68d799334036a689c298591c00aae4 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 4 Aug 2025 21:45:46 +0300
+Subject: [PATCH 084/102] spi: airoha: return an error for continuous mode
+ dirmap creation cases
+
+This driver can accelerate single page operations only, thus
+continuous reading mode should not be used.
+
+Continuous reading will use sizes up to the size of one erase block.
+This size is much larger than the size of single flash page. Use this
+difference to identify continuous reading and return an error.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/airoha_snfi_spi.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/spi/airoha_snfi_spi.c b/drivers/spi/airoha_snfi_spi.c
+index f66dfd524f6..95f679378ab 100644
+--- a/drivers/spi/airoha_snfi_spi.c
++++ b/drivers/spi/airoha_snfi_spi.c
+@@ -539,6 +539,10 @@ static int airoha_snand_dirmap_create(struct spi_mem_dirmap_desc *desc)
+ 	if (desc->info.offset + desc->info.length > U32_MAX)
+ 		return -EINVAL;
+ 
++	/* continuous reading is not supported */
++	if (desc->info.length > SPI_NAND_CACHE_SIZE)
++		return -E2BIG;
++
+ 	if (!airoha_snand_supports_op(desc->slave, &desc->info.op_tmpl))
+ 		return -EOPNOTSUPP;
+ 
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/402-arm-airoha-do-not-use-get_ram_size-as-it-may-result-.patch
+++ b/package/boot/uboot-airoha/patches/402-arm-airoha-do-not-use-get_ram_size-as-it-may-result-.patch
@@ -1,0 +1,72 @@
+From fa5df05b108d952a823bef7cdb5f9e624d28987d Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 21:51:29 +0300
+Subject: [PATCH 096/102] arm: airoha: do not use get_ram_size() as it may
+ result in boot loop
+
+The general idea is good, but the call of
+
+  get_ram_size((void *)gd->ram_base, SZ_8G);
+
+produces the following result on my an7581 board with only 1Gb of
+memory:
+
+  "Synchronous Abort" handler, esr 0x96000004
+  elr: 0000000081e201c8 lr : 0000000081e20160 (reloc)
+  elr: 00000000bff501c8 lr : 00000000bff50160
+  x0 : 0000000180000000 x1 : 0000000100000000
+  x2 : 000000000000002e x3 : 0000000000000002
+  x4 : 000000001fbf0000 x5 : 0060000000000401
+  x6 : 0000000000000000 x7 : 00000000bffdb268
+  x8 : 0000000000000060 x9 : 00000000bffdb2c8
+  x10: 0000000000000000 x11: 0000000000000060
+  x12: 00000000bffdb268 x13: 00000000841c56d0
+  x14: 00000000841c56d0 x15: 0000000000000000
+  x16: 00000000841506e4 x17: dd7fe29aec3b07e8
+  x18: 00000000bf710e00 x19: 0000000080000000
+  x20: 0000000000000000 x21: 0000000020000000
+  x22: 0000000200000000 x23: 0000000000000001
+  x24: 0000000040000000 x25: 00000000bf708e78
+  x26: 00000000bf7bdca0 x27: 0000000000000000
+  x28: 0000000000000000 x29: 00000000bf708e20
+
+  Code: 910943ff d65f03c0 d37df2a1 8b150e60 (f8616a62)
+  Resetting CPU ...
+
+So just not call get_ram_size() and use the value from dtb.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ arch/arm/mach-airoha/an7581/init.c | 2 +-
+ arch/arm/mach-airoha/an7583/init.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-airoha/an7581/init.c b/arch/arm/mach-airoha/an7581/init.c
+index caf1006b22b..53309556a68 100644
+--- a/arch/arm/mach-airoha/an7581/init.c
++++ b/arch/arm/mach-airoha/an7581/init.c
+@@ -22,7 +22,7 @@ int dram_init(void)
+ 	if (ret)
+ 		return ret;
+ 
+-	gd->ram_size = get_ram_size((void *)gd->ram_base, SZ_8G);
++//	gd->ram_size = get_ram_size((void *)gd->ram_base, SZ_8G);
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-airoha/an7583/init.c b/arch/arm/mach-airoha/an7583/init.c
+index c00837b4234..a1d63cce8f6 100644
+--- a/arch/arm/mach-airoha/an7583/init.c
++++ b/arch/arm/mach-airoha/an7583/init.c
+@@ -22,7 +22,7 @@ int dram_init(void)
+ 	if (ret)
+ 		return ret;
+ 
+-	gd->ram_size = get_ram_size((void *)gd->ram_base, SZ_8G);
++//	gd->ram_size = get_ram_size((void *)gd->ram_base, SZ_8G);
+ 
+ 	return 0;
+ }
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/403-01-arm-an7581-do-not-use-psci-for-system-reset-it-not-w.patch
+++ b/package/boot/uboot-airoha/patches/403-01-arm-an7581-do-not-use-psci-for-system-reset-it-not-w.patch
@@ -1,0 +1,68 @@
+From 07af12173bf310618f5d9a52cc8b2060e9f1b0e0 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Fri, 23 May 2025 21:15:14 +0300
+Subject: [PATCH 097/102] arm/an7581: do not use psci for system reset, it not
+ work during BL31 stage
+
+Without a fix a following messages appears in the loop:
+
+  resetting ...
+  "Synchronous Abort" handler, esr 0x5e000000
+  elr: 0000000081e01cc0 lr : 00000000819f8370 (reloc)
+  elr: 000000009ff4ccc0 lr : 000000009fb43370
+  x0 : 0000000084000009 x1 : 0000000000000001
+  x2 : 000000009ffe929c x3 : 0000000000000000
+  x4 : 000000009fb7e900 x5 : 0000000000000000
+  x6 : 000000009fb47170 x7 : 000000009fb43730
+  x8 : 00000000000002b4 x9 : 000000009fb4325c
+  x10: 0000000000000002 x11: 00000000ffffffff
+  x12: 0000000000000001 x13: 000000009fb43730
+  x14: 000000009fb431f4 x15: 0000000000000000
+  x16: 000000009ff6c76c x17: dd7fe39aed3a17e8
+  x18: 000000009fb46e10 x19: 000000009ffdc948
+  x20: 0000000000000000 x21: 0000000000000000
+  x22: 000000009fb6d7d0 x23: 0000000000000001
+  x24: 000000009ffe929c x25: 0000000000000000
+  x26: 000000009fb7e900 x27: 0000000000000000
+  x28: 0000000000000000 x29: 000000009fb43350
+
+  Code: f9401fc4 f94023c5 f94027c6 d4000003 (f9000fc0)
+  Resetting CPU ...
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ arch/arm/mach-airoha/an7581/init.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-airoha/an7581/init.c b/arch/arm/mach-airoha/an7581/init.c
+index 53309556a68..b2e43cd8b1b 100644
+--- a/arch/arm/mach-airoha/an7581/init.c
++++ b/arch/arm/mach-airoha/an7581/init.c
+@@ -2,9 +2,11 @@
+ 
+ #include <fdtdec.h>
+ #include <init.h>
++#include <sysreset.h>
+ #include <asm/armv8/mmu.h>
+ #include <asm/global_data.h>
+ #include <asm/system.h>
++#include <asm/io.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -35,9 +37,10 @@ int dram_init_banksize(void)
+ 	return 0;
+ }
+ 
+-void reset_cpu(ulong addr)
++void reset_cpu(void)
+ {
+-	psci_system_reset();
++	writel(0x80000000, 0x1FB00040);
++	while(1);
+ }
+ 
+ static struct mm_region an7581_mem_map[] = {
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/403-02-arm-an7583-do-not-use-psci-for-system-reset-it-not-w.patch
+++ b/package/boot/uboot-airoha/patches/403-02-arm-an7583-do-not-use-psci-for-system-reset-it-not-w.patch
@@ -1,0 +1,69 @@
+From 370187f5b555fa16d3d5fe8c55ab4931026f9842 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Fri, 23 May 2025 21:15:14 +0300
+Subject: [PATCH 098/102] arm/an7583: do not use psci for system reset, it not
+ work during BL31 stage
+
+Without a fix a following messages appears in the loop:
+
+  resetting ...
+  "Synchronous Abort" handler, esr 0x5e000000
+  elr: 0000000081e01cc0 lr : 00000000819f8370 (reloc)
+  elr: 000000009ff4ccc0 lr : 000000009fb43370
+  x0 : 0000000084000009 x1 : 0000000000000001
+  x2 : 000000009ffe929c x3 : 0000000000000000
+  x4 : 000000009fb7e900 x5 : 0000000000000000
+  x6 : 000000009fb47170 x7 : 000000009fb43730
+  x8 : 00000000000002b4 x9 : 000000009fb4325c
+  x10: 0000000000000002 x11: 00000000ffffffff
+  x12: 0000000000000001 x13: 000000009fb43730
+  x14: 000000009fb431f4 x15: 0000000000000000
+  x16: 000000009ff6c76c x17: dd7fe39aed3a17e8
+  x18: 000000009fb46e10 x19: 000000009ffdc948
+  x20: 0000000000000000 x21: 0000000000000000
+  x22: 000000009fb6d7d0 x23: 0000000000000001
+  x24: 000000009ffe929c x25: 0000000000000000
+  x26: 000000009fb7e900 x27: 0000000000000000
+  x28: 0000000000000000 x29: 000000009fb43350
+
+  Code: f9401fc4 f94023c5 f94027c6 d4000003 (f9000fc0)
+  Resetting CPU ...
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ arch/arm/mach-airoha/an7583/init.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/mach-airoha/an7583/init.c b/arch/arm/mach-airoha/an7583/init.c
+index a1d63cce8f6..9817c81b574 100644
+--- a/arch/arm/mach-airoha/an7583/init.c
++++ b/arch/arm/mach-airoha/an7583/init.c
+@@ -2,9 +2,11 @@
+ 
+ #include <fdtdec.h>
+ #include <init.h>
++#include <sysreset.h>
+ #include <asm/armv8/mmu.h>
+-#include <asm/system.h>
+ #include <asm/global_data.h>
++#include <asm/system.h>
++#include <asm/io.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -35,9 +37,10 @@ int dram_init_banksize(void)
+ 	return 0;
+ }
+ 
+-void reset_cpu(ulong addr)
++void reset_cpu(void)
+ {
+-	psci_system_reset();
++	writel(0x80000000, 0x1FB00040);
++	while(1);
+ }
+ 
+ static struct mm_region an7583_mem_map[] = {
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/403-03-arm-an7581-dynamically-adjust-counter-frequency.patch
+++ b/package/boot/uboot-airoha/patches/403-03-arm-an7581-dynamically-adjust-counter-frequency.patch
@@ -1,0 +1,78 @@
+From eb0970d997e2017ec390f3f00e70df7f8ebc9872 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 31 Mar 2025 04:13:06 +0300
+Subject: [PATCH 099/102] arm/an7581: dynamically adjust counter frequency
+
+The hanging happens in spi-nand driver, function spinand_wait().
+For eMMC boards on BL31 stage the function get_timer() always
+returns zero. As result a finite loop becomes infinite.
+
+The issue was caused by uninitialized ARMv8-A/ARMv7-A system counter.
+The counter is
+ * properly initialized for spi-nand boards
+ * properly initialized for eMMC boards during BL33 stage
+ * not initialized for eMMC boards during BL31 stage
+
+According to airoha ATF code the timer should be initialized by
+the following code
+
+    write_cntfrq_el0(plat_get_syscnt_freq2());
+    generic_delay_timer_init();
+
+where
+
+    unsigned int plat_get_syscnt_freq2(void)
+    {
+      #if defined(TCSUPPORT_CPU_EN7581) || defined(TCSUPPORT_CPU_AN7552)
+	/* 7581 CPU timer clk fixed in 25M*/
+	return SYS_COUNTER_FREQ_IN_TICKS_25M;
+      #else
+	....
+      #endif
+    }
+
+and
+
+    #define SYS_COUNTER_FREQ_IN_TICKS_25M	25000000
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ board/airoha/an7581/an7581_rfb.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/board/airoha/an7581/an7581_rfb.c b/board/airoha/an7581/an7581_rfb.c
+index aa73679d929..6c56f80df6d 100644
+--- a/board/airoha/an7581/an7581_rfb.c
++++ b/board/airoha/an7581/an7581_rfb.c
+@@ -4,6 +4,7 @@
+  */
+ 
+ #include <asm/global_data.h>
++#include <asm/system.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -12,5 +13,20 @@ int board_init(void)
+ 	/* address of boot parameters */
+ 	gd->bd->bi_boot_params = CFG_SYS_SDRAM_BASE + 0x100;
+ 
++	if (current_el() == 3) {
++		/* Running in ATF BL31 stage, the counter frequency may not be set. */
++		unsigned long cntrfreq;
++
++		asm volatile("mrs %0, cntfrq_el0" : "=r" (cntrfreq));
++		if (cntrfreq == 0) {
++			cntrfreq = 25000000;
++
++			asm volatile("msr cntfrq_el0, %0" : : "r" (cntrfreq) : "memory");
++			asm volatile("mrs %0, cntfrq_el0" : "=r" (cntrfreq));
++
++			printf("Set system timer frequency to %lu Hz.\n", cntrfreq);
++		}
++	}
++
+ 	return 0;
+ }
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/403-04-arm-an7583-dynamically-adjust-counter-frequency.patch
+++ b/package/boot/uboot-airoha/patches/403-04-arm-an7583-dynamically-adjust-counter-frequency.patch
@@ -1,0 +1,85 @@
+From e05c31bf5a19717d214b75bc2bbf531576f9cad2 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 31 Mar 2025 04:13:06 +0300
+Subject: [PATCH 100/102] arm/an7583: dynamically adjust counter frequency
+
+The hanging happens in spi-nand driver, function spinand_wait().
+For eMMC boards on BL31 stage the function get_timer() always
+returns zero. As result a finite loop becomes infinite.
+
+The issue was caused by uninitialized ARMv8-A/ARMv7-A system counter.
+The counter is
+ * properly initialized for spi-nand boards
+ * properly initialized for eMMC boards during BL33 stage
+ * not initialized for eMMC boards during BL31 stage
+
+According to airoha ATF code the timer should be initialized by
+the following code
+
+    write_cntfrq_el0(plat_get_syscnt_freq2());
+    generic_delay_timer_init();
+
+where
+
+    unsigned int plat_get_syscnt_freq2(void)
+    {
+      #if defined(TCSUPPORT_CPU_EN7581) || defined(TCSUPPORT_CPU_AN7552)
+	/* 7581 CPU timer clk fixed in 25M*/
+	return SYS_COUNTER_FREQ_IN_TICKS_25M;
+      #else
+	....
+      #endif
+    }
+
+and
+
+    #define SYS_COUNTER_FREQ_IN_TICKS_25M	25000000
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ board/airoha/an7583/an7583_rfb.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/board/airoha/an7583/an7583_rfb.c b/board/airoha/an7583/an7583_rfb.c
+index aa73679d929..6c007ba073e 100644
+--- a/board/airoha/an7583/an7583_rfb.c
++++ b/board/airoha/an7583/an7583_rfb.c
+@@ -4,6 +4,10 @@
+  */
+ 
+ #include <asm/global_data.h>
++#include <asm/io.h>
++#include <asm/system.h>
++
++#define CR_AHB_HWCONF	(void __iomem *)0x1fa20254
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -12,5 +16,24 @@ int board_init(void)
+ 	/* address of boot parameters */
+ 	gd->bd->bi_boot_params = CFG_SYS_SDRAM_BASE + 0x100;
+ 
++	if (current_el() == 3) {
++		/* Running in ATF BL31 stage, the counter frequency may not be set. */
++		unsigned long cntrfreq;
++
++		asm volatile("mrs %0, cntfrq_el0" : "=r" (cntrfreq));
++		if (cntrfreq == 0) {
++			if (!(readl(CR_AHB_HWCONF) & (1 << 19))) {
++				cntrfreq = 20000000;
++			} else {
++				cntrfreq = 25000000;
++			}
++
++			asm volatile("msr cntfrq_el0, %0" : : "r" (cntrfreq) : "memory");
++			asm volatile("mrs %0, cntfrq_el0" : "=r" (cntrfreq));
++
++			printf("Set system timer frequency to %lu Hz.\n", cntrfreq);
++		}
++	}
++
+ 	return 0;
+ }
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/600-03-an7581-enable-DM_MDIO-and-MDIO-CMD-by-default.patch
+++ b/package/boot/uboot-airoha/patches/600-03-an7581-enable-DM_MDIO-and-MDIO-CMD-by-default.patch
@@ -1,4 +1,4 @@
-From 384ba5040f54fe87fe6e8b5b2c453a7033ef60a1 Mon Sep 17 00:00:00 2001
+From 2b6e3a5dc51ce6ed5a0c5279c6ca33aec45d9803 Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Fri, 22 Aug 2025 15:43:56 +0200
 Subject: [PATCH] an7581: enable DM_MDIO and MDIO CMD by default
@@ -8,13 +8,14 @@ Enable DM_MDIO and MDIO CMD in the default config.
 Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
  configs/an7581_evb_defconfig | 3 +++
- 1 file changed, 3 insertions(+)
+ configs/an7583_evb_defconfig | 4 ++++
+ 2 files changed, 7 insertions(+)
 
 diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
-index 5765dcbaaec..a9b4387179a 100644
+index 740c5291737..2792aa8ec88 100644
 --- a/configs/an7581_evb_defconfig
 +++ b/configs/an7581_evb_defconfig
-@@ -81,6 +81,9 @@ CONFIG_SPI=y
+@@ -78,5 +78,8 @@ CONFIG_SPI=y
  CONFIG_DM_SPI=y
  CONFIG_SHA512=y
  CONFIG_AIROHA_ETH=y
@@ -23,10 +24,11 @@ index 5765dcbaaec..a9b4387179a 100644
 +CONFIG_CMD_MDIO=y
  CONFIG_MMC_MTK=y
  CONFIG_AIROHA_SNFI_SPI=y
- CONFIG_CMD_UBI=y
+diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
+index 4a11e16e497..8f74ee800d0 100644
 --- a/configs/an7583_evb_defconfig
 +++ b/configs/an7583_evb_defconfig
-@@ -81,6 +81,10 @@ CONFIG_SPI=y
+@@ -78,5 +78,9 @@ CONFIG_SPI=y
  CONFIG_DM_SPI=y
  CONFIG_SHA512=y
  CONFIG_AIROHA_ETH=y
@@ -36,7 +38,6 @@ index 5765dcbaaec..a9b4387179a 100644
 +CONFIG_CMD_MDIO=y
  CONFIG_MMC_MTK=y
  CONFIG_AIROHA_SNFI_SPI=y
- CONFIG_CMD_UBI=y
 -- 
-2.50.0
+2.51.0
 

--- a/package/boot/uboot-airoha/patches/604-01-linux-bitfield.h-sync-linux-bitfield.h-from-Linux-6..patch
+++ b/package/boot/uboot-airoha/patches/604-01-linux-bitfield.h-sync-linux-bitfield.h-from-Linux-6..patch
@@ -1,4 +1,4 @@
-From 01cc7046ad2a1537791cda5175bce281f0a0acfc Mon Sep 17 00:00:00 2001
+From 0c71afe8c4d312e60d6d275885dfd1b9c1fe4535 Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Sat, 7 Jun 2025 23:11:20 +0200
 Subject: [PATCH] linux/bitfield.h: sync <linux/bitfield.h> from Linux 6.15
@@ -10,11 +10,11 @@ similar to how it's done with in Linux.
 
 Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
- include/linux/bitfield.h | 103 ++++++++++++++++++++++++++++-----------
- 1 file changed, 75 insertions(+), 28 deletions(-)
+ include/linux/bitfield.h | 77 +++++++++++++++++++++++++---------------
+ 1 file changed, 49 insertions(+), 28 deletions(-)
 
 diff --git a/include/linux/bitfield.h b/include/linux/bitfield.h
-index 7ad02f8cbb9..63928f17322 100644
+index 1b73ba6f9fa..63928f17322 100644
 --- a/include/linux/bitfield.h
 +++ b/include/linux/bitfield.h
 @@ -1,21 +1,13 @@
@@ -115,36 +115,7 @@ index 7ad02f8cbb9..63928f17322 100644
  		!((((typeof(_mask))_val) << __bf_shf(_mask)) & ~(_mask)); \
  	})
  
-@@ -90,10 +116,36 @@
- 		((typeof(_mask))(_val) << __bf_shf(_mask)) & (_mask);	\
- 	})
- 
-+#define __BF_CHECK_POW2(n)	BUILD_BUG_ON_ZERO(((n) & ((n) - 1)) != 0)
-+
-+/**
-+ * FIELD_PREP_CONST() - prepare a constant bitfield element
-+ * @_mask: shifted mask defining the field's length and position
-+ * @_val:  value to put in the field
-+ *
-+ * FIELD_PREP_CONST() masks and shifts up the value.  The result should
-+ * be combined with other fields of the bitfield using logical OR.
-+ *
-+ * Unlike FIELD_PREP() this is a constant expression and can therefore
-+ * be used in initializers. Error checking is less comfortable for this
-+ * version, and non-constant masks cannot be used.
-+ */
-+#define FIELD_PREP_CONST(_mask, _val)					\
-+	(								\
-+		/* mask must be non-zero */				\
-+		BUILD_BUG_ON_ZERO((_mask) == 0) +			\
-+		/* check if value fits */				\
-+		BUILD_BUG_ON_ZERO(~((_mask) >> __bf_shf(_mask)) & (_val)) + \
-+		/* check if mask is contiguous */			\
-+		__BF_CHECK_POW2((_mask) + (1ULL << __bf_shf(_mask))) +	\
-+		/* and create the value */				\
-+		(((typeof(_mask))(_val) << __bf_shf(_mask)) & (_mask))	\
-+	)
-+
+@@ -119,7 +145,7 @@
  /**
   * FIELD_GET() - extract a bitfield element
   * @_mask: shifted mask defining the field's length and position
@@ -153,7 +124,7 @@ index 7ad02f8cbb9..63928f17322 100644
   *
   * FIELD_GET() extracts the field specified by @_mask from the
   * bitfield passed in as @_reg by masking and shifting it down.
-@@ -108,20 +160,18 @@ extern void __compiletime_error("value doesn't fit into mask")
+@@ -134,20 +160,18 @@ extern void __compiletime_error("value doesn't fit into mask")
  __field_overflow(void);
  extern void __compiletime_error("bad bitfield mask")
  __bad_mask(void);
@@ -176,7 +147,7 @@ index 7ad02f8cbb9..63928f17322 100644
  static __always_inline __##type type##_encode_bits(base v, base field)	\
  {									\
  	if (__builtin_constant_p(v) && (v & ~field_mask(field)))	\
-@@ -133,26 +183,23 @@ static __always_inline __##type type##_replace_bits(__##type old,	\
+@@ -159,26 +183,23 @@ static __always_inline __##type type##_replace_bits(__##type old,	\
  {									\
  	return (old & ~to(field)) | type##_encode_bits(val, field);	\
  }									\

--- a/package/boot/uboot-airoha/patches/605-net-airoha-add-initial-support-for-multiple-GDM-port.patch
+++ b/package/boot/uboot-airoha/patches/605-net-airoha-add-initial-support-for-multiple-GDM-port.patch
@@ -1,7 +1,7 @@
-From db1c0c3f2e0275b191381e1de441297f6920973f Mon Sep 17 00:00:00 2001
+From 0bef63be54965af434d9674b4f0e97decfa431bb Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Wed, 1 Oct 2025 03:58:32 +0200
-Subject: [PATCH 17/21] net: airoha: add initial support for multiple GDM port
+Subject: [PATCH] net: airoha: add initial support for multiple GDM port
 
 Rework the driver to support multiple GDM port. The driver is split to
 main driver as a MISC driver with forced probe (by using the
@@ -16,7 +16,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  1 file changed, 129 insertions(+), 21 deletions(-)
 
 diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
-index 4b3653b76ec..0fb050e4b00 100644
+index 2e153a24c3e..91d7faa15b2 100644
 --- a/drivers/net/airoha_eth.c
 +++ b/drivers/net/airoha_eth.c
 @@ -9,6 +9,7 @@
@@ -45,7 +45,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  /* SCU */
  #define SCU_SHARE_FEMEM_SEL		0x958
  
-@@ -263,6 +266,21 @@
+@@ -264,6 +267,21 @@
  #define QDMA_ETH_RXMSG_CRSN_MASK	GENMASK(20, 16)
  #define QDMA_ETH_RXMSG_PPE_ENTRY_MASK	GENMASK(15, 0)
  
@@ -67,7 +67,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  struct airoha_qdma_desc {
  	__le32 rsv;
  	__le32 ctrl;
-@@ -326,11 +344,14 @@ struct airoha_eth {
+@@ -328,11 +346,14 @@ struct airoha_eth {
  	struct reset_ctl_bulk rsts;
  	struct reset_ctl_bulk xsi_rsts;
  
@@ -83,12 +83,19 @@ index 4b3653b76ec..0fb050e4b00 100644
  	int num_xsi_rsts;
  	const char * const *xsi_rsts_names;
  	ofnode (*get_scu_node)(struct udevice *dev);
-@@ -397,11 +418,27 @@ static u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val)
+@@ -399,6 +420,8 @@ static u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val)
  #define airoha_switch_rmw(eth, offset, mask, val)		\
  	airoha_rmw((eth)->switch_regs, (offset), (mask), (val))
  
 +static struct driver airoha_eth_port;
 +
+ static inline dma_addr_t dma_map_unaligned(void *vaddr, size_t len,
+ 					   enum dma_data_direction dir)
+ {
+@@ -420,11 +443,25 @@ static inline void dma_unmap_unaligned(dma_addr_t addr, size_t len,
+ 	dma_unmap_single(start, end - start, dir);
+ }
+ 
 +static int airoha_get_fe_port(struct airoha_gdm_port *port)
 +{
 +	struct airoha_qdma *qdma = port->qdma;
@@ -112,7 +119,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  		/*
  		 * Disable any kind of CRC drop or offload.
  		 * Enable padding of short TX packets to 60 bytes.
-@@ -786,12 +823,35 @@ static int airoha_switch_init(struct udevice *dev, struct airoha_eth *eth)
+@@ -815,12 +852,35 @@ static int airoha_switch_init(struct udevice *dev, struct airoha_eth *eth)
  	return 0;
  }
  
@@ -149,7 +156,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	int i, ret;
  
  	scu_node = data->get_scu_node(dev);
-@@ -808,6 +868,8 @@ static int airoha_eth_probe(struct udevice *dev)
+@@ -837,6 +897,8 @@ static int airoha_eth_probe(struct udevice *dev)
  	 */
  	regmap_write(scu_regmap, SCU_SHARE_FEMEM_SEL, 0x0);
  
@@ -158,7 +165,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	eth->fe_regs = dev_remap_addr_name(dev, "fe");
  	if (!eth->fe_regs)
  		return -ENOMEM;
-@@ -847,13 +909,42 @@ static int airoha_eth_probe(struct udevice *dev)
+@@ -876,13 +938,42 @@ static int airoha_eth_probe(struct udevice *dev)
  	if (ret)
  		return ret;
  
@@ -203,7 +210,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	struct airoha_queue *q;
  	int qid;
  
-@@ -871,8 +962,8 @@ static int airoha_eth_init(struct udevice *dev)
+@@ -900,8 +991,8 @@ static int airoha_eth_init(struct udevice *dev)
  
  static void airoha_eth_stop(struct udevice *dev)
  {
@@ -214,7 +221,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  
  	airoha_qdma_clear(qdma, REG_QDMA_GLOBAL_CFG,
  			  GLOBAL_CFG_TX_DMA_EN_MASK |
-@@ -881,8 +972,8 @@ static void airoha_eth_stop(struct udevice *dev)
+@@ -910,8 +1001,8 @@ static void airoha_eth_stop(struct udevice *dev)
  
  static int airoha_eth_send(struct udevice *dev, void *packet, int length)
  {
@@ -225,16 +232,16 @@ index 4b3653b76ec..0fb050e4b00 100644
  	struct airoha_qdma_desc *desc;
  	struct airoha_queue *q;
  	dma_addr_t dma_addr;
-@@ -901,7 +992,7 @@ static int airoha_eth_send(struct udevice *dev, void *packet, int length)
- 	desc = &q->desc[index];
- 	index = (index + 1) % q->ndesc;
+@@ -933,7 +1024,7 @@ static int airoha_eth_send(struct udevice *dev, void *packet, int length)
+ 	desc = &q->desc[q->head];
+ 	index = (q->head + 1) % q->ndesc;
  
 -	fport = 1;
 +	fport = airoha_get_fe_port(port);
  
  	msg0 = 0;
  	msg1 = FIELD_PREP(QDMA_ETH_TXMSG_FPORT_MASK, fport) |
-@@ -942,8 +1033,8 @@ static int airoha_eth_send(struct udevice *dev, void *packet, int length)
+@@ -975,8 +1066,8 @@ static int airoha_eth_send(struct udevice *dev, void *packet, int length)
  
  static int airoha_eth_recv(struct udevice *dev, int flags, uchar **packetp)
  {
@@ -244,8 +251,8 @@ index 4b3653b76ec..0fb050e4b00 100644
 +	struct airoha_qdma *qdma = port->qdma;
  	struct airoha_qdma_desc *desc;
  	struct airoha_queue *q;
- 	int qid, index;
-@@ -973,8 +1064,8 @@ static int airoha_eth_recv(struct udevice *dev, int flags, uchar **packetp)
+ 	u16 length;
+@@ -1003,8 +1094,8 @@ static int airoha_eth_recv(struct udevice *dev, int flags, uchar **packetp)
  
  static int arht_eth_free_pkt(struct udevice *dev, uchar *packet, int length)
  {
@@ -254,9 +261,9 @@ index 4b3653b76ec..0fb050e4b00 100644
 +	struct airoha_gdm_port *port = dev_get_priv(dev);
 +	struct airoha_qdma *qdma = port->qdma;
  	struct airoha_queue *q;
- 	int qid, index;
+ 	int qid;
  
-@@ -998,8 +1089,9 @@ static int arht_eth_free_pkt(struct udevice *dev, uchar *packet, int length)
+@@ -1045,8 +1136,9 @@ static int arht_eth_free_pkt(struct udevice *dev, uchar *packet, int length)
  
  static int arht_eth_write_hwaddr(struct udevice *dev)
  {
@@ -267,7 +274,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	unsigned char *mac = pdata->enetaddr;
  	u32 macaddr_lsb, macaddr_msb;
  
-@@ -1011,8 +1103,8 @@ static int arht_eth_write_hwaddr(struct udevice *dev)
+@@ -1058,8 +1150,8 @@ static int arht_eth_write_hwaddr(struct udevice *dev)
  		      FIELD_PREP(SMACCR1_MAC0, mac[0]);
  
  	/* Set MAC for Switch */
@@ -278,8 +285,8 @@ index 4b3653b76ec..0fb050e4b00 100644
  
  	return 0;
  }
-@@ -1041,6 +1133,12 @@ static int airoha_eth_bind(struct udevice *dev)
- 	ofnode switch_node;
+@@ -1088,6 +1180,12 @@ static int airoha_eth_bind(struct udevice *dev)
+ 	struct udevice *mdio_dev;
  	int ret = 0;
  
 +	/*
@@ -291,7 +298,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	if (!CONFIG_IS_ENABLED(MDIO_MT7531))
  		return 0;
  
-@@ -1060,6 +1158,7 @@ static int airoha_eth_bind(struct udevice *dev)
+@@ -1113,6 +1211,7 @@ static int airoha_eth_bind(struct udevice *dev)
  }
  
  static const struct airoha_eth_soc_data en7581_data = {
@@ -299,7 +306,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	.xsi_rsts_names = en7581_xsi_rsts_names,
  	.num_xsi_rsts = ARRAY_SIZE(en7581_xsi_rsts_names),
  	.get_scu_node = en7581_get_scu_node,
-@@ -1067,6 +1166,7 @@ static const struct airoha_eth_soc_data en7581_data = {
+@@ -1120,6 +1219,7 @@ static const struct airoha_eth_soc_data en7581_data = {
  };
  
  static const struct airoha_eth_soc_data an7583_data = {
@@ -307,7 +314,7 @@ index 4b3653b76ec..0fb050e4b00 100644
  	.xsi_rsts_names = an7583_xsi_rsts_names,
  	.num_xsi_rsts = ARRAY_SIZE(an7583_xsi_rsts_names),
  	.get_scu_node = an7583_get_scu_node,
-@@ -1091,13 +1191,21 @@ static const struct eth_ops airoha_eth_ops = {
+@@ -1145,13 +1245,21 @@ static const struct eth_ops airoha_eth_ops = {
  	.write_hwaddr = arht_eth_write_hwaddr,
  };
  

--- a/package/boot/uboot-airoha/patches/611-01-net-airoha-pcs-make-building-rules-better.patch
+++ b/package/boot/uboot-airoha/patches/611-01-net-airoha-pcs-make-building-rules-better.patch
@@ -1,0 +1,33 @@
+From 57028233836fbe71ee19084e7d9858e0e39b1b0a Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sat, 18 Oct 2025 21:12:24 +0300
+Subject: [PATCH 085/102] net: airoha: pcs: make building rules better
+
+This also disable building of pcs-airoha-common.c if we don't
+need PSC support.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/airoha/Makefile | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/airoha/Makefile b/drivers/net/airoha/Makefile
+index c52688c9cb9..a3b84518129 100644
+--- a/drivers/net/airoha/Makefile
++++ b/drivers/net/airoha/Makefile
+@@ -1,9 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0
+ 
+-obj-y				+= pcs-airoha-common.o
+-ifdef CONFIG_PCS_AIROHA_AN7581
+-obj-y				+= pcs-an7581.o
+-endif
+-ifdef CONFIG_PCS_AIROHA_AN7583
+-obj-y				+= pcs-an7583.o
+-endif
++obj-$(CONFIG_PCS_AIROHA)	+= pcs-airoha-common.o
++obj-$(CONFIG_PCS_AIROHA_AN7581)	+= pcs-an7581.o
++obj-$(CONFIG_PCS_AIROHA_AN7583)	+= pcs-an7583.o
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/611-02-net-airoha-do-not-call-airoha_fe_init-from-GDM-port-.patch
+++ b/package/boot/uboot-airoha/patches/611-02-net-airoha-do-not-call-airoha_fe_init-from-GDM-port-.patch
@@ -1,0 +1,77 @@
+From b0ccc85bf2bc8c48f3ec185473c404933b2316f9 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 10:36:16 +0300
+Subject: [PATCH 086/102] net: airoha: do not call airoha_fe_init() from GDM
+ port independent code
+
+We should not call airoha_fe_init() from GDM port independent code,
+because it do a GDM specific things.
+
+Makes airoha_fe_maccr_init() and airoha_fe_init() port dependent
+and call them from airoha_eth_port_probe()
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/airoha_eth.c | 28 ++++++++++++----------------
+ 1 file changed, 12 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
+index 23e209a21d1..d0378bd4e69 100644
+--- a/drivers/net/airoha_eth.c
++++ b/drivers/net/airoha_eth.c
+@@ -467,22 +467,18 @@ static int airoha_get_fe_port(struct airoha_gdm_port *port)
+ 	}
+ }
+ 
+-static void airoha_fe_maccr_init(struct airoha_eth *eth)
++static void airoha_fe_maccr_init(struct airoha_gdm_port *port)
+ {
+-	int p;
+-
+-	for (p = 1; p <= AIROHA_MAX_NUM_GDM_PORTS; p++) {
+-		/*
+-		 * Disable any kind of CRC drop or offload.
+-		 * Enable padding of short TX packets to 60 bytes.
+-		 */
+-		airoha_fe_wr(eth, REG_GDM_FWD_CFG(p), GDM_PAD_EN);
+-	}
++	/*
++	 * Disable any kind of CRC drop or offload.
++	 * Enable padding of short TX packets to 60 bytes.
++	 */
++	airoha_fe_wr(port->qdma->eth, REG_GDM_FWD_CFG(port->id), GDM_PAD_EN);
+ }
+ 
+-static int airoha_fe_init(struct airoha_eth *eth)
++static int airoha_fe_init(struct airoha_gdm_port *port)
+ {
+-	airoha_fe_maccr_init(eth);
++	airoha_fe_maccr_init(port);
+ 
+ 	return 0;
+ }
+@@ -786,10 +782,6 @@ static int airoha_hw_init(struct udevice *dev,
+ 
+ 	mdelay(20);
+ 
+-	ret = airoha_fe_init(eth);
+-	if (ret)
+-		return ret;
+-
+ 	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++) {
+ 		ret = airoha_qdma_init(dev, eth, &eth->qdma[i]);
+ 		if (ret)
+@@ -1010,6 +1002,10 @@ static int airoha_eth_port_probe(struct udevice *dev)
+ 
+ 	port->qdma = &eth->qdma[0];
+ 
++	ret = airoha_fe_init(port);
++	if (ret)
++		return ret;
++
+ 	if (port->id > 1) {
+ 		ret = airoha_pcs_init(dev);
+ 		if (ret)
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/611-03-net-airoha-init-switch-before-GDM-port-initializatio.patch
+++ b/package/boot/uboot-airoha/patches/611-03-net-airoha-init-switch-before-GDM-port-initializatio.patch
@@ -1,0 +1,42 @@
+From 86d2a4ee41146128b5d57ed720f2aa8fec707b67 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 10:36:16 +0300
+Subject: [PATCH 087/102] net: airoha: init switch before GDM port
+ initialization
+
+Call airoha_switch_init() before creating GDM instances, so if
+allocation of GDM port fails, early created GDM instances will work
+normally.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/airoha_eth.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
+index d0378bd4e69..db8d25aa8f9 100644
+--- a/drivers/net/airoha_eth.c
++++ b/drivers/net/airoha_eth.c
+@@ -972,6 +972,10 @@ static int airoha_eth_probe(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
++	ret = airoha_switch_init(dev, eth);
++	if (ret)
++		return ret;
++
+ 	ofnode_for_each_subnode(node, dev_ofnode(dev)) {
+ 		if (!ofnode_device_is_compatible(node, "airoha,eth-mac"))
+ 			continue;
+@@ -984,7 +988,7 @@ static int airoha_eth_probe(struct udevice *dev)
+ 			return ret;
+ 	}
+ 
+-	return airoha_switch_init(dev, eth);
++	return 0;
+ }
+ 
+ static int airoha_eth_port_of_to_plat(struct udevice *dev)
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/611-04-net-airoha-allocate-string-for-GDM-port-name.patch
+++ b/package/boot/uboot-airoha/patches/611-04-net-airoha-allocate-string-for-GDM-port-name.patch
@@ -1,0 +1,55 @@
+From 54d6c9272165e7643e38bf5c77cdaf801f1001a6 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 10:36:16 +0300
+Subject: [PATCH 088/102] net: airoha: allocate string for GDM port name
+
+Allocate string for GDM port. This have following benefits:
+ - avoid out of boundaries access to gdm_port_str[] array in
+   airoha_alloc_gdm_port()
+ - no entries for non-used GDM ports
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/airoha_eth.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
+index db8d25aa8f9..5e9a240831d 100644
+--- a/drivers/net/airoha_eth.c
++++ b/drivers/net/airoha_eth.c
+@@ -359,7 +359,6 @@ struct airoha_eth {
+ 	struct airoha_eth_soc_data *soc;
+ 
+ 	struct airoha_qdma qdma[AIROHA_MAX_NUM_QDMA];
+-	char gdm_port_str[AIROHA_MAX_NUM_GDM_PORTS][AIROHA_GDM_PORT_STRING_LEN];
+ };
+ 
+ struct airoha_eth_soc_data {
+@@ -901,12 +900,21 @@ static int airoha_alloc_gdm_port(struct udevice *dev, ofnode node)
+ 	if (id > AIROHA_MAX_NUM_GDM_PORTS)
+ 		return -EINVAL;
+ 
+-	str = eth->gdm_port_str[id];
++	str = malloc(AIROHA_GDM_PORT_STRING_LEN);
++	if (!str)
++		return -ENOMEM;
++
+ 	snprintf(str, AIROHA_GDM_PORT_STRING_LEN,
+ 		 "airoha-gdm%d", id);
+ 
+-	return device_bind_with_driver_data(dev, &airoha_eth_port, str,
+-					    (ulong)eth, node, &gdm_dev);
++	ret = device_bind_with_driver_data(dev, &airoha_eth_port, str,
++					   (ulong)eth, node, &gdm_dev);
++	if (ret) {
++		free(str);
++		return ret;
++	}
++
++	return 0;
+ }
+ 
+ static int airoha_eth_probe(struct udevice *dev)
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/611-05-net-airoha-declare-airoha_eth_port-as-U_BOOT_DRIVER.patch
+++ b/package/boot/uboot-airoha/patches/611-05-net-airoha-declare-airoha_eth_port-as-U_BOOT_DRIVER.patch
@@ -1,0 +1,64 @@
+From 99804f8bbac74b6ca59e814784addc8d8e3b62dd Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 10:36:16 +0300
+Subject: [PATCH 089/102] net: airoha: declare airoha_eth_port as
+ U_BOOT_DRIVER()
+
+Declare airoha_eth_port as U_BOOT_DRIVER(), fix airoha_alloc_gdm_port()
+to lookup a driver instead of direct airoha_eth_port usage.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/airoha_eth.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
+index 5e9a240831d..29b3a1f0800 100644
+--- a/drivers/net/airoha_eth.c
++++ b/drivers/net/airoha_eth.c
+@@ -429,8 +429,6 @@ static u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val)
+ #define airoha_switch_rmw(eth, offset, mask, val)		\
+ 	airoha_rmw((eth)->switch_regs, (offset), (mask), (val))
+ 
+-static struct driver airoha_eth_port;
+-
+ static inline dma_addr_t dma_map_unaligned(void *vaddr, size_t len,
+ 					   enum dma_data_direction dir)
+ {
+@@ -889,10 +887,15 @@ static int airoha_alloc_gdm_port(struct udevice *dev, ofnode node)
+ {
+ 	struct airoha_eth *eth = dev_get_priv(dev);
+ 	struct udevice *gdm_dev;
++	struct driver *gdm_drv;
+ 	char *str;
+ 	int ret;
+ 	u32 id;
+ 
++	gdm_drv = lists_driver_lookup_name("airoha-eth-port");
++	if (!gdm_drv)
++		return -ENOENT;
++
+ 	ret = ofnode_read_u32(node, "reg", &id);
+ 	if (ret)
+ 		return ret;
+@@ -907,7 +910,7 @@ static int airoha_alloc_gdm_port(struct udevice *dev, ofnode node)
+ 	snprintf(str, AIROHA_GDM_PORT_STRING_LEN,
+ 		 "airoha-gdm%d", id);
+ 
+-	ret = device_bind_with_driver_data(dev, &airoha_eth_port, str,
++	ret = device_bind_with_driver_data(dev, gdm_drv, str,
+ 					   (ulong)eth, node, &gdm_dev);
+ 	if (ret) {
+ 		free(str);
+@@ -1352,7 +1355,7 @@ static const struct eth_ops airoha_eth_ops = {
+ 	.write_hwaddr = arht_eth_write_hwaddr,
+ };
+ 
+-static struct driver airoha_eth_port = {
++U_BOOT_DRIVER(airoha_eth_port) = {
+ 	.name = "airoha-eth-port",
+ 	.id = UCLASS_ETH,
+ 	.of_to_plat = airoha_eth_port_of_to_plat,
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/611-06-net-airoha-makes-PCS-support-optional.patch
+++ b/package/boot/uboot-airoha/patches/611-06-net-airoha-makes-PCS-support-optional.patch
@@ -1,0 +1,117 @@
+From 949e683381e5f3bf35d87ef022dd6f616426ffa5 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 10:36:16 +0300
+Subject: [PATCH 090/102] net: airoha: makes PCS support optional
+
+It's not possible to disable PCS support just now, an7581 u-boot will not
+compile. This patch fixes an issue.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/Kconfig      |  1 +
+ drivers/net/airoha_eth.c | 17 ++++++++++++++++-
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/Kconfig b/drivers/net/Kconfig
+index 6f65a3890d2..9f19c7efb56 100644
+--- a/drivers/net/Kconfig
++++ b/drivers/net/Kconfig
+@@ -134,6 +134,7 @@ config MDIO_AIROHA
+ config AIROHA_ETH
+ 	bool "Airoha Ethernet QDMA Driver"
+ 	depends on ARCH_AIROHA
++	select MISC
+ 	select PHYLIB
+ 	select DM_ETH_PHY
+ 	select DM_RESET
+diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
+index 29b3a1f0800..d83a1eb29d9 100644
+--- a/drivers/net/airoha_eth.c
++++ b/drivers/net/airoha_eth.c
+@@ -725,6 +725,7 @@ static int airoha_qdma_init(struct udevice *dev,
+ 	return airoha_qdma_hw_init(qdma);
+ }
+ 
++#if defined(CONFIG_PCS_AIROHA)
+ static int airoha_pcs_init(struct udevice *dev)
+ {
+ 	struct airoha_gdm_port *port = dev_get_priv(dev);
+@@ -752,6 +753,7 @@ static int airoha_pcs_init(struct udevice *dev)
+ 	return airoha_pcs_config(pcs_dev, port->neg_mode,
+ 				 port->mode, NULL, true);
+ }
++#endif
+ 
+ static int airoha_hw_init(struct udevice *dev,
+ 			  struct airoha_eth *eth)
+@@ -903,6 +905,11 @@ static int airoha_alloc_gdm_port(struct udevice *dev, ofnode node)
+ 	if (id > AIROHA_MAX_NUM_GDM_PORTS)
+ 		return -EINVAL;
+ 
++#if !defined(CONFIG_PCS_AIROHA)
++	if (id != 1)
++		return -ENOTSUPP;
++#endif
++
+ 	str = malloc(AIROHA_GDM_PORT_STRING_LEN);
+ 	if (!str)
+ 		return -ENOMEM;
+@@ -995,7 +1002,7 @@ static int airoha_eth_probe(struct udevice *dev)
+ 			continue;
+ 
+ 		ret = airoha_alloc_gdm_port(dev, node);
+-		if (ret)
++		if (ret && ret != -ENOTSUPP)
+ 			return ret;
+ 	}
+ 
+@@ -1022,11 +1029,15 @@ static int airoha_eth_port_probe(struct udevice *dev)
+ 		return ret;
+ 
+ 	if (port->id > 1) {
++#if defined(CONFIG_PCS_AIROHA)
+ 		ret = airoha_pcs_init(dev);
+ 		if (ret)
+ 			return ret;
+ 
+ 		port->phydev = dm_eth_phy_connect(dev);
++#else
++		return -EINVAL;
++#endif
+ 	}
+ 
+ 	return 0;
+@@ -1048,6 +1059,7 @@ static int airoha_eth_init(struct udevice *dev)
+ 			GLOBAL_CFG_TX_DMA_EN_MASK |
+ 			GLOBAL_CFG_RX_DMA_EN_MASK);
+ 
++#if defined(CONFIG_PCS_AIROHA)
+ 	if (port->id > 1) {
+ 		struct phy_device *phydev = port->phydev;
+ 		int speed, duplex;
+@@ -1088,6 +1100,7 @@ static int airoha_eth_init(struct udevice *dev)
+ 		airoha_pcs_link_up(port->pcs_dev, port->neg_mode, port->mode,
+ 				   speed, duplex);
+ 	}
++#endif
+ 
+ 	return 0;
+ }
+@@ -1097,12 +1110,14 @@ static void airoha_eth_stop(struct udevice *dev)
+ 	struct airoha_gdm_port *port = dev_get_priv(dev);
+ 	struct airoha_qdma *qdma = port->qdma;
+ 
++#if defined(CONFIG_PCS_AIROHA)
+ 	if (port->id > 1) {
+ 		if (port->phydev)
+ 			phy_shutdown(port->phydev);
+ 
+ 		airoha_pcs_link_down(port->pcs_dev);
+ 	}
++#endif
+ 
+ 	airoha_qdma_clear(qdma, REG_QDMA_GLOBAL_CFG,
+ 			  GLOBAL_CFG_TX_DMA_EN_MASK |
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/612-net-airoha-use-mt7531-mdio-for-GDM1.patch
+++ b/package/boot/uboot-airoha/patches/612-net-airoha-use-mt7531-mdio-for-GDM1.patch
@@ -1,0 +1,100 @@
+From 7669dede18f5becc05cef7fa1f94b83d58a7aba7 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Wed, 15 Oct 2025 19:01:08 +0300
+Subject: [PATCH 091/102] net: airoha: use mt7531 mdio for GDM1
+
+Current code just bind mt7531 mdio with it's driver, so mdio device may
+not be probed and hense not usable.
+
+This patch
+ * force probe mt7531 mdio for GDM1 port
+ * set mdio bus for the GDM port (if corresponding mdio/phydev is available)
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/net/airoha_eth.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/airoha_eth.c b/drivers/net/airoha_eth.c
+index d83a1eb29d9..cc7e4aafcba 100644
+--- a/drivers/net/airoha_eth.c
++++ b/drivers/net/airoha_eth.c
+@@ -12,6 +12,7 @@
+ #include <dm/device-internal.h>
+ #include <dm/devres.h>
+ #include <dm/lists.h>
++#include <eth_phy.h>
+ #include <mapmem.h>
+ #include <miiphy.h>
+ #include <net.h>
+@@ -358,6 +359,7 @@ struct airoha_eth {
+ 
+ 	struct airoha_eth_soc_data *soc;
+ 
++	struct udevice *switch_mdio;
+ 	struct airoha_qdma qdma[AIROHA_MAX_NUM_QDMA];
+ };
+ 
+@@ -1020,6 +1022,8 @@ static int airoha_eth_port_probe(struct udevice *dev)
+ {
+ 	struct airoha_eth *eth = (void *)dev_get_driver_data(dev);
+ 	struct airoha_gdm_port *port = dev_get_priv(dev);
++	struct mdio_perdev_priv *pdata;
++	struct mii_dev *mdio_bus;
+ 	int ret;
+ 
+ 	port->qdma = &eth->qdma[0];
+@@ -1028,6 +1032,7 @@ static int airoha_eth_port_probe(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
++	mdio_bus = NULL;
+ 	if (port->id > 1) {
+ #if defined(CONFIG_PCS_AIROHA)
+ 		ret = airoha_pcs_init(dev);
+@@ -1035,11 +1040,23 @@ static int airoha_eth_port_probe(struct udevice *dev)
+ 			return ret;
+ 
+ 		port->phydev = dm_eth_phy_connect(dev);
++		if (port->phydev)
++			mdio_bus = port->phydev->bus;
+ #else
+ 		return -EINVAL;
+ #endif
++	} else {
++		if (eth->switch_mdio && !device_probe(eth->switch_mdio)) {
++			pdata = dev_get_uclass_priv(eth->switch_mdio);
++			mdio_bus = pdata->mii_bus;
++		}
+ 	}
+ 
++#ifdef CONFIG_DM_ETH_PHY
++	if (!IS_ERR_OR_NULL(mdio_bus))
++		eth_phy_set_mdio_bus(dev, mdio_bus);
++#endif
++
+ 	return 0;
+ }
+ 
+@@ -1301,8 +1318,8 @@ static ofnode an7583_get_scu_node(struct udevice *dev)
+ static int airoha_eth_bind(struct udevice *dev)
+ {
+ 	struct airoha_eth_soc_data *data = (void *)dev_get_driver_data(dev);
++	struct airoha_eth *eth = dev_get_priv(dev);
+ 	ofnode switch_node, mdio_node;
+-	struct udevice *mdio_dev;
+ 	int ret = 0;
+ 
+ 	/*
+@@ -1328,7 +1345,7 @@ static int airoha_eth_bind(struct udevice *dev)
+ 	}
+ 
+ 	ret = device_bind_driver_to_node(dev, "mt7531-mdio", "mdio",
+-					 mdio_node, &mdio_dev);
++					 mdio_node, &eth->switch_mdio);
+ 	if (ret)
+ 		debug("Warning: failed to bind mdio controller\n");
+ 
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/900-airoha-enable-UBI-support-and-define-default-partiti.patch
+++ b/package/boot/uboot-airoha/patches/900-airoha-enable-UBI-support-and-define-default-partiti.patch
@@ -1,7 +1,7 @@
-From 28a72d957b897e7f7212c11f99052a32b0f6abc4 Mon Sep 17 00:00:00 2001
+From 0f3a734a55a908b43cd1497f9be39f85783b0840 Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Wed, 28 May 2025 03:10:53 +0200
-Subject: [PATCH 1/2] airoha: enable UBI support and define default partition
+Subject: [PATCH] airoha: enable UBI support and define default partition
 
 Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
@@ -12,10 +12,10 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  4 files changed, 70 insertions(+)
 
 diff --git a/arch/arm/dts/an7581-u-boot.dtsi b/arch/arm/dts/an7581-u-boot.dtsi
-index a9297ca6503..1960b8ca300 100644
+index 4548076b96a..0af2c843250 100644
 --- a/arch/arm/dts/an7581-u-boot.dtsi
 +++ b/arch/arm/dts/an7581-u-boot.dtsi
-@@ -76,6 +76,22 @@
+@@ -152,6 +152,22 @@
  				spi-max-frequency = <50000000>;
  				spi-tx-bus-width = <1>;
  				spi-rx-bus-width = <2>;
@@ -39,10 +39,10 @@ index a9297ca6503..1960b8ca300 100644
  		};
  
 diff --git a/arch/arm/dts/an7583-evb.dts b/arch/arm/dts/an7583-evb.dts
-index d02cd194e8a..096dd395c90 100644
+index 51cad19b2ac..9b60a94d78c 100644
 --- a/arch/arm/dts/an7583-evb.dts
 +++ b/arch/arm/dts/an7583-evb.dts
-@@ -46,6 +46,28 @@
+@@ -60,6 +60,28 @@
  	};
  };
  
@@ -72,11 +72,11 @@ index d02cd194e8a..096dd395c90 100644
  	pinctrl-names = "default";
  	pinctrl-0 = <&pcie0_rst_pins>;
 diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
-index c74247e13db..6006bebd04d 100644
+index e6e7f544ee8..c2989504c1a 100644
 --- a/configs/an7581_evb_defconfig
 +++ b/configs/an7581_evb_defconfig
-@@ -79,3 +79,19 @@ CONFIG_SHA512=y
- CONFIG_AIROHA_ETH=y
+@@ -84,3 +84,19 @@ CONFIG_CMD_MII=y
+ CONFIG_CMD_MDIO=y
  CONFIG_MMC_MTK=y
  CONFIG_AIROHA_SNFI_SPI=y
 +CONFIG_CMD_UBI=y
@@ -96,11 +96,11 @@ index c74247e13db..6006bebd04d 100644
 +# CONFIG_UBIFS_SILENCE_MSG is not set
 +# CONFIG_UBIFS_SILENCE_DEBUG_DUMP is not set
 diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
-index 89b4e180015..8577f53a9c7 100644
+index d8baa346150..1cac49df3cc 100644
 --- a/configs/an7583_evb_defconfig
 +++ b/configs/an7583_evb_defconfig
-@@ -81,3 +81,19 @@ CONFIG_SHA512=y
- CONFIG_AIROHA_ETH=y
+@@ -85,3 +85,19 @@ CONFIG_CMD_MII=y
+ CONFIG_CMD_MDIO=y
  CONFIG_MMC_MTK=y
  CONFIG_AIROHA_SNFI_SPI=y
 +CONFIG_CMD_UBI=y
@@ -120,5 +120,5 @@ index 89b4e180015..8577f53a9c7 100644
 +# CONFIG_UBIFS_SILENCE_MSG is not set
 +# CONFIG_UBIFS_SILENCE_DEBUG_DUMP is not set
 -- 
-2.48.1
+2.51.0
 

--- a/package/boot/uboot-airoha/patches/902-an7581-add-default-command-and-cmd-entry.patch
+++ b/package/boot/uboot-airoha/patches/902-an7581-add-default-command-and-cmd-entry.patch
@@ -1,4 +1,4 @@
-From 4943888e64c13f81e431346420f9fc285e86b1eb Mon Sep 17 00:00:00 2001
+From 5544d646015b01f187ac78891da35ecca6f0688a Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Thu, 5 Jun 2025 20:07:48 +0200
 Subject: [PATCH] an7581: add default command and cmd entry
@@ -6,11 +6,13 @@ Subject: [PATCH] an7581: add default command and cmd entry
 Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
  configs/an7581_evb_defconfig |  4 ++++
+ configs/an7583_evb_defconfig |  4 ++++
  defenvs/an7581_rfb_env       | 33 +++++++++++++++++++++++++++++++++
- 2 files changed, 37 insertions(+)
+ defenvs/an7583_rfb_env       | 33 +++++++++++++++++++++++++++++++++
+ 4 files changed, 74 insertions(+)
 
 diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
-index d2ce869e2ec..5765dcbaaec 100644
+index 60e9097bf41..c970445f200 100644
 --- a/configs/an7581_evb_defconfig
 +++ b/configs/an7581_evb_defconfig
 @@ -1,5 +1,7 @@
@@ -35,11 +37,38 @@ index d2ce869e2ec..5765dcbaaec 100644
  CONFIG_CMD_GPIO=y
  CONFIG_CMD_MMC=y
  CONFIG_CMD_MTD=y
+diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
+index ff395e39a7b..b68c691a4e7 100644
+--- a/configs/an7583_evb_defconfig
++++ b/configs/an7583_evb_defconfig
+@@ -1,6 +1,8 @@
+ CONFIG_ARM=y
+ CONFIG_ARCH_AIROHA=y
+ CONFIG_TARGET_AN7583=y
++CONFIG_AUTOBOOT_USE_MENUKEY=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
+ CONFIG_TEXT_BASE=0x81E00000
+ CONFIG_SYS_MALLOC_F_LEN=0x4000
+ CONFIG_NR_DRAM_BANKS=1
+@@ -22,11 +24,13 @@ CONFIG_SYS_CONSOLE_IS_IN_ENV=y
+ CONFIG_HUSH_PARSER=y
+ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_SYS_MAXARGS=8
++CONFIG_CMD_ASKENV=y
+ CONFIG_CMD_BOOTZ=y
+ CONFIG_CMD_BOOTMENU=y
+ # CONFIG_CMD_ELF is not set
+ # CONFIG_CMD_XIMG is not set
+ CONFIG_CMD_BIND=y
++CONFIG_CMD_ERASEENV=y
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_MTD=y
 diff --git a/defenvs/an7581_rfb_env b/defenvs/an7581_rfb_env
-index 4f5aaa75af2..55536b7b299 100644
+index 716ddc321e2..9c6b6e14d94 100644
 --- a/defenvs/an7581_rfb_env
 +++ b/defenvs/an7581_rfb_env
-@@ -1,3 +1,36 @@
+@@ -2,3 +2,36 @@ loadaddr=0x81800000
  ipaddr=192.168.1.1
  serverip=192.168.1.10
  bootargs=ubi.mtd=ubi root=/dev/ubiblock0_5 rootwait
@@ -76,35 +105,11 @@ index 4f5aaa75af2..55536b7b299 100644
 +_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
 +_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
 +_init_ubi_volumes=ubi check art || ubi create art 0x400000 dynamic 3 ; ubi check kernel || ubi create kernel 0xa00000 dynamic 4 ; ubi check rootfs || ubi create rootfs 0x2800000 dynamic 5 ; ubi check kernel_alt || ubi create kernel_alt 0xa00000 dynamic 6 ; ubi check rootfs_alt || ubi create rootfs_alt 0x2800000 dynamic 7 ; ubi check rootfs_data || ubi create rootfs_data - dynamic 8
---- a/configs/an7583_evb_defconfig
-+++ b/configs/an7583_evb_defconfig
-@@ -1,5 +1,7 @@
- CONFIG_ARCH_AIROHA=y
- CONFIG_TARGET_AN7583=y
-+CONFIG_AUTOBOOT_USE_MENUKEY=y
-+CONFIG_AUTOBOOT_MENU_SHOW=y
- CONFIG_TEXT_BASE=0x81E00000
- CONFIG_SYS_MALLOC_F_LEN=0x4000
- CONFIG_NR_DRAM_BANKS=1
-@@ -21,11 +23,13 @@ CONFIG_SYS_CONSOLE_IS_IN_ENV=y
- CONFIG_HUSH_PARSER=y
- CONFIG_SYS_PROMPT="U-Boot> "
- CONFIG_SYS_MAXARGS=8
-+CONFIG_CMD_ASKENV=y
- CONFIG_CMD_BOOTZ=y
- CONFIG_CMD_BOOTMENU=y
- # CONFIG_CMD_ELF is not set
- # CONFIG_CMD_XIMG is not set
- CONFIG_CMD_BIND=y
-+CONFIG_CMD_ERASEENV=y
- CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
- CONFIG_CMD_MTD=y
-diff --git a/defenvs/an7581_rfb_env b/defenvs/an7581_rfb_env
-index 4f5aaa75af2..55536b7b299 100644
+diff --git a/defenvs/an7583_rfb_env b/defenvs/an7583_rfb_env
+index 716ddc321e2..42de6056ad4 100644
 --- a/defenvs/an7583_rfb_env
 +++ b/defenvs/an7583_rfb_env
-@@ -1,3 +1,36 @@
+@@ -2,3 +2,36 @@ loadaddr=0x81800000
  ipaddr=192.168.1.1
  serverip=192.168.1.10
  bootargs=ubi.mtd=ubi root=/dev/ubiblock0_5 rootwait
@@ -142,5 +147,5 @@ index 4f5aaa75af2..55536b7b299 100644
 +_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
 +_init_ubi_volumes=ubi check art || ubi create art 0x400000 dynamic 3 ; ubi check kernel || ubi create kernel 0xa00000 dynamic 4 ; ubi check rootfs || ubi create rootfs 0x2800000 dynamic 5 ; ubi check kernel_alt || ubi create kernel_alt 0xa00000 dynamic 6 ; ubi check rootfs_alt || ubi create rootfs_alt 0x2800000 dynamic 7 ; ubi check rootfs_data || ubi create rootfs_data - dynamic 8
 -- 
-2.48.1
+2.51.0
 

--- a/package/boot/uboot-airoha/patches/905-configs-enable-AS21xxx-PHY-config-for-Airoha-RFB-boa.patch
+++ b/package/boot/uboot-airoha/patches/905-configs-enable-AS21xxx-PHY-config-for-Airoha-RFB-boa.patch
@@ -1,7 +1,7 @@
-From 369d74a62c15f17eafdbdc671349d08cdc30388e Mon Sep 17 00:00:00 2001
+From 8ebfa81c9509a20fdf276dd2fa38bbfb6648b62e Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Wed, 15 Oct 2025 02:40:17 +0200
-Subject: [PATCH 10/10] configs: enable AS21xxx PHY config for Airoha RFB board
+Subject: [PATCH] configs: enable AS21xxx PHY config for Airoha RFB board
 
 Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  2 files changed, 4 insertions(+)
 
 diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
-index 255509c5c37..6d5b9a4dba7 100644
+index 7ae888876cb..7ae13cf577a 100644
 --- a/configs/an7581_evb_defconfig
 +++ b/configs/an7581_evb_defconfig
 @@ -108,3 +108,6 @@ CONFIG_DEFAULT_ENV_FILE="defenvs/an7581_rfb_env"
@@ -21,12 +21,12 @@ index 255509c5c37..6d5b9a4dba7 100644
 +CONFIG_PHY_ETHERNET_ID=y
 +CONFIG_PHY_AS21XXX=y
 diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
-index a3c882c807f..63ce0065957 100644
+index be61a380dd1..7427b9eb8d5 100644
 --- a/configs/an7583_evb_defconfig
 +++ b/configs/an7583_evb_defconfig
 @@ -103,3 +103,6 @@ CONFIG_DEFAULT_ENV_FILE="defenvs/an7583_rfb_env"
  CONFIG_FIP_LOADER=y
- CONFIG_PCS_AIROHA_AN7581=y
+ CONFIG_PCS_AIROHA_AN7583=y
  CONFIG_PHY_AIROHA_EN8811=y
 +CONFIG_PHY_ANEG_TIMEOUT=10000
 +CONFIG_PHY_ETHERNET_ID=y

--- a/package/boot/uboot-airoha/patches/906-01-configs-an7581-add-CONFIG_TARGET_AN7581-y.patch
+++ b/package/boot/uboot-airoha/patches/906-01-configs-an7581-add-CONFIG_TARGET_AN7581-y.patch
@@ -1,0 +1,26 @@
+From fbd92adf3022e5d627d8890d7e1aa7eb4f44c6f4 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sun, 19 Oct 2025 06:13:20 +0300
+Subject: [PATCH 092/102] configs: an7581: add CONFIG_TARGET_AN7581=y
+
+its better have target definition than relay on default
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ configs/an7581_evb_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
+index f8485954a09..d49ae08dcc2 100644
+--- a/configs/an7581_evb_defconfig
++++ b/configs/an7581_evb_defconfig
+@@ -1,5 +1,6 @@
+ CONFIG_ARM=y
+ CONFIG_ARCH_AIROHA=y
++CONFIG_TARGET_AN7581=y
+ CONFIG_AUTOBOOT_USE_MENUKEY=y
+ CONFIG_AUTOBOOT_MENU_SHOW=y
+ CONFIG_TEXT_BASE=0x81E00000
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/906-02-configs-an758x-do-not-drop-UBI-redundand-env.patch
+++ b/package/boot/uboot-airoha/patches/906-02-configs-an758x-do-not-drop-UBI-redundand-env.patch
@@ -1,0 +1,58 @@
+From 8efbf7e0f7cdea7b8fca986cee7ed2921449e20a Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sun, 19 Oct 2025 07:44:38 +0300
+Subject: [PATCH 093/102] configs: an758x: do not drop UBI redundand env
+
+redundand env is not set because SYS_REDUNDAND_ENVIRONMENT=y is missed
+
+also remove double defined PCS_AIROHA_AN7581=y
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ configs/an7581_evb_defconfig | 2 +-
+ configs/an7583_evb_defconfig | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configs/an7581_evb_defconfig b/configs/an7581_evb_defconfig
+index d49ae08dcc2..713fc284aa4 100644
+--- a/configs/an7581_evb_defconfig
++++ b/configs/an7581_evb_defconfig
+@@ -95,6 +95,7 @@ CONFIG_CMD_UBIFS=y
+ CONFIG_ENV_IS_IN_UBI=y
+ CONFIG_ENV_UBI_PART="ubi"
+ CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
+ CONFIG_ENV_UBI_VID_OFFSET=0
+ CONFIG_MTD_UBI=y
+@@ -108,7 +109,6 @@ CONFIG_UBI_BLOCK=y
+ CONFIG_USE_DEFAULT_ENV_FILE=y
+ CONFIG_DEFAULT_ENV_FILE="defenvs/an7581_rfb_env"
+ CONFIG_FIP_LOADER=y
+-CONFIG_PCS_AIROHA_AN7581=y
+ CONFIG_PHY_AIROHA_EN8811=y
+ CONFIG_PHY_ANEG_TIMEOUT=10000
+ CONFIG_PHY_ETHERNET_ID=y
+diff --git a/configs/an7583_evb_defconfig b/configs/an7583_evb_defconfig
+index d18123b9088..d83f254add3 100644
+--- a/configs/an7583_evb_defconfig
++++ b/configs/an7583_evb_defconfig
+@@ -95,6 +95,7 @@ CONFIG_CMD_UBIFS=y
+ CONFIG_ENV_IS_IN_UBI=y
+ CONFIG_ENV_UBI_PART="ubi"
+ CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
+ CONFIG_ENV_UBI_VID_OFFSET=0
+ CONFIG_MTD_UBI=y
+@@ -108,7 +109,6 @@ CONFIG_UBI_BLOCK=y
+ CONFIG_USE_DEFAULT_ENV_FILE=y
+ CONFIG_DEFAULT_ENV_FILE="defenvs/an7583_rfb_env"
+ CONFIG_FIP_LOADER=y
+-CONFIG_PCS_AIROHA_AN7583=y
+ CONFIG_PHY_AIROHA_EN8811=y
+ CONFIG_PHY_ANEG_TIMEOUT=10000
+ CONFIG_PHY_ETHERNET_ID=y
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/907-01-dts-airoha-an7581-remove-board-specific-mtd-partitio.patch
+++ b/package/boot/uboot-airoha/patches/907-01-dts-airoha-an7581-remove-board-specific-mtd-partitio.patch
@@ -1,0 +1,78 @@
+From b92a35dd3f8539bfa1c5df54a275106e24bad990 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Tue, 28 Oct 2025 11:54:22 +0300
+Subject: [PATCH 094/102] dts: airoha: an7581: remove board specific mtd
+ partitions from a common file
+
+Other board may want to use other partitioning, so put partitions to a
+board specific file.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ arch/arm/dts/an7581-u-boot.dtsi     | 16 ----------------
+ arch/arm/dts/en7581-evb-u-boot.dtsi | 22 ++++++++++++++++++++++
+ 2 files changed, 22 insertions(+), 16 deletions(-)
+
+diff --git a/arch/arm/dts/an7581-u-boot.dtsi b/arch/arm/dts/an7581-u-boot.dtsi
+index 0af2c843250..4548076b96a 100644
+--- a/arch/arm/dts/an7581-u-boot.dtsi
++++ b/arch/arm/dts/an7581-u-boot.dtsi
+@@ -152,22 +152,6 @@
+ 				spi-max-frequency = <50000000>;
+ 				spi-tx-bus-width = <1>;
+ 				spi-rx-bus-width = <2>;
+-
+-				partitions {
+-					compatible = "fixed-partitions";
+-					#address-cells = <1>;
+-					#size-cells = <1>;
+-
+-					bl2@0 {
+-						label = "bl2";
+-						reg = <0x0 0x20000>;
+-					};
+-
+-					ubi@20000 {
+-						label = "ubi";
+-						reg = <0x20000 0x0>;
+-					};
+-				};
+ 			};
+ 		};
+ 
+diff --git a/arch/arm/dts/en7581-evb-u-boot.dtsi b/arch/arm/dts/en7581-evb-u-boot.dtsi
+index 94a06403308..c52bd3eb547 100644
+--- a/arch/arm/dts/en7581-evb-u-boot.dtsi
++++ b/arch/arm/dts/en7581-evb-u-boot.dtsi
+@@ -17,6 +17,28 @@
+ 
+ #include "an7581-u-boot.dtsi"
+ 
++&snfi {
++	status = "okay";
++};
++
++&spi_nand {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		bl2@0 {
++			label = "bl2";
++			reg = <0x0 0x20000>;
++		};
++
++		ubi@20000 {
++			label = "ubi";
++			reg = <0x20000 0x0>;
++		};
++	};
++};
++
+ &mdio {
+ 	as21xxx_0: ethernet-phy@1c {
+ 		reg = <0x1c>;
+-- 
+2.51.0
+

--- a/package/boot/uboot-airoha/patches/907-02-dts-airoha-an7583-fix-system-controller-node-name.patch
+++ b/package/boot/uboot-airoha/patches/907-02-dts-airoha-an7583-fix-system-controller-node-name.patch
@@ -1,0 +1,29 @@
+From de6f43c3c1fe8deac5633ee63d7360ad2ffdfabf Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Tue, 28 Oct 2025 12:01:34 +0300
+Subject: [PATCH 095/102] dts: airoha: an7583: fix system controller node name
+
+Generally node name includes proper register starting address,
+fix scu node to follow this common rule.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ arch/arm/dts/an7583.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/an7583.dtsi b/arch/arm/dts/an7583.dtsi
+index 55dd1a8e1cb..b443e01f98d 100644
+--- a/arch/arm/dts/an7583.dtsi
++++ b/arch/arm/dts/an7583.dtsi
+@@ -250,7 +250,7 @@
+ 			reg = <0x0 0x1fbe3400 0x0 0xff>;
+ 		};
+ 
+-		scu: system-controller@1fa20000 {
++		scu: system-controller@1fb00000 {
+ 			compatible = "syscon", "simple-mfd";
+ 			reg = <0x0 0x1fb00000 0x0 0x970>;
+ 
+-- 
+2.51.0
+

--- a/target/linux/airoha/patches-6.6/029-02-spi-airoha-remove-unnecessary-restriction-length.patch
+++ b/target/linux/airoha/patches-6.6/029-02-spi-airoha-remove-unnecessary-restriction-length.patch
@@ -1,0 +1,31 @@
+From 4658f57ba7f60c3bd8e14c1ca7acf2090aee8436 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Tue, 12 Aug 2025 06:21:35 +0300
+Subject: [PATCH v6 02/13] spi: airoha: remove unnecessary restriction length
+
+The "length < 160" restriction is not needed because airoha_snand_write_data()
+and airoha_snand_read_data() will properly handle data transfers above
+SPI_MAX_TRANSFER_SIZE.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -579,13 +579,6 @@ static int airoha_snand_adjust_op_size(s
+ 
+ 		if (op->data.nbytes > max_len)
+ 			op->data.nbytes = max_len;
+-	} else {
+-		max_len = 1 + op->addr.nbytes + op->dummy.nbytes;
+-		if (max_len >= 160)
+-			return -EOPNOTSUPP;
+-
+-		if (op->data.nbytes > 160 - max_len)
+-			op->data.nbytes = 160 - max_len;
+ 	}
+ 
+ 	return 0;

--- a/target/linux/airoha/patches-6.6/029-03-spi-airoha-add-support-of-dual-quad-wires-spi-mod.patch
+++ b/target/linux/airoha/patches-6.6/029-03-spi-airoha-add-support-of-dual-quad-wires-spi-mod.patch
@@ -1,0 +1,209 @@
+From 703b10241666b468484a6ec5eb5c7c71fb2463ef Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Sat, 7 Jun 2025 09:09:38 +0300
+Subject: [PATCH v6 03/13] spi: airoha: add support of dual/quad wires spi
+ modes to exec_op() handler
+
+Booting without this patch and disabled dirmap support results in
+
+[    2.980719] spi-nand spi0.0: Micron SPI NAND was found.
+[    2.986040] spi-nand spi0.0: 256 MiB, block size: 128 KiB, page size: 2048, OOB size: 128
+[    2.994709] 2 fixed-partitions partitions found on MTD device spi0.0
+[    3.001075] Creating 2 MTD partitions on "spi0.0":
+[    3.005862] 0x000000000000-0x000000020000 : "bl2"
+[    3.011272] 0x000000020000-0x000010000000 : "ubi"
+...
+[    6.195594] ubi0: attaching mtd1
+[   13.338398] ubi0: scanning is finished
+[   13.342188] ubi0 error: ubi_read_volume_table: the layout volume was not found
+[   13.349784] ubi0 error: ubi_attach_mtd_dev: failed to attach mtd1, error -22
+[   13.356897] UBI error: cannot attach mtd1
+
+If dirmap is disabled or not supported in the spi driver, the dirmap requests
+will be executed via exec_op() handler. Thus, if the hardware supports
+dual/quad spi modes, then corresponding requests will be sent to exec_op()
+handler. Current driver does not support such requests, so error is arrised.
+As result the flash can't be read/write.
+
+This patch adds support of dual and quad wires spi modes to exec_op() handler.
+
+Fixes: a403997c12019 ("spi: airoha: add SPI-NAND Flash controller driver")
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 108 ++++++++++++++++++++++++++--------
+ 1 file changed, 82 insertions(+), 26 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -192,6 +192,14 @@
+ #define SPI_NAND_OP_RESET			0xff
+ #define SPI_NAND_OP_DIE_SELECT			0xc2
+ 
++/* SNAND FIFO commands */
++#define SNAND_FIFO_TX_BUSWIDTH_SINGLE		0x08
++#define SNAND_FIFO_TX_BUSWIDTH_DUAL		0x09
++#define SNAND_FIFO_TX_BUSWIDTH_QUAD		0x0a
++#define SNAND_FIFO_RX_BUSWIDTH_SINGLE		0x0c
++#define SNAND_FIFO_RX_BUSWIDTH_DUAL		0x0e
++#define SNAND_FIFO_RX_BUSWIDTH_QUAD		0x0f
++
+ #define SPI_NAND_CACHE_SIZE			(SZ_4K + SZ_256)
+ #define SPI_MAX_TRANSFER_SIZE			511
+ 
+@@ -387,10 +395,26 @@ static int airoha_snand_set_mode(struct
+ 	return regmap_write(as_ctrl->regmap_ctrl, REG_SPI_CTRL_DUMMY, 0);
+ }
+ 
+-static int airoha_snand_write_data(struct airoha_snand_ctrl *as_ctrl, u8 cmd,
+-				   const u8 *data, int len)
++static int airoha_snand_write_data(struct airoha_snand_ctrl *as_ctrl,
++				   const u8 *data, int len, int buswidth)
+ {
+ 	int i, data_len;
++	u8 cmd;
++
++	switch (buswidth) {
++	case 0:
++	case 1:
++		cmd = SNAND_FIFO_TX_BUSWIDTH_SINGLE;
++		break;
++	case 2:
++		cmd = SNAND_FIFO_TX_BUSWIDTH_DUAL;
++		break;
++	case 4:
++		cmd = SNAND_FIFO_TX_BUSWIDTH_QUAD;
++		break;
++	default:
++		return -EINVAL;
++	}
+ 
+ 	for (i = 0; i < len; i += data_len) {
+ 		int err;
+@@ -409,16 +433,32 @@ static int airoha_snand_write_data(struc
+ 	return 0;
+ }
+ 
+-static int airoha_snand_read_data(struct airoha_snand_ctrl *as_ctrl, u8 *data,
+-				  int len)
++static int airoha_snand_read_data(struct airoha_snand_ctrl *as_ctrl,
++				  u8 *data, int len, int buswidth)
+ {
+ 	int i, data_len;
++	u8 cmd;
++
++	switch (buswidth) {
++	case 0:
++	case 1:
++		cmd = SNAND_FIFO_RX_BUSWIDTH_SINGLE;
++		break;
++	case 2:
++		cmd = SNAND_FIFO_RX_BUSWIDTH_DUAL;
++		break;
++	case 4:
++		cmd = SNAND_FIFO_RX_BUSWIDTH_QUAD;
++		break;
++	default:
++		return -EINVAL;
++	}
+ 
+ 	for (i = 0; i < len; i += data_len) {
+ 		int err;
+ 
+ 		data_len = min(len - i, SPI_MAX_TRANSFER_SIZE);
+-		err = airoha_snand_set_fifo_op(as_ctrl, 0xc, data_len);
++		err = airoha_snand_set_fifo_op(as_ctrl, cmd, data_len);
+ 		if (err)
+ 			return err;
+ 
+@@ -891,12 +931,28 @@ error_dma_unmap:
+ static int airoha_snand_exec_op(struct spi_mem *mem,
+ 				const struct spi_mem_op *op)
+ {
+-	u8 data[8], cmd, opcode = op->cmd.opcode;
+ 	struct airoha_snand_ctrl *as_ctrl;
++	int op_len, addr_len, dummy_len;
++	u8 buf[20], *data;
+ 	int i, err;
+ 
+ 	as_ctrl = spi_controller_get_devdata(mem->spi->controller);
+ 
++	op_len = op->cmd.nbytes;
++	addr_len = op->addr.nbytes;
++	dummy_len = op->dummy.nbytes;
++
++	if (op_len + dummy_len + addr_len > sizeof(buf))
++		return -EIO;
++
++	data = buf;
++	for (i = 0; i < op_len; i++)
++		*data++ = op->cmd.opcode >> (8 * (op_len - i - 1));
++	for (i = 0; i < addr_len; i++)
++		*data++ = op->addr.val >> (8 * (addr_len - i - 1));
++	for (i = 0; i < dummy_len; i++)
++		*data++ = 0xff;
++
+ 	/* switch to manual mode */
+ 	err = airoha_snand_set_mode(as_ctrl, SPI_MODE_MANUAL);
+ 	if (err < 0)
+@@ -907,40 +963,40 @@ static int airoha_snand_exec_op(struct s
+ 		return err;
+ 
+ 	/* opcode */
+-	err = airoha_snand_write_data(as_ctrl, 0x8, &opcode, sizeof(opcode));
++	data = buf;
++	err = airoha_snand_write_data(as_ctrl, data, op_len,
++				      op->cmd.buswidth);
+ 	if (err)
+ 		return err;
+ 
+ 	/* addr part */
+-	cmd = opcode == SPI_NAND_OP_GET_FEATURE ? 0x11 : 0x8;
+-	put_unaligned_be64(op->addr.val, data);
+-
+-	for (i = ARRAY_SIZE(data) - op->addr.nbytes;
+-	     i < ARRAY_SIZE(data); i++) {
+-		err = airoha_snand_write_data(as_ctrl, cmd, &data[i],
+-					      sizeof(data[0]));
++	data += op_len;
++	if (addr_len) {
++		err = airoha_snand_write_data(as_ctrl, data, addr_len,
++					      op->addr.buswidth);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+ 	/* dummy */
+-	data[0] = 0xff;
+-	for (i = 0; i < op->dummy.nbytes; i++) {
+-		err = airoha_snand_write_data(as_ctrl, 0x8, &data[0],
+-					      sizeof(data[0]));
++	data += addr_len;
++	if (dummy_len) {
++		err = airoha_snand_write_data(as_ctrl, data, dummy_len,
++					      op->dummy.buswidth);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+ 	/* data */
+-	if (op->data.dir == SPI_MEM_DATA_IN) {
+-		err = airoha_snand_read_data(as_ctrl, op->data.buf.in,
+-					     op->data.nbytes);
+-		if (err)
+-			return err;
+-	} else {
+-		err = airoha_snand_write_data(as_ctrl, 0x8, op->data.buf.out,
+-					      op->data.nbytes);
++	if (op->data.nbytes) {
++		if (op->data.dir == SPI_MEM_DATA_IN)
++			err = airoha_snand_read_data(as_ctrl, op->data.buf.in,
++						     op->data.nbytes,
++						     op->data.buswidth);
++		else
++			err = airoha_snand_write_data(as_ctrl, op->data.buf.out,
++						      op->data.nbytes,
++						      op->data.buswidth);
+ 		if (err)
+ 			return err;
+ 	}

--- a/target/linux/airoha/patches-6.6/029-04-spi-airoha-remove-unnecessary-switch-to-non-dma-m.patch
+++ b/target/linux/airoha/patches-6.6/029-04-spi-airoha-remove-unnecessary-switch-to-non-dma-m.patch
@@ -1,0 +1,29 @@
+From fb41a3e3bc357592b28a8abb504df99dad642588 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 11 Aug 2025 13:09:51 +0300
+Subject: [PATCH v6 04/13] spi: airoha: remove unnecessary switch to non-dma
+ mode
+
+The code switches to dma at the start of dirmap operation and returns
+to non-dma at the end of dirmap operation, so an additional switch to
+non-dma at the start of dirmap write is not required.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -808,9 +808,6 @@ static ssize_t airoha_snand_dirmap_write
+ 	int err;
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+-	err = airoha_snand_set_mode(as_ctrl, SPI_MODE_MANUAL);
+-	if (err < 0)
+-		return err;
+ 
+ 	memcpy(txrx_buf + offs, buf, len);
+ 	dma_addr = dma_map_single(as_ctrl->dev, txrx_buf, SPI_NAND_CACHE_SIZE,

--- a/target/linux/airoha/patches-6.6/029-05-spi-airoha-switch-back-to-non-dma-mode-in-the-cas.patch
+++ b/target/linux/airoha/patches-6.6/029-05-spi-airoha-switch-back-to-non-dma-mode-in-the-cas.patch
@@ -1,0 +1,54 @@
+From 711584484d76448763959ed4e103895d9dcc7438 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 11 Aug 2025 20:24:42 +0300
+Subject: [PATCH v6 05/13] spi: airoha: switch back to non-dma mode in the case
+ of error
+
+Current dirmap code does not switch back to non-dma mode in the case of
+error. This is wrong.
+
+This patch fixes dirmap read/write error path.
+
+Fixes: a403997c12019 ("spi: airoha: add SPI-NAND Flash controller driver")
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Acked-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -687,13 +687,13 @@ static ssize_t airoha_snand_dirmap_read(
+ 
+ 	err = airoha_snand_nfi_config(as_ctrl);
+ 	if (err)
+-		return err;
++		goto error_dma_mode_off;
+ 
+ 	dma_addr = dma_map_single(as_ctrl->dev, txrx_buf, SPI_NAND_CACHE_SIZE,
+ 				  DMA_FROM_DEVICE);
+ 	err = dma_mapping_error(as_ctrl->dev, dma_addr);
+ 	if (err)
+-		return err;
++		goto error_dma_mode_off;
+ 
+ 	/* set dma addr */
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_STRADDR,
+@@ -793,6 +793,8 @@ static ssize_t airoha_snand_dirmap_read(
+ error_dma_unmap:
+ 	dma_unmap_single(as_ctrl->dev, dma_addr, SPI_NAND_CACHE_SIZE,
+ 			 DMA_FROM_DEVICE);
++error_dma_mode_off:
++	airoha_snand_set_mode(as_ctrl, SPI_MODE_MANUAL);
+ 	return err;
+ }
+ 
+@@ -922,6 +924,7 @@ static ssize_t airoha_snand_dirmap_write
+ error_dma_unmap:
+ 	dma_unmap_single(as_ctrl->dev, dma_addr, SPI_NAND_CACHE_SIZE,
+ 			 DMA_TO_DEVICE);
++	airoha_snand_set_mode(as_ctrl, SPI_MODE_MANUAL);
+ 	return err;
+ }
+ 

--- a/target/linux/airoha/patches-6.6/029-06-spi-airoha-fix-reading-writing-of-flashes-with-mo.patch
+++ b/target/linux/airoha/patches-6.6/029-06-spi-airoha-fix-reading-writing-of-flashes-with-mo.patch
@@ -1,0 +1,102 @@
+From d8a0a67bf75c4cf2a760b6fa0002b0baff6e8b20 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 11 Aug 2025 20:32:40 +0300
+Subject: [PATCH v6 06/13] spi: airoha: fix reading/writing of flashes with
+ more than one plane per lun
+
+Attaching UBI on the flash with more than one plane per lun will lead to
+the following error:
+
+[    2.980989] spi-nand spi0.0: Micron SPI NAND was found.
+[    2.986309] spi-nand spi0.0: 256 MiB, block size: 128 KiB, page size: 2048, OOB size: 128
+[    2.994978] 2 fixed-partitions partitions found on MTD device spi0.0
+[    3.001350] Creating 2 MTD partitions on "spi0.0":
+[    3.006159] 0x000000000000-0x000000020000 : "bl2"
+[    3.011663] 0x000000020000-0x000010000000 : "ubi"
+...
+[    6.391748] ubi0: attaching mtd1
+[    6.412545] ubi0 error: ubi_attach: PEB 0 contains corrupted VID header, and the data does not contain all 0xFF
+[    6.422677] ubi0 error: ubi_attach: this may be a non-UBI PEB or a severe VID header corruption which requires manual inspection
+[    6.434249] Volume identifier header dump:
+[    6.438349]     magic     55424923
+[    6.441482]     version   1
+[    6.444007]     vol_type  0
+[    6.446539]     copy_flag 0
+[    6.449068]     compat    0
+[    6.451594]     vol_id    0
+[    6.454120]     lnum      1
+[    6.456651]     data_size 4096
+[    6.459442]     used_ebs  1061644134
+[    6.462748]     data_pad  0
+[    6.465274]     sqnum     0
+[    6.467805]     hdr_crc   61169820
+[    6.470943] Volume identifier header hexdump:
+[    6.475308] hexdump of PEB 0 offset 4096, length 126976
+[    6.507391] ubi0 warning: ubi_attach: valid VID header but corrupted EC header at PEB 4
+[    6.515415] ubi0 error: ubi_compare_lebs: unsupported on-flash UBI format
+[    6.522222] ubi0 error: ubi_attach_mtd_dev: failed to attach mtd1, error -22
+[    6.529294] UBI error: cannot attach mtd1
+
+Non dirmap reading works good. Looking to spi_mem_no_dirmap_read() code we'll see:
+
+	static ssize_t spi_mem_no_dirmap_read(struct spi_mem_dirmap_desc *desc,
+					      u64 offs, size_t len, void *buf)
+	{
+		struct spi_mem_op op = desc->info.op_tmpl;
+		int ret;
+
+// --- see here ---
+		op.addr.val = desc->info.offset + offs;
+//-----------------
+		op.data.buf.in = buf;
+		op.data.nbytes = len;
+		ret = spi_mem_adjust_op_size(desc->mem, &op);
+		if (ret)
+		return ret;
+
+		ret = spi_mem_exec_op(desc->mem, &op);
+		if (ret)
+			return ret;
+
+		return op.data.nbytes;
+	}
+
+The similar happens for spi_mem_no_dirmap_write(). Thus the address
+passed to the flash should take in the account the value of
+desc->info.offset.
+
+This patch fix dirmap reading/writing of flashes with more than one
+plane per lun.
+
+Fixes: a403997c12019 ("spi: airoha: add SPI-NAND Flash controller driver")
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -722,8 +722,9 @@ static ssize_t airoha_snand_dirmap_read(
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	/* set read addr */
+-	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_RD_CTL3, 0x0);
++	/* set read addr: zero page offset + descriptor read offset */
++	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_RD_CTL3,
++			   desc->info.offset);
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+@@ -856,7 +857,9 @@ static ssize_t airoha_snand_dirmap_write
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_PG_CTL2, 0x0);
++	/* set write addr: zero page offset + descriptor write offset */
++	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_PG_CTL2,
++			   desc->info.offset);
+ 	if (err)
+ 		goto error_dma_unmap;
+ 

--- a/target/linux/airoha/patches-6.6/029-07-spi-airoha-unify-dirmap-read-write-code.patch
+++ b/target/linux/airoha/patches-6.6/029-07-spi-airoha-unify-dirmap-read-write-code.patch
@@ -1,0 +1,135 @@
+From 995b1a65206ee28d5403db0518cb230f2ce429ef Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 11 Aug 2025 19:57:43 +0300
+Subject: [PATCH v6 07/13] spi: airoha: unify dirmap read/write code
+
+Makes dirmap writing looks similar to dirmap reading. Just a minor
+refactoring, no behavior change is expected.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/spi-airoha-snfi.c | 50 ++++++++++++++++++++++-------------
+ 1 file changed, 32 insertions(+), 18 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -668,6 +668,8 @@ static ssize_t airoha_snand_dirmap_read(
+ 	u32 val, rd_mode;
+ 	int err;
+ 
++	as_ctrl = spi_controller_get_devdata(spi->controller);
++
+ 	switch (op->cmd.opcode) {
+ 	case SPI_NAND_OP_READ_FROM_CACHE_DUAL:
+ 		rd_mode = 1;
+@@ -680,7 +682,6 @@ static ssize_t airoha_snand_dirmap_read(
+ 		break;
+ 	}
+ 
+-	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 	err = airoha_snand_set_mode(as_ctrl, SPI_MODE_DMA);
+ 	if (err < 0)
+ 		return err;
+@@ -744,7 +745,7 @@ static ssize_t airoha_snand_dirmap_read(
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	/* trigger dma start read */
++	/* trigger dma reading */
+ 	err = regmap_clear_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+ 				SPI_NFI_RD_TRIG);
+ 	if (err)
+@@ -802,37 +803,47 @@ error_dma_mode_off:
+ static ssize_t airoha_snand_dirmap_write(struct spi_mem_dirmap_desc *desc,
+ 					 u64 offs, size_t len, const void *buf)
+ {
+-	struct spi_mem_op *op = &desc->info.op_tmpl;
+ 	struct spi_device *spi = desc->mem->spi;
+ 	u8 *txrx_buf = spi_get_ctldata(spi);
+ 	struct airoha_snand_ctrl *as_ctrl;
+ 	dma_addr_t dma_addr;
+-	u32 wr_mode, val;
++	u32 wr_mode, val, opcode;
+ 	int err;
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 
++	opcode = desc->info.op_tmpl.cmd.opcode;
++	switch (opcode) {
++	case SPI_NAND_OP_PROGRAM_LOAD_SINGLE:
++	case SPI_NAND_OP_PROGRAM_LOAD_RAMDOM_SINGLE:
++		wr_mode = 0;
++		break;
++	case SPI_NAND_OP_PROGRAM_LOAD_QUAD:
++	case SPI_NAND_OP_PROGRAM_LOAD_RAMDON_QUAD:
++		wr_mode = 2;
++		break;
++	default:
++		/* unknown opcode */
++		return -EOPNOTSUPP;
++	}
++
+ 	memcpy(txrx_buf + offs, buf, len);
+-	dma_addr = dma_map_single(as_ctrl->dev, txrx_buf, SPI_NAND_CACHE_SIZE,
+-				  DMA_TO_DEVICE);
+-	err = dma_mapping_error(as_ctrl->dev, dma_addr);
+-	if (err)
+-		return err;
+ 
+ 	err = airoha_snand_set_mode(as_ctrl, SPI_MODE_DMA);
+ 	if (err < 0)
+-		goto error_dma_unmap;
++		return err;
+ 
+ 	err = airoha_snand_nfi_config(as_ctrl);
+ 	if (err)
+-		goto error_dma_unmap;
++		goto error_dma_mode_off;
+ 
+-	if (op->cmd.opcode == SPI_NAND_OP_PROGRAM_LOAD_QUAD ||
+-	    op->cmd.opcode == SPI_NAND_OP_PROGRAM_LOAD_RAMDON_QUAD)
+-		wr_mode = BIT(1);
+-	else
+-		wr_mode = 0;
++	dma_addr = dma_map_single(as_ctrl->dev, txrx_buf, SPI_NAND_CACHE_SIZE,
++				  DMA_TO_DEVICE);
++	err = dma_mapping_error(as_ctrl->dev, dma_addr);
++	if (err)
++		goto error_dma_mode_off;
+ 
++	/* set dma addr */
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_STRADDR,
+ 			   dma_addr);
+ 	if (err)
+@@ -846,12 +857,13 @@ static ssize_t airoha_snand_dirmap_write
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
++	/* set write command */
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_PG_CTL1,
+-			   FIELD_PREP(SPI_NFI_PG_LOAD_CMD,
+-				      op->cmd.opcode));
++			   FIELD_PREP(SPI_NFI_PG_LOAD_CMD, opcode));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
++	/* set write mode */
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_SNF_MISC_CTL,
+ 			   FIELD_PREP(SPI_NFI_DATA_READ_WR_MODE, wr_mode));
+ 	if (err)
+@@ -883,6 +895,7 @@ static ssize_t airoha_snand_dirmap_write
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
++	/* trigger dma writing */
+ 	err = regmap_clear_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+ 				SPI_NFI_WR_TRIG);
+ 	if (err)
+@@ -927,6 +940,7 @@ static ssize_t airoha_snand_dirmap_write
+ error_dma_unmap:
+ 	dma_unmap_single(as_ctrl->dev, dma_addr, SPI_NAND_CACHE_SIZE,
+ 			 DMA_TO_DEVICE);
++error_dma_mode_off:
+ 	airoha_snand_set_mode(as_ctrl, SPI_MODE_MANUAL);
+ 	return err;
+ }

--- a/target/linux/airoha/patches-6.6/029-08-spi-airoha-support-of-dualio-quadio-flash-reading.patch
+++ b/target/linux/airoha/patches-6.6/029-08-spi-airoha-support-of-dualio-quadio-flash-reading.patch
@@ -1,0 +1,92 @@
+From baaba9b8d3d907575323cbb7fabeae23db2a542b Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 11 Aug 2025 20:52:34 +0300
+Subject: [PATCH v6 08/13] spi: airoha: support of dualio/quadio flash reading
+ commands
+
+Airoha snfi spi controller supports acceleration of DUAL/QUAD
+operations, but does not supports DUAL_IO/QUAD_IO operations.
+Luckily DUAL/QUAD operations do the same as DUAL_IO/QUAD_IO ones,
+so we can issue corresponding DUAL/QUAD operation instead of
+DUAL_IO/QUAD_IO one.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 28 ++++++++++++++++++++++------
+ 1 file changed, 22 insertions(+), 6 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -147,6 +147,8 @@
+ #define SPI_NFI_CUS_SEC_SIZE_EN			BIT(16)
+ 
+ #define REG_SPI_NFI_RD_CTL2			0x0510
++#define SPI_NFI_DATA_READ_CMD			GENMASK(7, 0)
++
+ #define REG_SPI_NFI_RD_CTL3			0x0514
+ 
+ #define REG_SPI_NFI_PG_CTL1			0x0524
+@@ -179,7 +181,9 @@
+ #define SPI_NAND_OP_READ_FROM_CACHE_SINGLE	0x03
+ #define SPI_NAND_OP_READ_FROM_CACHE_SINGLE_FAST	0x0b
+ #define SPI_NAND_OP_READ_FROM_CACHE_DUAL	0x3b
++#define SPI_NAND_OP_READ_FROM_CACHE_DUALIO	0xbb
+ #define SPI_NAND_OP_READ_FROM_CACHE_QUAD	0x6b
++#define SPI_NAND_OP_READ_FROM_CACHE_QUADIO	0xeb
+ #define SPI_NAND_OP_WRITE_ENABLE		0x06
+ #define SPI_NAND_OP_WRITE_DISABLE		0x04
+ #define SPI_NAND_OP_PROGRAM_LOAD_SINGLE		0x02
+@@ -660,26 +664,38 @@ static int airoha_snand_dirmap_create(st
+ static ssize_t airoha_snand_dirmap_read(struct spi_mem_dirmap_desc *desc,
+ 					u64 offs, size_t len, void *buf)
+ {
+-	struct spi_mem_op *op = &desc->info.op_tmpl;
+ 	struct spi_device *spi = desc->mem->spi;
+ 	struct airoha_snand_ctrl *as_ctrl;
+ 	u8 *txrx_buf = spi_get_ctldata(spi);
+ 	dma_addr_t dma_addr;
+-	u32 val, rd_mode;
++	u32 val, rd_mode, opcode;
+ 	int err;
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 
+-	switch (op->cmd.opcode) {
++	/*
++	 * DUALIO and QUADIO opcodes are not supported by the spi controller,
++	 * replace them with supported opcodes.
++	 */
++	opcode = desc->info.op_tmpl.cmd.opcode;
++	switch (opcode) {
++	case SPI_NAND_OP_READ_FROM_CACHE_SINGLE:
++	case SPI_NAND_OP_READ_FROM_CACHE_SINGLE_FAST:
++		rd_mode = 0;
++		break;
+ 	case SPI_NAND_OP_READ_FROM_CACHE_DUAL:
++	case SPI_NAND_OP_READ_FROM_CACHE_DUALIO:
++		opcode = SPI_NAND_OP_READ_FROM_CACHE_DUAL;
+ 		rd_mode = 1;
+ 		break;
+ 	case SPI_NAND_OP_READ_FROM_CACHE_QUAD:
++	case SPI_NAND_OP_READ_FROM_CACHE_QUADIO:
++		opcode = SPI_NAND_OP_READ_FROM_CACHE_QUAD;
+ 		rd_mode = 2;
+ 		break;
+ 	default:
+-		rd_mode = 0;
+-		break;
++		/* unknown opcode */
++		return -EOPNOTSUPP;
+ 	}
+ 
+ 	err = airoha_snand_set_mode(as_ctrl, SPI_MODE_DMA);
+@@ -713,7 +729,7 @@ static ssize_t airoha_snand_dirmap_read(
+ 
+ 	/* set read command */
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_RD_CTL2,
+-			   op->cmd.opcode);
++			   FIELD_PREP(SPI_NFI_DATA_READ_CMD, opcode));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 

--- a/target/linux/airoha/patches-6.6/029-09-spi-airoha-buffer-must-be-0xff-ed-before-writing.patch
+++ b/target/linux/airoha/patches-6.6/029-09-spi-airoha-buffer-must-be-0xff-ed-before-writing.patch
@@ -1,0 +1,29 @@
+From 6ca9cd453cb5d8a6411791295771b4dbd1c623de Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 11 Aug 2025 21:18:04 +0300
+Subject: [PATCH v6 09/13] spi: airoha: buffer must be 0xff-ed before writing
+
+During writing, the entire flash page (including OOB) will be updated
+with the values from the temporary buffer, so we need to fill the
+untouched areas of the buffer with 0xff value to prevent accidental
+data overwriting.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/spi-airoha-snfi.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -843,7 +843,11 @@ static ssize_t airoha_snand_dirmap_write
+ 		return -EOPNOTSUPP;
+ 	}
+ 
++	if (offs > 0)
++		memset(txrx_buf, 0xff, offs);
+ 	memcpy(txrx_buf + offs, buf, len);
++	if (bytes > offs + len)
++		memset(txrx_buf + offs + len, 0xff, bytes - offs - len);
+ 
+ 	err = airoha_snand_set_mode(as_ctrl, SPI_MODE_DMA);
+ 	if (err < 0)

--- a/target/linux/airoha/patches-6.6/029-10-spi-airoha-avoid-setting-of-page-oob-sizes-in-REG.patch
+++ b/target/linux/airoha/patches-6.6/029-10-spi-airoha-avoid-setting-of-page-oob-sizes-in-REG.patch
@@ -1,0 +1,62 @@
+From 4abbbc74306598159fe1dc545f929ae594bf4dd1 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 18:00:32 +0300
+Subject: [PATCH v6 10/13] spi: airoha: avoid setting of page/oob sizes in
+ REG_SPI_NFI_PAGEFMT
+
+spi-airoha-snfi uses custom sector size in REG_SPI_NFI_SECCUS_SIZE
+register, so setting of page/oob sizes in REG_SPI_NFI_PAGEFMT is not
+required.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/spi-airoha-snfi.c | 38 -----------------------------------
+ 1 file changed, 38 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -518,44 +518,6 @@ static int airoha_snand_nfi_config(struc
+ 	if (err)
+ 		return err;
+ 
+-	/* page format */
+-	switch (as_ctrl->nfi_cfg.spare_size) {
+-	case 26:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x1);
+-		break;
+-	case 27:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x2);
+-		break;
+-	case 28:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x3);
+-		break;
+-	default:
+-		val = FIELD_PREP(SPI_NFI_SPARE_SIZE, 0x0);
+-		break;
+-	}
+-
+-	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_PAGEFMT,
+-				 SPI_NFI_SPARE_SIZE, val);
+-	if (err)
+-		return err;
+-
+-	switch (as_ctrl->nfi_cfg.page_size) {
+-	case 2048:
+-		val = FIELD_PREP(SPI_NFI_PAGE_SIZE, 0x1);
+-		break;
+-	case 4096:
+-		val = FIELD_PREP(SPI_NFI_PAGE_SIZE, 0x2);
+-		break;
+-	default:
+-		val = FIELD_PREP(SPI_NFI_PAGE_SIZE, 0x0);
+-		break;
+-	}
+-
+-	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_PAGEFMT,
+-				 SPI_NFI_PAGE_SIZE, val);
+-	if (err)
+-		return err;
+-
+ 	/* sec num */
+ 	val = FIELD_PREP(SPI_NFI_SEC_NUM, as_ctrl->nfi_cfg.sec_num);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,

--- a/target/linux/airoha/patches-6.6/029-11-spi-airoha-reduce-the-number-of-modification-of-R.patch
+++ b/target/linux/airoha/patches-6.6/029-11-spi-airoha-reduce-the-number-of-modification-of-R.patch
@@ -1,0 +1,197 @@
+From 0d8f58869192df0acdba286d233b57a4feeaf94b Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 18:49:34 +0300
+Subject: [PATCH v6 11/13] spi: airoha: reduce the number of modification of
+ REG_SPI_NFI_CNFG and REG_SPI_NFI_SECCUS_SIZE registers
+
+This just reduce the number of modification of REG_SPI_NFI_CNFG and
+REG_SPI_NFI_SECCUS_SIZE registers during dirmap operation.
+
+This patch is a necessary step to avoid reading flash page settings
+from SNFI registers during driver startup.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 135 +++++++++++++++++++++++++---------
+ 1 file changed, 102 insertions(+), 33 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -664,7 +664,48 @@ static ssize_t airoha_snand_dirmap_read(
+ 	if (err < 0)
+ 		return err;
+ 
+-	err = airoha_snand_nfi_config(as_ctrl);
++	/* NFI reset */
++	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
++			   SPI_NFI_FIFO_FLUSH | SPI_NFI_RST);
++	if (err)
++		goto error_dma_mode_off;
++
++	/* NFI configure:
++	 *   - No AutoFDM (custom sector size (SECCUS) register will be used)
++	 *   - No SoC's hardware ECC (flash internal ECC will be used)
++	 *   - Use burst mode (faster, but requires 16 byte alignment for addresses)
++	 *   - Setup for reading (SPI_NFI_READ_MODE)
++	 *   - Setup reading command: FIELD_PREP(SPI_NFI_OPMODE, 6)
++	 *   - Use DMA instead of PIO for data reading
++	 */
++	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_READ_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 SPI_NFI_HW_ECC_EN |
++				 SPI_NFI_AUTO_FDM_EN |
++				 SPI_NFI_OPMODE,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_READ_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 FIELD_PREP(SPI_NFI_OPMODE, 6));
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set number of sector will be read */
++	val = FIELD_PREP(SPI_NFI_SEC_NUM, as_ctrl->nfi_cfg.sec_num);
++	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
++				 SPI_NFI_SEC_NUM, val);
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set custom sector size */
++	val = as_ctrl->nfi_cfg.sec_size;
++	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
++				 SPI_NFI_CUS_SEC_SIZE |
++				 SPI_NFI_CUS_SEC_SIZE_EN,
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+@@ -680,7 +721,14 @@ static ssize_t airoha_snand_dirmap_read(
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	/* set cust sec size */
++	/*
++	 * Setup transfer length
++	 * ---------------------
++	 * The following rule MUST be met:
++	 *     transfer_length =
++	 *        = NFI_SNF_MISC_CTL2.read_data_byte_number =
++	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
++	 */
+ 	val = as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num;
+ 	val = FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, val);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi,
+@@ -707,18 +755,6 @@ static ssize_t airoha_snand_dirmap_read(
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	/* set nfi read */
+-	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-				 SPI_NFI_OPMODE,
+-				 FIELD_PREP(SPI_NFI_OPMODE, 6));
+-	if (err)
+-		goto error_dma_unmap;
+-
+-	err = regmap_set_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-			      SPI_NFI_READ_MODE | SPI_NFI_DMA_MODE);
+-	if (err)
+-		goto error_dma_unmap;
+-
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_CMD, 0x0);
+ 	if (err)
+ 		goto error_dma_unmap;
+@@ -815,7 +851,48 @@ static ssize_t airoha_snand_dirmap_write
+ 	if (err < 0)
+ 		return err;
+ 
+-	err = airoha_snand_nfi_config(as_ctrl);
++	/* NFI reset */
++	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
++			   SPI_NFI_FIFO_FLUSH | SPI_NFI_RST);
++	if (err)
++		goto error_dma_mode_off;
++
++	/*
++	 * NFI configure:
++	 *   - No AutoFDM (custom sector size (SECCUS) register will be used)
++	 *   - No SoC's hardware ECC (flash internal ECC will be used)
++	 *   - Use burst mode (faster, but requires 16 byte alignment for addresses)
++	 *   - Setup for writing (SPI_NFI_READ_MODE bit is cleared)
++	 *   - Setup writing command: FIELD_PREP(SPI_NFI_OPMODE, 3)
++	 *   - Use DMA instead of PIO for data writing
++	 */
++	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_READ_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 SPI_NFI_HW_ECC_EN |
++				 SPI_NFI_AUTO_FDM_EN |
++				 SPI_NFI_OPMODE,
++				 SPI_NFI_DMA_MODE |
++				 SPI_NFI_DMA_BURST_EN |
++				 FIELD_PREP(SPI_NFI_OPMODE, 3));
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set number of sector will be written */
++	val = FIELD_PREP(SPI_NFI_SEC_NUM, as_ctrl->nfi_cfg.sec_num);
++	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
++				 SPI_NFI_SEC_NUM, val);
++	if (err)
++		goto error_dma_mode_off;
++
++	/* Set custom sector size */
++	val = as_ctrl->nfi_cfg.sec_size;
++	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
++				 SPI_NFI_CUS_SEC_SIZE |
++				 SPI_NFI_CUS_SEC_SIZE_EN,
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+@@ -831,8 +908,16 @@ static ssize_t airoha_snand_dirmap_write
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM,
+-			 as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num);
++	/*
++	 * Setup transfer length
++	 * ---------------------
++	 * The following rule MUST be met:
++	 *     transfer_length =
++	 *        = NFI_SNF_MISC_CTL2.write_data_byte_number =
++	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
++	 */
++	val = as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num;
++	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM, val);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi,
+ 				 REG_SPI_NFI_SNF_MISC_CTL2,
+ 				 SPI_NFI_PROG_LOAD_BYTE_NUM, val);
+@@ -857,22 +942,6 @@ static ssize_t airoha_snand_dirmap_write
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+-	err = regmap_clear_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-				SPI_NFI_READ_MODE);
+-	if (err)
+-		goto error_dma_unmap;
+-
+-	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-				 SPI_NFI_OPMODE,
+-				 FIELD_PREP(SPI_NFI_OPMODE, 3));
+-	if (err)
+-		goto error_dma_unmap;
+-
+-	err = regmap_set_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-			      SPI_NFI_DMA_MODE);
+-	if (err)
+-		goto error_dma_unmap;
+-
+ 	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_CMD, 0x80);
+ 	if (err)
+ 		goto error_dma_unmap;

--- a/target/linux/airoha/patches-6.6/029-12-spi-airoha-set-custom-sector-size-equal-to-flash-.patch
+++ b/target/linux/airoha/patches-6.6/029-12-spi-airoha-set-custom-sector-size-equal-to-flash-.patch
@@ -1,0 +1,140 @@
+From 893ee23d650ca9ee36541b9a5ae0bc18be01a11f Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 22:47:17 +0300
+Subject: [PATCH v6 12/13] spi: airoha: set custom sector size equal to flash
+ page size
+
+Set custom sector size equal to flash page size including oob. Thus we
+will always read a single sector. The maximum custom sector size is
+8187, so all possible flash sector sizes are supported.
+
+This patch is a necessary step to avoid reading flash page settings
+from SNFI registers during driver startup.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ drivers/spi/spi-airoha-snfi.c | 35 +++++++++++++++++++----------------
+ 1 file changed, 19 insertions(+), 16 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -519,7 +519,7 @@ static int airoha_snand_nfi_config(struc
+ 		return err;
+ 
+ 	/* sec num */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, as_ctrl->nfi_cfg.sec_num);
++	val = FIELD_PREP(SPI_NFI_SEC_NUM, 1);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+ 				 SPI_NFI_SEC_NUM, val);
+ 	if (err)
+@@ -532,7 +532,8 @@ static int airoha_snand_nfi_config(struc
+ 		return err;
+ 
+ 	/* set cust sec size */
+-	val = FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, as_ctrl->nfi_cfg.sec_size);
++	val = FIELD_PREP(SPI_NFI_CUS_SEC_SIZE,
++			 as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num);
+ 	return regmap_update_bits(as_ctrl->regmap_nfi,
+ 				  REG_SPI_NFI_SECCUS_SIZE,
+ 				  SPI_NFI_CUS_SEC_SIZE, val);
+@@ -631,10 +632,13 @@ static ssize_t airoha_snand_dirmap_read(
+ 	u8 *txrx_buf = spi_get_ctldata(spi);
+ 	dma_addr_t dma_addr;
+ 	u32 val, rd_mode, opcode;
++	size_t bytes;
+ 	int err;
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 
++	bytes = as_ctrl->nfi_cfg.sec_num * as_ctrl->nfi_cfg.sec_size;
++
+ 	/*
+ 	 * DUALIO and QUADIO opcodes are not supported by the spi controller,
+ 	 * replace them with supported opcodes.
+@@ -693,18 +697,17 @@ static ssize_t airoha_snand_dirmap_read(
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set number of sector will be read */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, as_ctrl->nfi_cfg.sec_num);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+-				 SPI_NFI_SEC_NUM, val);
++				 SPI_NFI_SEC_NUM,
++				 FIELD_PREP(SPI_NFI_SEC_NUM, 1));
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set custom sector size */
+-	val = as_ctrl->nfi_cfg.sec_size;
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
+ 				 SPI_NFI_CUS_SEC_SIZE |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN,
+-				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, bytes) |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+@@ -729,11 +732,10 @@ static ssize_t airoha_snand_dirmap_read(
+ 	 *        = NFI_SNF_MISC_CTL2.read_data_byte_number =
+ 	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
+ 	 */
+-	val = as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num;
+-	val = FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, val);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi,
+ 				 REG_SPI_NFI_SNF_MISC_CTL2,
+-				 SPI_NFI_READ_DATA_BYTE_NUM, val);
++				 SPI_NFI_READ_DATA_BYTE_NUM,
++				 FIELD_PREP(SPI_NFI_READ_DATA_BYTE_NUM, bytes));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 
+@@ -822,10 +824,13 @@ static ssize_t airoha_snand_dirmap_write
+ 	struct airoha_snand_ctrl *as_ctrl;
+ 	dma_addr_t dma_addr;
+ 	u32 wr_mode, val, opcode;
++	size_t bytes;
+ 	int err;
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 
++	bytes = as_ctrl->nfi_cfg.sec_num * as_ctrl->nfi_cfg.sec_size;
++
+ 	opcode = desc->info.op_tmpl.cmd.opcode;
+ 	switch (opcode) {
+ 	case SPI_NAND_OP_PROGRAM_LOAD_SINGLE:
+@@ -880,18 +885,17 @@ static ssize_t airoha_snand_dirmap_write
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set number of sector will be written */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, as_ctrl->nfi_cfg.sec_num);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+-				 SPI_NFI_SEC_NUM, val);
++				 SPI_NFI_SEC_NUM,
++				 FIELD_PREP(SPI_NFI_SEC_NUM, 1));
+ 	if (err)
+ 		goto error_dma_mode_off;
+ 
+ 	/* Set custom sector size */
+-	val = as_ctrl->nfi_cfg.sec_size;
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
+ 				 SPI_NFI_CUS_SEC_SIZE |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN,
+-				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, val) |
++				 FIELD_PREP(SPI_NFI_CUS_SEC_SIZE, bytes) |
+ 				 SPI_NFI_CUS_SEC_SIZE_EN);
+ 	if (err)
+ 		goto error_dma_mode_off;
+@@ -916,11 +920,10 @@ static ssize_t airoha_snand_dirmap_write
+ 	 *        = NFI_SNF_MISC_CTL2.write_data_byte_number =
+ 	 *        = NFI_CON.sector_number * NFI_SECCUS.custom_sector_size
+ 	 */
+-	val = as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num;
+-	val = FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM, val);
+ 	err = regmap_update_bits(as_ctrl->regmap_nfi,
+ 				 REG_SPI_NFI_SNF_MISC_CTL2,
+-				 SPI_NFI_PROG_LOAD_BYTE_NUM, val);
++				 SPI_NFI_PROG_LOAD_BYTE_NUM,
++				 FIELD_PREP(SPI_NFI_PROG_LOAD_BYTE_NUM, bytes));
+ 	if (err)
+ 		goto error_dma_unmap;
+ 

--- a/target/linux/airoha/patches-6.6/029-13-spi-airoha-avoid-reading-flash-page-settings-from.patch
+++ b/target/linux/airoha/patches-6.6/029-13-spi-airoha-avoid-reading-flash-page-settings-from.patch
@@ -1,0 +1,204 @@
+From 64a4d6e84145227211485067022cd4e5cf052e04 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Thu, 14 Aug 2025 23:56:24 +0300
+Subject: [PATCH v6 13/13] spi: airoha: avoid reading flash page settings from
+ SNFI registers during driver startup
+
+The spinand driver do 3 type of dirmap requests:
+ * read/write whole flash page without oob
+   (offs = 0, len = page_size)
+ * read/write whole flash page including oob
+   (offs = 0, len = page_size + oob_size)
+ * read/write oob area only
+   (offs = page_size, len = oob_size)
+
+The trick is:
+ * read/write a single "sector"
+ * set a custom sector size equal to offs + len. It's a bit safer to
+   rounded up "sector size" value 64.
+ * set the transfer length equal to custom sector size
+
+And it works!
+
+Thus we can remove a dirty hack that reads flash page settings from
+SNFI registers during driver startup. Also airoha_snand_adjust_op_size()
+function becomes unnecessary.
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+---
+ drivers/spi/spi-airoha-snfi.c | 115 ++--------------------------------
+ 1 file changed, 5 insertions(+), 110 deletions(-)
+
+--- a/drivers/spi/spi-airoha-snfi.c
++++ b/drivers/spi/spi-airoha-snfi.c
+@@ -223,13 +223,6 @@ struct airoha_snand_ctrl {
+ 	struct regmap *regmap_ctrl;
+ 	struct regmap *regmap_nfi;
+ 	struct clk *spi_clk;
+-
+-	struct {
+-		size_t page_size;
+-		size_t sec_size;
+-		u8 sec_num;
+-		u8 spare_size;
+-	} nfi_cfg;
+ };
+ 
+ static int airoha_snand_set_fifo_op(struct airoha_snand_ctrl *as_ctrl,
+@@ -490,55 +483,6 @@ static int airoha_snand_nfi_init(struct
+ 				  SPI_NFI_ALL_IRQ_EN, SPI_NFI_AHB_DONE_EN);
+ }
+ 
+-static int airoha_snand_nfi_config(struct airoha_snand_ctrl *as_ctrl)
+-{
+-	int err;
+-	u32 val;
+-
+-	err = regmap_write(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+-			   SPI_NFI_FIFO_FLUSH | SPI_NFI_RST);
+-	if (err)
+-		return err;
+-
+-	/* auto FDM */
+-	err = regmap_clear_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-				SPI_NFI_AUTO_FDM_EN);
+-	if (err)
+-		return err;
+-
+-	/* HW ECC */
+-	err = regmap_clear_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-				SPI_NFI_HW_ECC_EN);
+-	if (err)
+-		return err;
+-
+-	/* DMA Burst */
+-	err = regmap_set_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CNFG,
+-			      SPI_NFI_DMA_BURST_EN);
+-	if (err)
+-		return err;
+-
+-	/* sec num */
+-	val = FIELD_PREP(SPI_NFI_SEC_NUM, 1);
+-	err = regmap_update_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_CON,
+-				 SPI_NFI_SEC_NUM, val);
+-	if (err)
+-		return err;
+-
+-	/* enable cust sec size */
+-	err = regmap_set_bits(as_ctrl->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE,
+-			      SPI_NFI_CUS_SEC_SIZE_EN);
+-	if (err)
+-		return err;
+-
+-	/* set cust sec size */
+-	val = FIELD_PREP(SPI_NFI_CUS_SEC_SIZE,
+-			 as_ctrl->nfi_cfg.sec_size * as_ctrl->nfi_cfg.sec_num);
+-	return regmap_update_bits(as_ctrl->regmap_nfi,
+-				  REG_SPI_NFI_SECCUS_SIZE,
+-				  SPI_NFI_CUS_SEC_SIZE, val);
+-}
+-
+ static bool airoha_snand_is_page_ops(const struct spi_mem_op *op)
+ {
+ 	if (op->addr.nbytes != 2)
+@@ -571,26 +515,6 @@ static bool airoha_snand_is_page_ops(con
+ 	}
+ }
+ 
+-static int airoha_snand_adjust_op_size(struct spi_mem *mem,
+-				       struct spi_mem_op *op)
+-{
+-	size_t max_len;
+-
+-	if (airoha_snand_is_page_ops(op)) {
+-		struct airoha_snand_ctrl *as_ctrl;
+-
+-		as_ctrl = spi_controller_get_devdata(mem->spi->controller);
+-		max_len = as_ctrl->nfi_cfg.sec_size;
+-		max_len += as_ctrl->nfi_cfg.spare_size;
+-		max_len *= as_ctrl->nfi_cfg.sec_num;
+-
+-		if (op->data.nbytes > max_len)
+-			op->data.nbytes = max_len;
+-	}
+-
+-	return 0;
+-}
+-
+ static bool airoha_snand_supports_op(struct spi_mem *mem,
+ 				     const struct spi_mem_op *op)
+ {
+@@ -637,7 +561,8 @@ static ssize_t airoha_snand_dirmap_read(
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 
+-	bytes = as_ctrl->nfi_cfg.sec_num * as_ctrl->nfi_cfg.sec_size;
++	/* minimum oob size is 64 */
++	bytes = round_up(offs + len, 64);
+ 
+ 	/*
+ 	 * DUALIO and QUADIO opcodes are not supported by the spi controller,
+@@ -829,7 +754,8 @@ static ssize_t airoha_snand_dirmap_write
+ 
+ 	as_ctrl = spi_controller_get_devdata(spi->controller);
+ 
+-	bytes = as_ctrl->nfi_cfg.sec_num * as_ctrl->nfi_cfg.sec_size;
++	/* minimum oob size is 64 */
++	bytes = round_up(offs + len, 64);
+ 
+ 	opcode = desc->info.op_tmpl.cmd.opcode;
+ 	switch (opcode) {
+@@ -1076,7 +1002,6 @@ static int airoha_snand_exec_op(struct s
+ }
+ 
+ static const struct spi_controller_mem_ops airoha_snand_mem_ops = {
+-	.adjust_op_size = airoha_snand_adjust_op_size,
+ 	.supports_op = airoha_snand_supports_op,
+ 	.exec_op = airoha_snand_exec_op,
+ 	.dirmap_create = airoha_snand_dirmap_create,
+@@ -1101,36 +1026,6 @@ static int airoha_snand_setup(struct spi
+ 	return 0;
+ }
+ 
+-static int airoha_snand_nfi_setup(struct airoha_snand_ctrl *as_ctrl)
+-{
+-	u32 val, sec_size, sec_num;
+-	int err;
+-
+-	err = regmap_read(as_ctrl->regmap_nfi, REG_SPI_NFI_CON, &val);
+-	if (err)
+-		return err;
+-
+-	sec_num = FIELD_GET(SPI_NFI_SEC_NUM, val);
+-
+-	err = regmap_read(as_ctrl->regmap_nfi, REG_SPI_NFI_SECCUS_SIZE, &val);
+-	if (err)
+-		return err;
+-
+-	sec_size = FIELD_GET(SPI_NFI_CUS_SEC_SIZE, val);
+-
+-	/* init default value */
+-	as_ctrl->nfi_cfg.sec_size = sec_size;
+-	as_ctrl->nfi_cfg.sec_num = sec_num;
+-	as_ctrl->nfi_cfg.page_size = round_down(sec_size * sec_num, 1024);
+-	as_ctrl->nfi_cfg.spare_size = 16;
+-
+-	err = airoha_snand_nfi_init(as_ctrl);
+-	if (err)
+-		return err;
+-
+-	return airoha_snand_nfi_config(as_ctrl);
+-}
+-
+ static const struct regmap_config spi_ctrl_regmap_config = {
+ 	.name		= "ctrl",
+ 	.reg_bits	= 32,
+@@ -1204,7 +1099,7 @@ static int airoha_snand_probe(struct pla
+ 	ctrl->setup = airoha_snand_setup;
+ 	device_set_node(&ctrl->dev, dev_fwnode(dev));
+ 
+-	err = airoha_snand_nfi_setup(as_ctrl);
++	err = airoha_snand_nfi_init(as_ctrl);
+ 	if (err)
+ 		return err;
+ 

--- a/target/linux/airoha/patches-6.6/042-04-v6.14-PCI-mediatek-gen3-Move-reset-delay-in-mtk_pcie_en758.patch
+++ b/target/linux/airoha/patches-6.6/042-04-v6.14-PCI-mediatek-gen3-Move-reset-delay-in-mtk_pcie_en758.patch
@@ -33,7 +33,7 @@ Acked-by: Stephen Boyd <sboyd@kernel.org>
 
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
-@@ -490,7 +490,6 @@ static int en7581_pci_enable(struct clk_
+@@ -489,7 +489,6 @@ static int en7581_pci_enable(struct clk_
  	       REG_PCI_CONTROL_PERSTOUT;
  	val = readl(np_base + REG_PCI_CONTROL);
  	writel(val | mask, np_base + REG_PCI_CONTROL);

--- a/target/linux/airoha/patches-6.6/049-01-v6.16-thermal-drivers-Add-support-for-Airoha-EN7581-therma.patch
+++ b/target/linux/airoha/patches-6.6/049-01-v6.16-thermal-drivers-Add-support-for-Airoha-EN7581-therma.patch
@@ -28,11 +28,9 @@ Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
  3 files changed, 499 insertions(+)
  create mode 100644 drivers/thermal/airoha_thermal.c
 
-diff --git a/drivers/thermal/Kconfig b/drivers/thermal/Kconfig
-index 510c2b821546..a09c188b9ad1 100644
 --- a/drivers/thermal/Kconfig
 +++ b/drivers/thermal/Kconfig
-@@ -327,6 +327,15 @@ config QORIQ_THERMAL
+@@ -317,6 +317,15 @@ config QORIQ_THERMAL
  	  cpufreq is used as the cooling device to throttle CPUs when the
  	  passive trip is crossed.
  
@@ -48,11 +46,9 @@ index 510c2b821546..a09c188b9ad1 100644
  config SPEAR_THERMAL
  	tristate "SPEAr thermal sensor driver"
  	depends on PLAT_SPEAR || COMPILE_TEST
-diff --git a/drivers/thermal/Makefile b/drivers/thermal/Makefile
-index 9abf43a74f2b..d7718978db24 100644
 --- a/drivers/thermal/Makefile
 +++ b/drivers/thermal/Makefile
-@@ -38,6 +38,7 @@ obj-$(CONFIG_K3_THERMAL)	+= k3_bandgap.o k3_j72xx_bandgap.o
+@@ -34,6 +34,7 @@ obj-$(CONFIG_K3_THERMAL)	+= k3_bandgap.o
  # platform thermal drivers
  obj-y				+= broadcom/
  obj-$(CONFIG_THERMAL_MMIO)		+= thermal_mmio.o
@@ -60,9 +56,6 @@ index 9abf43a74f2b..d7718978db24 100644
  obj-$(CONFIG_SPEAR_THERMAL)	+= spear_thermal.o
  obj-$(CONFIG_SUN8I_THERMAL)     += sun8i_thermal.o
  obj-$(CONFIG_ROCKCHIP_THERMAL)	+= rockchip_thermal.o
-diff --git a/drivers/thermal/airoha_thermal.c b/drivers/thermal/airoha_thermal.c
-new file mode 100644
-index 000000000000..45116cdaee65
 --- /dev/null
 +++ b/drivers/thermal/airoha_thermal.c
 @@ -0,0 +1,489 @@
@@ -555,6 +548,3 @@ index 000000000000..45116cdaee65
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_DESCRIPTION("Airoha thermal driver");
 +MODULE_LICENSE("GPL");
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/049-02-v6.16-thermal-drivers-airoha-Fix-spelling-mistake.patch
+++ b/target/linux/airoha/patches-6.6/049-02-v6.16-thermal-drivers-airoha-Fix-spelling-mistake.patch
@@ -14,8 +14,6 @@ Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
  drivers/thermal/airoha_thermal.c | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
-diff --git a/drivers/thermal/airoha_thermal.c b/drivers/thermal/airoha_thermal.c
-index 45116cdaee65..9a7a702a17de 100644
 --- a/drivers/thermal/airoha_thermal.c
 +++ b/drivers/thermal/airoha_thermal.c
 @@ -155,7 +155,7 @@
@@ -27,7 +25,7 @@ index 45116cdaee65..9a7a702a17de 100644
   */
  #define   EN7581_MSRCTL_1SAMPLE			0x0
  #define   EN7581_MSRCTL_AVG2SAMPLE		0x1
-@@ -365,12 +365,12 @@ static void airoha_thermal_setup_monitor(struct airoha_thermal_priv *priv)
+@@ -365,12 +365,12 @@ static void airoha_thermal_setup_monitor
  	/*
  	 * Configure ADC valid reading addr
  	 * The AHB temp monitor system doesn't have direct access to the
@@ -44,6 +42,3 @@ index 45116cdaee65..9a7a702a17de 100644
  	 *
  	 * We set valid instead of volt as we don't enable valid/volt
  	 * split reading and AHB read valid addr in such case.
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/050-01-v6.16-net-phy-pass-PHY-driver-to-.match_phy_device-OP.patch
+++ b/target/linux/airoha/patches-6.6/050-01-v6.16-net-phy-pass-PHY-driver-to-.match_phy_device-OP.patch
@@ -43,11 +43,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  rust/kernel/net/phy.rs                 |  1 +
  11 files changed, 56 insertions(+), 28 deletions(-)
 
-diff --git a/drivers/net/phy/bcm87xx.c b/drivers/net/phy/bcm87xx.c
-index e81404bf8994..1e1e2259fc2b 100644
 --- a/drivers/net/phy/bcm87xx.c
 +++ b/drivers/net/phy/bcm87xx.c
-@@ -185,12 +185,14 @@ static irqreturn_t bcm87xx_handle_interrupt(struct phy_device *phydev)
+@@ -185,12 +185,14 @@ static irqreturn_t bcm87xx_handle_interr
  	return IRQ_HANDLED;
  }
  
@@ -64,11 +62,9 @@ index e81404bf8994..1e1e2259fc2b 100644
  {
  	return phydev->c45_ids.device_ids[4] == PHY_ID_BCM8727;
  }
-diff --git a/drivers/net/phy/icplus.c b/drivers/net/phy/icplus.c
-index bbcc7d2b54cd..c0c4f19cfb6a 100644
 --- a/drivers/net/phy/icplus.c
 +++ b/drivers/net/phy/icplus.c
-@@ -520,12 +520,14 @@ static int ip101a_g_match_phy_device(struct phy_device *phydev, bool ip101a)
+@@ -520,12 +520,14 @@ static int ip101a_g_match_phy_device(str
  	return ip101a == !ret;
  }
  
@@ -85,11 +81,9 @@ index bbcc7d2b54cd..c0c4f19cfb6a 100644
  {
  	return ip101a_g_match_phy_device(phydev, false);
  }
-diff --git a/drivers/net/phy/marvell10g.c b/drivers/net/phy/marvell10g.c
-index 5354c8895163..13e81dff42c1 100644
 --- a/drivers/net/phy/marvell10g.c
 +++ b/drivers/net/phy/marvell10g.c
-@@ -1264,7 +1264,8 @@ static int mv3310_get_number_of_ports(struct phy_device *phydev)
+@@ -1221,7 +1221,8 @@ static int mv3310_get_number_of_ports(st
  	return ret + 1;
  }
  
@@ -99,7 +93,7 @@ index 5354c8895163..13e81dff42c1 100644
  {
  	if ((phydev->c45_ids.device_ids[MDIO_MMD_PMAPMD] &
  	     MARVELL_PHY_ID_MASK) != MARVELL_PHY_ID_88X3310)
-@@ -1273,7 +1274,8 @@ static int mv3310_match_phy_device(struct phy_device *phydev)
+@@ -1230,7 +1231,8 @@ static int mv3310_match_phy_device(struc
  	return mv3310_get_number_of_ports(phydev) == 1;
  }
  
@@ -109,7 +103,7 @@ index 5354c8895163..13e81dff42c1 100644
  {
  	if ((phydev->c45_ids.device_ids[MDIO_MMD_PMAPMD] &
  	     MARVELL_PHY_ID_MASK) != MARVELL_PHY_ID_88X3310)
-@@ -1297,12 +1299,14 @@ static int mv211x_match_phy_device(struct phy_device *phydev, bool has_5g)
+@@ -1254,12 +1256,14 @@ static int mv211x_match_phy_device(struc
  	return !!(val & MDIO_PCS_SPEED_5G) == has_5g;
  }
  
@@ -126,11 +120,9 @@ index 5354c8895163..13e81dff42c1 100644
  {
  	return mv211x_match_phy_device(phydev, false);
  }
-diff --git a/drivers/net/phy/micrel.c b/drivers/net/phy/micrel.c
-index c2e5be404f07..64aa03aed770 100644
 --- a/drivers/net/phy/micrel.c
 +++ b/drivers/net/phy/micrel.c
-@@ -768,7 +768,8 @@ static int ksz8051_ksz8795_match_phy_device(struct phy_device *phydev,
+@@ -668,7 +668,8 @@ static int ksz8051_ksz8795_match_phy_dev
  		return !ret;
  }
  
@@ -140,7 +132,7 @@ index c2e5be404f07..64aa03aed770 100644
  {
  	return ksz8051_ksz8795_match_phy_device(phydev, true);
  }
-@@ -888,7 +889,8 @@ static int ksz8061_config_init(struct phy_device *phydev)
+@@ -788,7 +789,8 @@ static int ksz8061_config_init(struct ph
  	return kszphy_config_init(phydev);
  }
  
@@ -150,11 +142,9 @@ index c2e5be404f07..64aa03aed770 100644
  {
  	return ksz8051_ksz8795_match_phy_device(phydev, false);
  }
-diff --git a/drivers/net/phy/nxp-tja11xx.c b/drivers/net/phy/nxp-tja11xx.c
-index 07e94a2478ac..3c38a8ddae2f 100644
 --- a/drivers/net/phy/nxp-tja11xx.c
 +++ b/drivers/net/phy/nxp-tja11xx.c
-@@ -651,12 +651,14 @@ static int tja1102_match_phy_device(struct phy_device *phydev, bool port0)
+@@ -648,12 +648,14 @@ static int tja1102_match_phy_device(stru
  	return !ret;
  }
  
@@ -171,11 +161,9 @@ index 07e94a2478ac..3c38a8ddae2f 100644
  {
  	return tja1102_match_phy_device(phydev, false);
  }
-diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
-index 781dfa6680eb..6006cff1a73e 100644
 --- a/drivers/net/phy/phy_device.c
 +++ b/drivers/net/phy/phy_device.c
-@@ -554,7 +554,7 @@ static int phy_bus_match(struct device *dev, const struct device_driver *drv)
+@@ -533,7 +533,7 @@ static int phy_bus_match(struct device *
  		return 0;
  
  	if (phydrv->match_phy_device)
@@ -184,11 +172,9 @@ index 781dfa6680eb..6006cff1a73e 100644
  
  	if (phydev->is_c45) {
  		for (i = 1; i < num_ids; i++) {
-diff --git a/drivers/net/phy/realtek/realtek_main.c b/drivers/net/phy/realtek/realtek_main.c
-index b5e00cdf0123..c3dcb6257430 100644
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1315,13 +1315,15 @@ static bool rtlgen_supports_mmd(struct phy_device *phydev)
+@@ -1174,13 +1174,15 @@ static bool rtlgen_supports_mmd(struct p
  	return val > 0;
  }
  
@@ -206,8 +192,8 @@ index b5e00cdf0123..c3dcb6257430 100644
  {
  	return phydev->phy_id == RTL_GENERIC_PHYID &&
  	       rtlgen_supports_2_5gbps(phydev) &&
-@@ -1337,32 +1339,38 @@ static int rtlgen_is_c45_match(struct phy_device *phydev, unsigned int id,
- 		return !is_c45 && (id == phydev->phy_id);
+@@ -1218,32 +1220,38 @@ static int rtlgen_is_c45_match(struct ph
+ 	}
  }
  
 -static int rtl8221b_match_phy_device(struct phy_device *phydev)
@@ -251,7 +237,7 @@ index b5e00cdf0123..c3dcb6257430 100644
  {
  	if (phydev->is_c45)
  		return false;
-@@ -1381,7 +1389,8 @@ static int rtl_internal_nbaset_match_phy_device(struct phy_device *phydev)
+@@ -1261,7 +1269,8 @@ static int rtl_internal_nbaset_match_phy
  	return rtlgen_supports_2_5gbps(phydev) && !rtlgen_supports_mmd(phydev);
  }
  
@@ -261,11 +247,9 @@ index b5e00cdf0123..c3dcb6257430 100644
  {
  	return rtlgen_is_c45_match(phydev, RTL_8251B, true);
  }
-diff --git a/drivers/net/phy/teranetics.c b/drivers/net/phy/teranetics.c
-index 752d4bf7bb99..46c5ff7d7b56 100644
 --- a/drivers/net/phy/teranetics.c
 +++ b/drivers/net/phy/teranetics.c
-@@ -67,7 +67,8 @@ static int teranetics_read_status(struct phy_device *phydev)
+@@ -67,7 +67,8 @@ static int teranetics_read_status(struct
  	return 0;
  }
  
@@ -275,11 +259,9 @@ index 752d4bf7bb99..46c5ff7d7b56 100644
  {
  	return phydev->c45_ids.device_ids[3] == PHY_ID_TN2020;
  }
-diff --git a/include/linux/phy.h b/include/linux/phy.h
-index 92a88b5ce356..10e66d45a8e8 100644
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
-@@ -990,7 +990,8 @@ struct phy_driver {
+@@ -994,7 +994,8 @@ struct phy_driver {
  	 * driver for the given phydev.	 If NULL, matching is based on
  	 * phy_id and phy_id_mask.
  	 */
@@ -289,6 +271,3 @@ index 92a88b5ce356..10e66d45a8e8 100644
  
  	/**
  	 * @set_wol: Some devices (e.g. qnap TS-119P II) require PHY
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/050-04-v6.16-net-phy-introduce-genphy_match_phy_device.patch
+++ b/target/linux/airoha/patches-6.6/050-04-v6.16-net-phy-introduce-genphy_match_phy_device.patch
@@ -23,11 +23,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  include/linux/phy.h          |  3 +++
  2 files changed, 40 insertions(+), 15 deletions(-)
 
-diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
-index 6006cff1a73e..0f6f86252622 100644
 --- a/drivers/net/phy/phy_device.c
 +++ b/drivers/net/phy/phy_device.c
-@@ -543,20 +543,26 @@ static int phy_scan_fixups(struct phy_device *phydev)
+@@ -522,20 +522,26 @@ static int phy_scan_fixups(struct phy_de
  	return 0;
  }
  
@@ -66,7 +64,7 @@ index 6006cff1a73e..0f6f86252622 100644
  		for (i = 1; i < num_ids; i++) {
  			if (phydev->c45_ids.device_ids[i] == 0xffffffff)
  				continue;
-@@ -565,11 +571,27 @@ static int phy_bus_match(struct device *dev, const struct device_driver *drv)
+@@ -544,11 +550,27 @@ static int phy_bus_match(struct device *
  					   phydrv->phy_id, phydrv->phy_id_mask))
  				return 1;
  		}
@@ -97,11 +95,9 @@ index 6006cff1a73e..0f6f86252622 100644
  }
  
  static ssize_t
-diff --git a/include/linux/phy.h b/include/linux/phy.h
-index 10e66d45a8e8..32b9da274115 100644
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
-@@ -1868,6 +1868,9 @@ char *phy_attached_info_irq(struct phy_device *phydev)
+@@ -1847,6 +1847,9 @@ char *phy_attached_info_irq(struct phy_d
  	__malloc;
  void phy_attached_info(struct phy_device *phydev);
  
@@ -111,6 +107,3 @@ index 10e66d45a8e8..32b9da274115 100644
  /* Clause 22 PHY */
  int genphy_read_abilities(struct phy_device *phydev);
  int genphy_setup_forced(struct phy_device *phydev);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/050-05-v6.16-net-phy-Add-support-for-Aeonsemi-AS21xxx-PHYs.patch
+++ b/target/linux/airoha/patches-6.6/050-05-v6.16-net-phy-Add-support-for-Aeonsemi-AS21xxx-PHYs.patch
@@ -42,11 +42,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  4 files changed, 1106 insertions(+)
  create mode 100644 drivers/net/phy/as21xxx.c
 
-diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
-index 127a9fd0feb9..a95cecabfe1b 100644
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -76,6 +76,18 @@ config SFP
+@@ -142,6 +142,18 @@ endif # RTL8366_SMI
  
  comment "MII PHY device drivers"
  
@@ -65,21 +63,16 @@ index 127a9fd0feb9..a95cecabfe1b 100644
  config AIR_EN8811H_PHY
  	tristate "Airoha EN8811H 2.5 Gigabit PHY"
  	help
-diff --git a/drivers/net/phy/Makefile b/drivers/net/phy/Makefile
-index 7de69320a3a7..57933366fe54 100644
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
-@@ -32,6 +32,7 @@ obj-$(CONFIG_AIR_EN8811H_PHY)   += air_en8811h.o
+@@ -52,6 +52,7 @@ obj-$(CONFIG_ADIN1100_PHY)	+= adin1100.o
+ obj-$(CONFIG_AIR_EN8811H_PHY)   += air_en8811h.o
  obj-$(CONFIG_AMD_PHY)		+= amd.o
- obj-$(CONFIG_AMCC_QT2025_PHY)	+= qt2025.o
  obj-$(CONFIG_AQUANTIA_PHY)	+= aquantia/
 +obj-$(CONFIG_AS21XXX_PHY)	+= as21xxx.o
  obj-$(CONFIG_AX88796B_PHY)	+= ax88796b.o
  obj-$(CONFIG_BCM54140_PHY)	+= bcm54140.o
  obj-$(CONFIG_BCM63XX_PHY)	+= bcm63xx.o
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-new file mode 100644
-index 000000000000..92697f43087d
 --- /dev/null
 +++ b/drivers/net/phy/as21xxx.c
 @@ -0,0 +1,1087 @@
@@ -1170,6 +1163,3 @@ index 000000000000..92697f43087d
 +MODULE_DESCRIPTION("Aeonsemi AS21xxx PHY driver");
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_LICENSE("GPL");
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/051-v6.15-pinctrl-airoha-fix-wrong-PHY-LED-mapping-and-PHY2-LE.patch
+++ b/target/linux/airoha/patches-6.6/051-v6.15-pinctrl-airoha-fix-wrong-PHY-LED-mapping-and-PHY2-LE.patch
@@ -26,8 +26,6 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 159 ++++++++++------------
  1 file changed, 70 insertions(+), 89 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index 547a798b71c8..5d84a778683d 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
 @@ -6,6 +6,7 @@
@@ -38,7 +36,7 @@ index 547a798b71c8..5d84a778683d 100644
  #include <linux/bits.h>
  #include <linux/cleanup.h>
  #include <linux/gpio/driver.h>
-@@ -112,39 +113,19 @@
+@@ -106,39 +107,19 @@
  #define REG_LAN_LED1_MAPPING			0x0280
  
  #define LAN4_LED_MAPPING_MASK			GENMASK(18, 16)
@@ -83,7 +81,7 @@ index 547a798b71c8..5d84a778683d 100644
  
  /* CONF */
  #define REG_I2C_SDA_E2				0x001c
-@@ -1476,8 +1457,8 @@ static const struct airoha_pinctrl_func_group phy1_led0_func_group[] = {
+@@ -1470,8 +1451,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -94,7 +92,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1491,8 +1472,8 @@ static const struct airoha_pinctrl_func_group phy1_led0_func_group[] = {
+@@ -1485,8 +1466,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -105,7 +103,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1506,8 +1487,8 @@ static const struct airoha_pinctrl_func_group phy1_led0_func_group[] = {
+@@ -1500,8 +1481,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -116,7 +114,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1521,8 +1502,8 @@ static const struct airoha_pinctrl_func_group phy1_led0_func_group[] = {
+@@ -1515,8 +1496,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -127,7 +125,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1540,8 +1521,8 @@ static const struct airoha_pinctrl_func_group phy2_led0_func_group[] = {
+@@ -1534,8 +1515,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -138,7 +136,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1555,8 +1536,8 @@ static const struct airoha_pinctrl_func_group phy2_led0_func_group[] = {
+@@ -1549,8 +1530,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -149,7 +147,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1570,8 +1551,8 @@ static const struct airoha_pinctrl_func_group phy2_led0_func_group[] = {
+@@ -1564,8 +1545,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -160,7 +158,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1585,8 +1566,8 @@ static const struct airoha_pinctrl_func_group phy2_led0_func_group[] = {
+@@ -1579,8 +1560,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -171,7 +169,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1604,8 +1585,8 @@ static const struct airoha_pinctrl_func_group phy3_led0_func_group[] = {
+@@ -1598,8 +1579,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -182,7 +180,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1619,8 +1600,8 @@ static const struct airoha_pinctrl_func_group phy3_led0_func_group[] = {
+@@ -1613,8 +1594,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -193,7 +191,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1634,8 +1615,8 @@ static const struct airoha_pinctrl_func_group phy3_led0_func_group[] = {
+@@ -1628,8 +1609,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -204,7 +202,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1649,8 +1630,8 @@ static const struct airoha_pinctrl_func_group phy3_led0_func_group[] = {
+@@ -1643,8 +1624,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -215,7 +213,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1668,8 +1649,8 @@ static const struct airoha_pinctrl_func_group phy4_led0_func_group[] = {
+@@ -1662,8 +1643,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -226,7 +224,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1683,8 +1664,8 @@ static const struct airoha_pinctrl_func_group phy4_led0_func_group[] = {
+@@ -1677,8 +1658,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -237,7 +235,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1698,8 +1679,8 @@ static const struct airoha_pinctrl_func_group phy4_led0_func_group[] = {
+@@ -1692,8 +1673,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -248,7 +246,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1713,8 +1694,8 @@ static const struct airoha_pinctrl_func_group phy4_led0_func_group[] = {
+@@ -1707,8 +1688,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -259,7 +257,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1732,8 +1713,8 @@ static const struct airoha_pinctrl_func_group phy1_led1_func_group[] = {
+@@ -1726,8 +1707,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -270,7 +268,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1747,8 +1728,8 @@ static const struct airoha_pinctrl_func_group phy1_led1_func_group[] = {
+@@ -1741,8 +1722,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -281,7 +279,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1762,8 +1743,8 @@ static const struct airoha_pinctrl_func_group phy1_led1_func_group[] = {
+@@ -1756,8 +1737,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -292,7 +290,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1777,8 +1758,8 @@ static const struct airoha_pinctrl_func_group phy1_led1_func_group[] = {
+@@ -1771,8 +1752,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -303,7 +301,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1796,8 +1777,8 @@ static const struct airoha_pinctrl_func_group phy2_led1_func_group[] = {
+@@ -1790,8 +1771,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -314,7 +312,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1811,8 +1792,8 @@ static const struct airoha_pinctrl_func_group phy2_led1_func_group[] = {
+@@ -1805,8 +1786,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -325,7 +323,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1826,8 +1807,8 @@ static const struct airoha_pinctrl_func_group phy2_led1_func_group[] = {
+@@ -1820,8 +1801,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -336,7 +334,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1841,8 +1822,8 @@ static const struct airoha_pinctrl_func_group phy2_led1_func_group[] = {
+@@ -1835,8 +1816,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -347,7 +345,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1860,8 +1841,8 @@ static const struct airoha_pinctrl_func_group phy3_led1_func_group[] = {
+@@ -1854,8 +1835,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -358,7 +356,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1875,8 +1856,8 @@ static const struct airoha_pinctrl_func_group phy3_led1_func_group[] = {
+@@ -1869,8 +1850,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -369,7 +367,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1890,8 +1871,8 @@ static const struct airoha_pinctrl_func_group phy3_led1_func_group[] = {
+@@ -1884,8 +1865,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -380,7 +378,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1905,8 +1886,8 @@ static const struct airoha_pinctrl_func_group phy3_led1_func_group[] = {
+@@ -1899,8 +1880,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -391,7 +389,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
-@@ -1924,8 +1905,8 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1918,8 +1899,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -402,7 +400,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1939,8 +1920,8 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1933,8 +1914,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -413,7 +411,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1954,8 +1935,8 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1948,8 +1929,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -424,7 +422,7 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1969,8 +1950,8 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1963,8 +1944,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -435,6 +433,3 @@ index 547a798b71c8..5d84a778683d 100644
  		},
  		.regmap_size = 2,
  	},
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/052-v6.14-net-dsa-mt7530-Fix-traffic-flooding-for-MMIO-devices.patch
+++ b/target/linux/airoha/patches-6.6/052-v6.14-net-dsa-mt7530-Fix-traffic-flooding-for-MMIO-devices.patch
@@ -18,11 +18,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/dsa/mt7530.c | 8 ++------
  1 file changed, 2 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index 1c83af805209..5883eb93efb1 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -2591,7 +2591,8 @@ mt7531_setup_common(struct dsa_switch *ds)
+@@ -2595,7 +2595,8 @@ mt7531_setup_common(struct dsa_switch *d
  	if (ret < 0)
  		return ret;
  
@@ -32,7 +30,7 @@ index 1c83af805209..5883eb93efb1 100644
  }
  
  static int
-@@ -2687,11 +2688,6 @@ mt7531_setup(struct dsa_switch *ds)
+@@ -2691,11 +2692,6 @@ mt7531_setup(struct dsa_switch *ds)
  	if (ret)
  		return ret;
  
@@ -44,6 +42,3 @@ index 1c83af805209..5883eb93efb1 100644
  	ds->assisted_learning_on_cpu_port = true;
  	ds->mtu_enforcement_ingress = true;
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/053-v6.15-net-dsa-mt7530-sync-driver-specific-behavior-of-MT75.patch
+++ b/target/linux/airoha/patches-6.6/053-v6.15-net-dsa-mt7530-sync-driver-specific-behavior-of-MT75.patch
@@ -24,11 +24,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/dsa/mt7530.c | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index d70399bce5b9..c5d6628d7980 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -2419,6 +2419,9 @@ mt7531_setup_common(struct dsa_switch *ds)
+@@ -2540,6 +2540,9 @@ mt7531_setup_common(struct dsa_switch *d
  	struct mt7530_priv *priv = ds->priv;
  	int ret, i;
  
@@ -38,7 +36,7 @@ index d70399bce5b9..c5d6628d7980 100644
  	mt753x_trap_frames(priv);
  
  	/* Enable and reset MIB counters */
-@@ -2571,9 +2574,6 @@ mt7531_setup(struct dsa_switch *ds)
+@@ -2692,9 +2695,6 @@ mt7531_setup(struct dsa_switch *ds)
  	if (ret)
  		return ret;
  
@@ -48,6 +46,3 @@ index d70399bce5b9..c5d6628d7980 100644
  	return 0;
  }
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/054-v6.13-01-net-phy-mediatek-ge-soc-Fix-coding-style.patch
+++ b/target/linux/airoha/patches-6.6/054-v6.13-01-net-phy-mediatek-ge-soc-Fix-coding-style.patch
@@ -14,11 +14,9 @@ Signed-off-by: Andrew Lunn <andrew@lunn.ch>
  drivers/net/phy/mediatek-ge-soc.c | 36 ++++++++++++++++---------------
  1 file changed, 19 insertions(+), 17 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek-ge-soc.c b/drivers/net/phy/mediatek-ge-soc.c
-index f4f9412d0cd7..e9c422f4e24b 100644
 --- a/drivers/net/phy/mediatek-ge-soc.c
 +++ b/drivers/net/phy/mediatek-ge-soc.c
-@@ -408,16 +408,17 @@ static int tx_offset_cal_efuse(struct phy_device *phydev, u32 *buf)
+@@ -408,16 +408,17 @@ static int tx_offset_cal_efuse(struct ph
  
  static int tx_amp_fill_result(struct phy_device *phydev, u16 *buf)
  {
@@ -42,7 +40,7 @@ index f4f9412d0cd7..e9c422f4e24b 100644
  	switch (phydev->drv->phy_id) {
  	case MTK_GPHY_ID_MT7981:
  		/* We add some calibration to efuse values
-@@ -1069,10 +1070,10 @@ static int start_cal(struct phy_device *phydev, enum CAL_ITEM cal_item,
+@@ -1069,10 +1070,10 @@ static int start_cal(struct phy_device *
  
  static int mt798x_phy_calibration(struct phy_device *phydev)
  {
@@ -55,7 +53,7 @@ index f4f9412d0cd7..e9c422f4e24b 100644
  
  	cell = nvmem_cell_get(&phydev->mdio.dev, "phy-cal-data");
  	if (IS_ERR(cell)) {
-@@ -1210,14 +1211,15 @@ static int mt798x_phy_led_brightness_set(struct phy_device *phydev,
+@@ -1210,14 +1211,15 @@ static int mt798x_phy_led_brightness_set
  	return mt798x_phy_hw_led_on_set(phydev, index, (value != LED_OFF));
  }
  
@@ -79,7 +77,7 @@ index f4f9412d0cd7..e9c422f4e24b 100644
  
  static int mt798x_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
  					  unsigned long rules)
-@@ -1415,7 +1417,7 @@ static int mt7988_phy_probe_shared(struct phy_device *phydev)
+@@ -1415,7 +1417,7 @@ static int mt7988_phy_probe_shared(struc
  	 * LED_C and LED_D respectively. At the same time those pins are used to
  	 * bootstrap configuration of the reference clock source (LED_A),
  	 * DRAM DDRx16b x2/x1 (LED_B) and boot device (LED_C, LED_D).
@@ -88,6 +86,3 @@ index f4f9412d0cd7..e9c422f4e24b 100644
  	 * either to GND or to VIO.
  	 * The detected value at boot time is accessible at run-time using the
  	 * TPBANK0 register located in the gpio base of the pinctrl, in order
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/054-v6.13-02-net-phy-mediatek-ge-soc-Shrink-line-wrapping-to-80-c.patch
+++ b/target/linux/airoha/patches-6.6/054-v6.13-02-net-phy-mediatek-ge-soc-Shrink-line-wrapping-to-80-c.patch
@@ -14,11 +14,9 @@ Signed-off-by: Andrew Lunn <andrew@lunn.ch>
  drivers/net/phy/mediatek-ge-soc.c | 125 +++++++++++++++++++++---------
  1 file changed, 88 insertions(+), 37 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek-ge-soc.c b/drivers/net/phy/mediatek-ge-soc.c
-index e9c422f4e24b..1d7719b6c351 100644
 --- a/drivers/net/phy/mediatek-ge-soc.c
 +++ b/drivers/net/phy/mediatek-ge-soc.c
-@@ -342,7 +342,8 @@ static int cal_cycle(struct phy_device *phydev, int devad,
+@@ -342,7 +342,8 @@ static int cal_cycle(struct phy_device *
  	ret = phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND1,
  					MTK_PHY_RG_AD_CAL_CLK, reg_val,
  					reg_val & MTK_PHY_DA_CAL_CLK, 500,
@@ -28,7 +26,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  	if (ret) {
  		phydev_err(phydev, "Calibration cycle timeout\n");
  		return ret;
-@@ -441,40 +442,72 @@ static int tx_amp_fill_result(struct phy_device *phydev, u16 *buf)
+@@ -441,40 +442,72 @@ static int tx_amp_fill_result(struct phy
  	}
  
  	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TXVLD_DA_RG,
@@ -117,7 +115,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  
  	return 0;
  }
-@@ -663,7 +696,8 @@ static int tx_vcm_cal_sw(struct phy_device *phydev, u8 rg_txreserve_x)
+@@ -663,7 +696,8 @@ static int tx_vcm_cal_sw(struct phy_devi
  		goto restore;
  
  	/* We calibrate TX-VCM in different logic. Check upper index and then
@@ -127,7 +125,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  	 */
  	ret = upper_ret - lower_ret;
  	if (ret == 1) {
-@@ -692,7 +726,8 @@ static int tx_vcm_cal_sw(struct phy_device *phydev, u8 rg_txreserve_x)
+@@ -692,7 +726,8 @@ static int tx_vcm_cal_sw(struct phy_devi
  	} else if (upper_idx == TXRESERVE_MAX && upper_ret == 0 &&
  		   lower_ret == 0) {
  		ret = 0;
@@ -137,7 +135,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  			    upper_idx);
  	} else {
  		ret = -EINVAL;
-@@ -796,7 +831,8 @@ static void mt7981_phy_finetune(struct phy_device *phydev)
+@@ -796,7 +831,8 @@ static void mt7981_phy_finetune(struct p
  
  	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 9 */
  	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG234,
@@ -147,7 +145,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  		       BIT(0) | FIELD_PREP(MTK_PHY_LPF_X_AVERAGE_MASK, 0x9));
  
  	/* rg_tr_lpf_cnt_val = 512 */
-@@ -865,7 +901,8 @@ static void mt7988_phy_finetune(struct phy_device *phydev)
+@@ -865,7 +901,8 @@ static void mt7988_phy_finetune(struct p
  
  	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 10 */
  	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG234,
@@ -157,7 +155,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  		       BIT(0) | FIELD_PREP(MTK_PHY_LPF_X_AVERAGE_MASK, 0xa));
  
  	/* rg_tr_lpf_cnt_val = 1023 */
-@@ -977,7 +1014,8 @@ static void mt798x_phy_eee(struct phy_device *phydev)
+@@ -977,7 +1014,8 @@ static void mt798x_phy_eee(struct phy_de
  	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
  
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_3);
@@ -167,7 +165,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  		     FIELD_PREP(MTK_PHY_LPI_WAKE_TIMER_1000_MASK, 0x19c));
  
  	__phy_modify(phydev, MTK_PHY_LPI_REG_1c, MTK_PHY_SMI_DET_ON_THRESH_MASK,
-@@ -987,7 +1025,8 @@ static void mt798x_phy_eee(struct phy_device *phydev)
+@@ -987,7 +1025,8 @@ static void mt798x_phy_eee(struct phy_de
  	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
  		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122,
  		       MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
@@ -177,7 +175,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  }
  
  static int cal_sw(struct phy_device *phydev, enum CAL_ITEM cal_item,
-@@ -1147,7 +1186,8 @@ static int mt798x_phy_hw_led_on_set(struct phy_device *phydev, u8 index,
+@@ -1147,7 +1186,8 @@ static int mt798x_phy_hw_led_on_set(stru
  					(index ? 16 : 0), &priv->led_state);
  	if (changed)
  		return phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
@@ -187,7 +185,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  				      MTK_PHY_LED_ON_MASK,
  				      on ? MTK_PHY_LED_ON_FORCE_ON : 0);
  	else
-@@ -1157,7 +1197,8 @@ static int mt798x_phy_hw_led_on_set(struct phy_device *phydev, u8 index,
+@@ -1157,7 +1197,8 @@ static int mt798x_phy_hw_led_on_set(stru
  static int mt798x_phy_hw_led_blink_set(struct phy_device *phydev, u8 index,
  				       bool blinking)
  {
@@ -197,7 +195,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  	struct mtk_socphy_priv *priv = phydev->priv;
  	bool changed;
  
-@@ -1170,8 +1211,10 @@ static int mt798x_phy_hw_led_blink_set(struct phy_device *phydev, u8 index,
+@@ -1170,8 +1211,10 @@ static int mt798x_phy_hw_led_blink_set(s
  			      (index ? 16 : 0), &priv->led_state);
  	if (changed)
  		return phy_write_mmd(phydev, MDIO_MMD_VEND2, index ?
@@ -210,7 +208,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  	else
  		return 0;
  }
-@@ -1237,7 +1280,8 @@ static int mt798x_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
+@@ -1237,7 +1280,8 @@ static int mt798x_phy_led_hw_is_supporte
  static int mt798x_phy_led_hw_control_get(struct phy_device *phydev, u8 index,
  					 unsigned long *rules)
  {
@@ -220,7 +218,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  	unsigned int bit_netdev = MTK_PHY_LED_STATE_NETDEV + (index ? 16 : 0);
  	unsigned int bit_on = MTK_PHY_LED_STATE_FORCE_ON + (index ? 16 : 0);
  	struct mtk_socphy_priv *priv = phydev->priv;
-@@ -1258,8 +1302,8 @@ static int mt798x_phy_led_hw_control_get(struct phy_device *phydev, u8 index,
+@@ -1258,8 +1302,8 @@ static int mt798x_phy_led_hw_control_get
  	if (blink < 0)
  		return -EIO;
  
@@ -231,7 +229,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  	    (blink & (MTK_PHY_LED_BLINK_RX | MTK_PHY_LED_BLINK_TX)))
  		set_bit(bit_netdev, &priv->led_state);
  	else
-@@ -1333,17 +1377,23 @@ static int mt798x_phy_led_hw_control_set(struct phy_device *phydev, u8 index,
+@@ -1333,17 +1377,23 @@ static int mt798x_phy_led_hw_control_set
  
  	if (rules & BIT(TRIGGER_NETDEV_RX)) {
  		blink |= (on & MTK_PHY_LED_ON_LINK) ?
@@ -261,7 +259,7 @@ index e9c422f4e24b..1d7719b6c351 100644
  			  MTK_PHY_LED_BLINK_TX;
  	}
  
-@@ -1400,7 +1450,8 @@ static int mt7988_phy_fix_leds_polarities(struct phy_device *phydev)
+@@ -1400,7 +1450,8 @@ static int mt7988_phy_fix_leds_polaritie
  	/* Only now setup pinctrl to avoid bogus blinking */
  	pinctrl = devm_pinctrl_get_select(&phydev->mdio.dev, "gbe-led");
  	if (IS_ERR(pinctrl))
@@ -271,6 +269,3 @@ index e9c422f4e24b..1d7719b6c351 100644
  
  	return 0;
  }
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/054-v6.13-03-net-phy-mediatek-ge-soc-Propagate-error-code-correct.patch
+++ b/target/linux/airoha/patches-6.6/054-v6.13-03-net-phy-mediatek-ge-soc-Propagate-error-code-correct.patch
@@ -14,8 +14,6 @@ Signed-off-by: Andrew Lunn <andrew@lunn.ch>
  drivers/net/phy/mediatek-ge-soc.c | 8 +++++---
  1 file changed, 5 insertions(+), 3 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek-ge-soc.c b/drivers/net/phy/mediatek-ge-soc.c
-index 1d7719b6c351..a931832b1418 100644
 --- a/drivers/net/phy/mediatek-ge-soc.c
 +++ b/drivers/net/phy/mediatek-ge-soc.c
 @@ -110,7 +110,7 @@
@@ -27,7 +25,7 @@ index 1d7719b6c351..a931832b1418 100644
  
  #define MTK_PHY_RG_AD_CAL_CLK			0x17b
  #define   MTK_PHY_DA_CAL_CLK			BIT(0)
-@@ -351,8 +351,10 @@ static int cal_cycle(struct phy_device *phydev, int devad,
+@@ -351,8 +351,10 @@ static int cal_cycle(struct phy_device *
  
  	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CALIN,
  			   MTK_PHY_DA_CALIN_FLAG);
@@ -40,6 +38,3 @@ index 1d7719b6c351..a931832b1418 100644
  	phydev_dbg(phydev, "cal_val: 0x%x, ret: %d\n", cal_val, ret);
  
  	return ret;
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/055-v6.13-net-phy-mediatek-Re-organize-MediaTek-ethernet-phy-d.patch
+++ b/target/linux/airoha/patches-6.6/055-v6.13-net-phy-mediatek-Re-organize-MediaTek-ethernet-phy-d.patch
@@ -26,11 +26,9 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  rename drivers/net/phy/{mediatek-ge-soc.c => mediatek/mtk-ge-soc.c} (100%)
  rename drivers/net/phy/{mediatek-ge.c => mediatek/mtk-ge.c} (100%)
 
-diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
-index ee3ea0b56d48..15828f4710a9 100644
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -266,22 +266,7 @@ config MAXLINEAR_GPHY
+@@ -325,22 +325,7 @@ config MAXLINEAR_GPHY
  	  Support for the Maxlinear GPY115, GPY211, GPY212, GPY215,
  	  GPY241, GPY245 PHYs.
  
@@ -54,11 +52,9 @@ index ee3ea0b56d48..15828f4710a9 100644
  
  config MICREL_PHY
  	tristate "Micrel PHYs"
-diff --git a/drivers/net/phy/Makefile b/drivers/net/phy/Makefile
-index 90f886844381..e6145153e837 100644
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
-@@ -74,8 +74,7 @@ obj-$(CONFIG_MARVELL_PHY)	+= marvell.o
+@@ -83,8 +83,7 @@ obj-$(CONFIG_MARVELL_PHY)	+= marvell.o
  obj-$(CONFIG_MARVELL_88Q2XXX_PHY)	+= marvell-88q2xxx.o
  obj-$(CONFIG_MARVELL_88X2222_PHY)	+= marvell-88x2222.o
  obj-$(CONFIG_MAXLINEAR_GPHY)	+= mxl-gpy.o
@@ -68,9 +64,6 @@ index 90f886844381..e6145153e837 100644
  obj-$(CONFIG_MESON_GXL_PHY)	+= meson-gxl.o
  obj-$(CONFIG_MICREL_KS8995MA)	+= spi_ks8995.o
  obj-$(CONFIG_MICREL_PHY)	+= micrel.o
-diff --git a/drivers/net/phy/mediatek/Kconfig b/drivers/net/phy/mediatek/Kconfig
-new file mode 100644
-index 000000000000..112d9c0f219c
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/Kconfig
 @@ -0,0 +1,22 @@
@@ -96,23 +89,3537 @@ index 000000000000..112d9c0f219c
 +	  the MT7981 and MT7988 SoCs. These PHYs need calibration data
 +	  present in the SoCs efuse and will dynamically calibrate VCM
 +	  (common-mode voltage) during startup.
-diff --git a/drivers/net/phy/mediatek/Makefile b/drivers/net/phy/mediatek/Makefile
-new file mode 100644
-index 000000000000..005bde26c1d7
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/Makefile
 @@ -0,0 +1,3 @@
 +# SPDX-License-Identifier: GPL-2.0
 +obj-$(CONFIG_MEDIATEK_GE_PHY)		+= mtk-ge.o
 +obj-$(CONFIG_MEDIATEK_GE_SOC_PHY)	+= mtk-ge-soc.o
-diff --git a/drivers/net/phy/mediatek-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-similarity index 100%
-rename from drivers/net/phy/mediatek-ge-soc.c
-rename to drivers/net/phy/mediatek/mtk-ge-soc.c
-diff --git a/drivers/net/phy/mediatek-ge.c b/drivers/net/phy/mediatek/mtk-ge.c
-similarity index 100%
-rename from drivers/net/phy/mediatek-ge.c
-rename to drivers/net/phy/mediatek/mtk-ge.c
--- 
-2.48.1
-
+--- a/drivers/net/phy/mediatek-ge-soc.c
++++ /dev/null
+@@ -1,1610 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0+
+-#include <linux/bitfield.h>
+-#include <linux/bitmap.h>
+-#include <linux/mfd/syscon.h>
+-#include <linux/module.h>
+-#include <linux/nvmem-consumer.h>
+-#include <linux/pinctrl/consumer.h>
+-#include <linux/phy.h>
+-#include <linux/regmap.h>
+-
+-#define MTK_GPHY_ID_MT7981			0x03a29461
+-#define MTK_GPHY_ID_MT7988			0x03a29481
+-
+-#define MTK_EXT_PAGE_ACCESS			0x1f
+-#define MTK_PHY_PAGE_STANDARD			0x0000
+-#define MTK_PHY_PAGE_EXTENDED_3			0x0003
+-
+-#define MTK_PHY_LPI_REG_14			0x14
+-#define MTK_PHY_LPI_WAKE_TIMER_1000_MASK	GENMASK(8, 0)
+-
+-#define MTK_PHY_LPI_REG_1c			0x1c
+-#define MTK_PHY_SMI_DET_ON_THRESH_MASK		GENMASK(13, 8)
+-
+-#define MTK_PHY_PAGE_EXTENDED_2A30		0x2a30
+-#define MTK_PHY_PAGE_EXTENDED_52B5		0x52b5
+-
+-#define ANALOG_INTERNAL_OPERATION_MAX_US	20
+-#define TXRESERVE_MIN				0
+-#define TXRESERVE_MAX				7
+-
+-#define MTK_PHY_ANARG_RG			0x10
+-#define   MTK_PHY_TCLKOFFSET_MASK		GENMASK(12, 8)
+-
+-/* Registers on MDIO_MMD_VEND1 */
+-#define MTK_PHY_TXVLD_DA_RG			0x12
+-#define   MTK_PHY_DA_TX_I2MPB_A_GBE_MASK	GENMASK(15, 10)
+-#define   MTK_PHY_DA_TX_I2MPB_A_TBT_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_A2		0x16
+-#define   MTK_PHY_DA_TX_I2MPB_A_HBT_MASK	GENMASK(15, 10)
+-#define   MTK_PHY_DA_TX_I2MPB_A_TST_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_B1		0x17
+-#define   MTK_PHY_DA_TX_I2MPB_B_GBE_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_DA_TX_I2MPB_B_TBT_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_B2		0x18
+-#define   MTK_PHY_DA_TX_I2MPB_B_HBT_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_DA_TX_I2MPB_B_TST_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_C1		0x19
+-#define   MTK_PHY_DA_TX_I2MPB_C_GBE_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_DA_TX_I2MPB_C_TBT_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_C2		0x20
+-#define   MTK_PHY_DA_TX_I2MPB_C_HBT_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_DA_TX_I2MPB_C_TST_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_D1		0x21
+-#define   MTK_PHY_DA_TX_I2MPB_D_GBE_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_DA_TX_I2MPB_D_TBT_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_TX_I2MPB_TEST_MODE_D2		0x22
+-#define   MTK_PHY_DA_TX_I2MPB_D_HBT_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_DA_TX_I2MPB_D_TST_MASK	GENMASK(5, 0)
+-
+-#define MTK_PHY_RXADC_CTRL_RG7			0xc6
+-#define   MTK_PHY_DA_AD_BUF_BIAS_LP_MASK	GENMASK(9, 8)
+-
+-#define MTK_PHY_RXADC_CTRL_RG9			0xc8
+-#define   MTK_PHY_DA_RX_PSBN_TBT_MASK		GENMASK(14, 12)
+-#define   MTK_PHY_DA_RX_PSBN_HBT_MASK		GENMASK(10, 8)
+-#define   MTK_PHY_DA_RX_PSBN_GBE_MASK		GENMASK(6, 4)
+-#define   MTK_PHY_DA_RX_PSBN_LP_MASK		GENMASK(2, 0)
+-
+-#define MTK_PHY_LDO_OUTPUT_V			0xd7
+-
+-#define MTK_PHY_RG_ANA_CAL_RG0			0xdb
+-#define   MTK_PHY_RG_CAL_CKINV			BIT(12)
+-#define   MTK_PHY_RG_ANA_CALEN			BIT(8)
+-#define   MTK_PHY_RG_ZCALEN_A			BIT(0)
+-
+-#define MTK_PHY_RG_ANA_CAL_RG1			0xdc
+-#define   MTK_PHY_RG_ZCALEN_B			BIT(12)
+-#define   MTK_PHY_RG_ZCALEN_C			BIT(8)
+-#define   MTK_PHY_RG_ZCALEN_D			BIT(4)
+-#define   MTK_PHY_RG_TXVOS_CALEN		BIT(0)
+-
+-#define MTK_PHY_RG_ANA_CAL_RG5			0xe0
+-#define   MTK_PHY_RG_REXT_TRIM_MASK		GENMASK(13, 8)
+-
+-#define MTK_PHY_RG_TX_FILTER			0xfe
+-
+-#define MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG120	0x120
+-#define   MTK_PHY_LPI_SIG_EN_LO_THRESH1000_MASK	GENMASK(12, 8)
+-#define   MTK_PHY_LPI_SIG_EN_HI_THRESH1000_MASK	GENMASK(4, 0)
+-
+-#define MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122	0x122
+-#define   MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK	GENMASK(7, 0)
+-
+-#define MTK_PHY_RG_TESTMUX_ADC_CTRL		0x144
+-#define   MTK_PHY_RG_TXEN_DIG_MASK		GENMASK(5, 5)
+-
+-#define MTK_PHY_RG_CR_TX_AMP_OFFSET_A_B		0x172
+-#define   MTK_PHY_CR_TX_AMP_OFFSET_A_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_CR_TX_AMP_OFFSET_B_MASK	GENMASK(6, 0)
+-
+-#define MTK_PHY_RG_CR_TX_AMP_OFFSET_C_D		0x173
+-#define   MTK_PHY_CR_TX_AMP_OFFSET_C_MASK	GENMASK(13, 8)
+-#define   MTK_PHY_CR_TX_AMP_OFFSET_D_MASK	GENMASK(6, 0)
+-
+-#define MTK_PHY_RG_AD_CAL_COMP			0x17a
+-#define   MTK_PHY_AD_CAL_COMP_OUT_MASK		GENMASK(8, 8)
+-
+-#define MTK_PHY_RG_AD_CAL_CLK			0x17b
+-#define   MTK_PHY_DA_CAL_CLK			BIT(0)
+-
+-#define MTK_PHY_RG_AD_CALIN			0x17c
+-#define   MTK_PHY_DA_CALIN_FLAG			BIT(0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN0_A		0x17d
+-#define   MTK_PHY_DASN_DAC_IN0_A_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN0_B		0x17e
+-#define   MTK_PHY_DASN_DAC_IN0_B_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN0_C		0x17f
+-#define   MTK_PHY_DASN_DAC_IN0_C_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN0_D		0x180
+-#define   MTK_PHY_DASN_DAC_IN0_D_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN1_A		0x181
+-#define   MTK_PHY_DASN_DAC_IN1_A_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN1_B		0x182
+-#define   MTK_PHY_DASN_DAC_IN1_B_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN1_C		0x183
+-#define   MTK_PHY_DASN_DAC_IN1_C_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DASN_DAC_IN1_D		0x184
+-#define   MTK_PHY_DASN_DAC_IN1_D_MASK		GENMASK(9, 0)
+-
+-#define MTK_PHY_RG_DEV1E_REG19b			0x19b
+-#define   MTK_PHY_BYPASS_DSP_LPI_READY		BIT(8)
+-
+-#define MTK_PHY_RG_LP_IIR2_K1_L			0x22a
+-#define MTK_PHY_RG_LP_IIR2_K1_U			0x22b
+-#define MTK_PHY_RG_LP_IIR2_K2_L			0x22c
+-#define MTK_PHY_RG_LP_IIR2_K2_U			0x22d
+-#define MTK_PHY_RG_LP_IIR2_K3_L			0x22e
+-#define MTK_PHY_RG_LP_IIR2_K3_U			0x22f
+-#define MTK_PHY_RG_LP_IIR2_K4_L			0x230
+-#define MTK_PHY_RG_LP_IIR2_K4_U			0x231
+-#define MTK_PHY_RG_LP_IIR2_K5_L			0x232
+-#define MTK_PHY_RG_LP_IIR2_K5_U			0x233
+-
+-#define MTK_PHY_RG_DEV1E_REG234			0x234
+-#define   MTK_PHY_TR_OPEN_LOOP_EN_MASK		GENMASK(0, 0)
+-#define   MTK_PHY_LPF_X_AVERAGE_MASK		GENMASK(7, 4)
+-#define   MTK_PHY_TR_LP_IIR_EEE_EN		BIT(12)
+-
+-#define MTK_PHY_RG_LPF_CNT_VAL			0x235
+-
+-#define MTK_PHY_RG_DEV1E_REG238			0x238
+-#define   MTK_PHY_LPI_SLV_SEND_TX_TIMER_MASK	GENMASK(8, 0)
+-#define   MTK_PHY_LPI_SLV_SEND_TX_EN		BIT(12)
+-
+-#define MTK_PHY_RG_DEV1E_REG239			0x239
+-#define   MTK_PHY_LPI_SEND_LOC_TIMER_MASK	GENMASK(8, 0)
+-#define   MTK_PHY_LPI_TXPCS_LOC_RCV		BIT(12)
+-
+-#define MTK_PHY_RG_DEV1E_REG27C			0x27c
+-#define   MTK_PHY_VGASTATE_FFE_THR_ST1_MASK	GENMASK(12, 8)
+-#define MTK_PHY_RG_DEV1E_REG27D			0x27d
+-#define   MTK_PHY_VGASTATE_FFE_THR_ST2_MASK	GENMASK(4, 0)
+-
+-#define MTK_PHY_RG_DEV1E_REG2C7			0x2c7
+-#define   MTK_PHY_MAX_GAIN_MASK			GENMASK(4, 0)
+-#define   MTK_PHY_MIN_GAIN_MASK			GENMASK(12, 8)
+-
+-#define MTK_PHY_RG_DEV1E_REG2D1			0x2d1
+-#define   MTK_PHY_VCO_SLICER_THRESH_BITS_HIGH_EEE_MASK	GENMASK(7, 0)
+-#define   MTK_PHY_LPI_SKIP_SD_SLV_TR		BIT(8)
+-#define   MTK_PHY_LPI_TR_READY			BIT(9)
+-#define   MTK_PHY_LPI_VCO_EEE_STG0_EN		BIT(10)
+-
+-#define MTK_PHY_RG_DEV1E_REG323			0x323
+-#define   MTK_PHY_EEE_WAKE_MAS_INT_DC		BIT(0)
+-#define   MTK_PHY_EEE_WAKE_SLV_INT_DC		BIT(4)
+-
+-#define MTK_PHY_RG_DEV1E_REG324			0x324
+-#define   MTK_PHY_SMI_DETCNT_MAX_MASK		GENMASK(5, 0)
+-#define   MTK_PHY_SMI_DET_MAX_EN		BIT(8)
+-
+-#define MTK_PHY_RG_DEV1E_REG326			0x326
+-#define   MTK_PHY_LPI_MODE_SD_ON		BIT(0)
+-#define   MTK_PHY_RESET_RANDUPD_CNT		BIT(1)
+-#define   MTK_PHY_TREC_UPDATE_ENAB_CLR		BIT(2)
+-#define   MTK_PHY_LPI_QUIT_WAIT_DFE_SIG_DET_OFF	BIT(4)
+-#define   MTK_PHY_TR_READY_SKIP_AFE_WAKEUP	BIT(5)
+-
+-#define MTK_PHY_LDO_PUMP_EN_PAIRAB		0x502
+-#define MTK_PHY_LDO_PUMP_EN_PAIRCD		0x503
+-
+-#define MTK_PHY_DA_TX_R50_PAIR_A		0x53d
+-#define MTK_PHY_DA_TX_R50_PAIR_B		0x53e
+-#define MTK_PHY_DA_TX_R50_PAIR_C		0x53f
+-#define MTK_PHY_DA_TX_R50_PAIR_D		0x540
+-
+-/* Registers on MDIO_MMD_VEND2 */
+-#define MTK_PHY_LED0_ON_CTRL			0x24
+-#define MTK_PHY_LED1_ON_CTRL			0x26
+-#define   MTK_PHY_LED_ON_MASK			GENMASK(6, 0)
+-#define   MTK_PHY_LED_ON_LINK1000		BIT(0)
+-#define   MTK_PHY_LED_ON_LINK100		BIT(1)
+-#define   MTK_PHY_LED_ON_LINK10			BIT(2)
+-#define   MTK_PHY_LED_ON_LINK			(MTK_PHY_LED_ON_LINK10 |\
+-						 MTK_PHY_LED_ON_LINK100 |\
+-						 MTK_PHY_LED_ON_LINK1000)
+-#define   MTK_PHY_LED_ON_LINKDOWN		BIT(3)
+-#define   MTK_PHY_LED_ON_FDX			BIT(4) /* Full duplex */
+-#define   MTK_PHY_LED_ON_HDX			BIT(5) /* Half duplex */
+-#define   MTK_PHY_LED_ON_FORCE_ON		BIT(6)
+-#define   MTK_PHY_LED_ON_POLARITY		BIT(14)
+-#define   MTK_PHY_LED_ON_ENABLE			BIT(15)
+-
+-#define MTK_PHY_LED0_BLINK_CTRL			0x25
+-#define MTK_PHY_LED1_BLINK_CTRL			0x27
+-#define   MTK_PHY_LED_BLINK_1000TX		BIT(0)
+-#define   MTK_PHY_LED_BLINK_1000RX		BIT(1)
+-#define   MTK_PHY_LED_BLINK_100TX		BIT(2)
+-#define   MTK_PHY_LED_BLINK_100RX		BIT(3)
+-#define   MTK_PHY_LED_BLINK_10TX		BIT(4)
+-#define   MTK_PHY_LED_BLINK_10RX		BIT(5)
+-#define   MTK_PHY_LED_BLINK_RX			(MTK_PHY_LED_BLINK_10RX |\
+-						 MTK_PHY_LED_BLINK_100RX |\
+-						 MTK_PHY_LED_BLINK_1000RX)
+-#define   MTK_PHY_LED_BLINK_TX			(MTK_PHY_LED_BLINK_10TX |\
+-						 MTK_PHY_LED_BLINK_100TX |\
+-						 MTK_PHY_LED_BLINK_1000TX)
+-#define   MTK_PHY_LED_BLINK_COLLISION		BIT(6)
+-#define   MTK_PHY_LED_BLINK_RX_CRC_ERR		BIT(7)
+-#define   MTK_PHY_LED_BLINK_RX_IDLE_ERR		BIT(8)
+-#define   MTK_PHY_LED_BLINK_FORCE_BLINK		BIT(9)
+-
+-#define MTK_PHY_LED1_DEFAULT_POLARITIES		BIT(1)
+-
+-#define MTK_PHY_RG_BG_RASEL			0x115
+-#define   MTK_PHY_RG_BG_RASEL_MASK		GENMASK(2, 0)
+-
+-/* 'boottrap' register reflecting the configuration of the 4 PHY LEDs */
+-#define RG_GPIO_MISC_TPBANK0			0x6f0
+-#define   RG_GPIO_MISC_TPBANK0_BOOTMODE		GENMASK(11, 8)
+-
+-/* These macro privides efuse parsing for internal phy. */
+-#define EFS_DA_TX_I2MPB_A(x)			(((x) >> 0) & GENMASK(5, 0))
+-#define EFS_DA_TX_I2MPB_B(x)			(((x) >> 6) & GENMASK(5, 0))
+-#define EFS_DA_TX_I2MPB_C(x)			(((x) >> 12) & GENMASK(5, 0))
+-#define EFS_DA_TX_I2MPB_D(x)			(((x) >> 18) & GENMASK(5, 0))
+-#define EFS_DA_TX_AMP_OFFSET_A(x)		(((x) >> 24) & GENMASK(5, 0))
+-
+-#define EFS_DA_TX_AMP_OFFSET_B(x)		(((x) >> 0) & GENMASK(5, 0))
+-#define EFS_DA_TX_AMP_OFFSET_C(x)		(((x) >> 6) & GENMASK(5, 0))
+-#define EFS_DA_TX_AMP_OFFSET_D(x)		(((x) >> 12) & GENMASK(5, 0))
+-#define EFS_DA_TX_R50_A(x)			(((x) >> 18) & GENMASK(5, 0))
+-#define EFS_DA_TX_R50_B(x)			(((x) >> 24) & GENMASK(5, 0))
+-
+-#define EFS_DA_TX_R50_C(x)			(((x) >> 0) & GENMASK(5, 0))
+-#define EFS_DA_TX_R50_D(x)			(((x) >> 6) & GENMASK(5, 0))
+-
+-#define EFS_RG_BG_RASEL(x)			(((x) >> 4) & GENMASK(2, 0))
+-#define EFS_RG_REXT_TRIM(x)			(((x) >> 7) & GENMASK(5, 0))
+-
+-enum {
+-	NO_PAIR,
+-	PAIR_A,
+-	PAIR_B,
+-	PAIR_C,
+-	PAIR_D,
+-};
+-
+-enum calibration_mode {
+-	EFUSE_K,
+-	SW_K
+-};
+-
+-enum CAL_ITEM {
+-	REXT,
+-	TX_OFFSET,
+-	TX_AMP,
+-	TX_R50,
+-	TX_VCM
+-};
+-
+-enum CAL_MODE {
+-	EFUSE_M,
+-	SW_M
+-};
+-
+-#define MTK_PHY_LED_STATE_FORCE_ON	0
+-#define MTK_PHY_LED_STATE_FORCE_BLINK	1
+-#define MTK_PHY_LED_STATE_NETDEV	2
+-
+-struct mtk_socphy_priv {
+-	unsigned long		led_state;
+-};
+-
+-struct mtk_socphy_shared {
+-	u32			boottrap;
+-	struct mtk_socphy_priv	priv[4];
+-};
+-
+-static int mtk_socphy_read_page(struct phy_device *phydev)
+-{
+-	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
+-}
+-
+-static int mtk_socphy_write_page(struct phy_device *phydev, int page)
+-{
+-	return __phy_write(phydev, MTK_EXT_PAGE_ACCESS, page);
+-}
+-
+-/* One calibration cycle consists of:
+- * 1.Set DA_CALIN_FLAG high to start calibration. Keep it high
+- *   until AD_CAL_COMP is ready to output calibration result.
+- * 2.Wait until DA_CAL_CLK is available.
+- * 3.Fetch AD_CAL_COMP_OUT.
+- */
+-static int cal_cycle(struct phy_device *phydev, int devad,
+-		     u32 regnum, u16 mask, u16 cal_val)
+-{
+-	int reg_val;
+-	int ret;
+-
+-	phy_modify_mmd(phydev, devad, regnum,
+-		       mask, cal_val);
+-	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CALIN,
+-			 MTK_PHY_DA_CALIN_FLAG);
+-
+-	ret = phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND1,
+-					MTK_PHY_RG_AD_CAL_CLK, reg_val,
+-					reg_val & MTK_PHY_DA_CAL_CLK, 500,
+-					ANALOG_INTERNAL_OPERATION_MAX_US,
+-					false);
+-	if (ret) {
+-		phydev_err(phydev, "Calibration cycle timeout\n");
+-		return ret;
+-	}
+-
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CALIN,
+-			   MTK_PHY_DA_CALIN_FLAG);
+-	ret = phy_read_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CAL_COMP);
+-	if (ret < 0)
+-		return ret;
+-	ret = FIELD_GET(MTK_PHY_AD_CAL_COMP_OUT_MASK, ret);
+-	phydev_dbg(phydev, "cal_val: 0x%x, ret: %d\n", cal_val, ret);
+-
+-	return ret;
+-}
+-
+-static int rext_fill_result(struct phy_device *phydev, u16 *buf)
+-{
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG5,
+-		       MTK_PHY_RG_REXT_TRIM_MASK, buf[0] << 8);
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND2, MTK_PHY_RG_BG_RASEL,
+-		       MTK_PHY_RG_BG_RASEL_MASK, buf[1]);
+-
+-	return 0;
+-}
+-
+-static int rext_cal_efuse(struct phy_device *phydev, u32 *buf)
+-{
+-	u16 rext_cal_val[2];
+-
+-	rext_cal_val[0] = EFS_RG_REXT_TRIM(buf[3]);
+-	rext_cal_val[1] = EFS_RG_BG_RASEL(buf[3]);
+-	rext_fill_result(phydev, rext_cal_val);
+-
+-	return 0;
+-}
+-
+-static int tx_offset_fill_result(struct phy_device *phydev, u16 *buf)
+-{
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_A_B,
+-		       MTK_PHY_CR_TX_AMP_OFFSET_A_MASK, buf[0] << 8);
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_A_B,
+-		       MTK_PHY_CR_TX_AMP_OFFSET_B_MASK, buf[1]);
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_C_D,
+-		       MTK_PHY_CR_TX_AMP_OFFSET_C_MASK, buf[2] << 8);
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_C_D,
+-		       MTK_PHY_CR_TX_AMP_OFFSET_D_MASK, buf[3]);
+-
+-	return 0;
+-}
+-
+-static int tx_offset_cal_efuse(struct phy_device *phydev, u32 *buf)
+-{
+-	u16 tx_offset_cal_val[4];
+-
+-	tx_offset_cal_val[0] = EFS_DA_TX_AMP_OFFSET_A(buf[0]);
+-	tx_offset_cal_val[1] = EFS_DA_TX_AMP_OFFSET_B(buf[1]);
+-	tx_offset_cal_val[2] = EFS_DA_TX_AMP_OFFSET_C(buf[1]);
+-	tx_offset_cal_val[3] = EFS_DA_TX_AMP_OFFSET_D(buf[1]);
+-
+-	tx_offset_fill_result(phydev, tx_offset_cal_val);
+-
+-	return 0;
+-}
+-
+-static int tx_amp_fill_result(struct phy_device *phydev, u16 *buf)
+-{
+-	const int vals_9481[16] = { 10, 6, 6, 10,
+-				    10, 6, 6, 10,
+-				    10, 6, 6, 10,
+-				    10, 6, 6, 10 };
+-	const int vals_9461[16] = { 7, 1, 4, 7,
+-				    7, 1, 4, 7,
+-				    7, 1, 4, 7,
+-				    7, 1, 4, 7 };
+-	int bias[16] = {};
+-	int i;
+-
+-	switch (phydev->drv->phy_id) {
+-	case MTK_GPHY_ID_MT7981:
+-		/* We add some calibration to efuse values
+-		 * due to board level influence.
+-		 * GBE: +7, TBT: +1, HBT: +4, TST: +7
+-		 */
+-		memcpy(bias, (const void *)vals_9461, sizeof(bias));
+-		break;
+-	case MTK_GPHY_ID_MT7988:
+-		memcpy(bias, (const void *)vals_9481, sizeof(bias));
+-		break;
+-	}
+-
+-	/* Prevent overflow */
+-	for (i = 0; i < 12; i++) {
+-		if (buf[i >> 2] + bias[i] > 63) {
+-			buf[i >> 2] = 63;
+-			bias[i] = 0;
+-		}
+-	}
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TXVLD_DA_RG,
+-		       MTK_PHY_DA_TX_I2MPB_A_GBE_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_GBE_MASK,
+-				  buf[0] + bias[0]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TXVLD_DA_RG,
+-		       MTK_PHY_DA_TX_I2MPB_A_TBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_TBT_MASK,
+-				  buf[0] + bias[1]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_A2,
+-		       MTK_PHY_DA_TX_I2MPB_A_HBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_HBT_MASK,
+-				  buf[0] + bias[2]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_A2,
+-		       MTK_PHY_DA_TX_I2MPB_A_TST_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_TST_MASK,
+-				  buf[0] + bias[3]));
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B1,
+-		       MTK_PHY_DA_TX_I2MPB_B_GBE_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_GBE_MASK,
+-				  buf[1] + bias[4]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B1,
+-		       MTK_PHY_DA_TX_I2MPB_B_TBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_TBT_MASK,
+-				  buf[1] + bias[5]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B2,
+-		       MTK_PHY_DA_TX_I2MPB_B_HBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_HBT_MASK,
+-				  buf[1] + bias[6]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B2,
+-		       MTK_PHY_DA_TX_I2MPB_B_TST_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_TST_MASK,
+-				  buf[1] + bias[7]));
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C1,
+-		       MTK_PHY_DA_TX_I2MPB_C_GBE_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_GBE_MASK,
+-				  buf[2] + bias[8]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C1,
+-		       MTK_PHY_DA_TX_I2MPB_C_TBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_TBT_MASK,
+-				  buf[2] + bias[9]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C2,
+-		       MTK_PHY_DA_TX_I2MPB_C_HBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_HBT_MASK,
+-				  buf[2] + bias[10]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C2,
+-		       MTK_PHY_DA_TX_I2MPB_C_TST_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_TST_MASK,
+-				  buf[2] + bias[11]));
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D1,
+-		       MTK_PHY_DA_TX_I2MPB_D_GBE_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_GBE_MASK,
+-				  buf[3] + bias[12]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D1,
+-		       MTK_PHY_DA_TX_I2MPB_D_TBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_TBT_MASK,
+-				  buf[3] + bias[13]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D2,
+-		       MTK_PHY_DA_TX_I2MPB_D_HBT_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_HBT_MASK,
+-				  buf[3] + bias[14]));
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D2,
+-		       MTK_PHY_DA_TX_I2MPB_D_TST_MASK,
+-		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_TST_MASK,
+-				  buf[3] + bias[15]));
+-
+-	return 0;
+-}
+-
+-static int tx_amp_cal_efuse(struct phy_device *phydev, u32 *buf)
+-{
+-	u16 tx_amp_cal_val[4];
+-
+-	tx_amp_cal_val[0] = EFS_DA_TX_I2MPB_A(buf[0]);
+-	tx_amp_cal_val[1] = EFS_DA_TX_I2MPB_B(buf[0]);
+-	tx_amp_cal_val[2] = EFS_DA_TX_I2MPB_C(buf[0]);
+-	tx_amp_cal_val[3] = EFS_DA_TX_I2MPB_D(buf[0]);
+-	tx_amp_fill_result(phydev, tx_amp_cal_val);
+-
+-	return 0;
+-}
+-
+-static int tx_r50_fill_result(struct phy_device *phydev, u16 tx_r50_cal_val,
+-			      u8 txg_calen_x)
+-{
+-	int bias = 0;
+-	u16 reg, val;
+-
+-	if (phydev->drv->phy_id == MTK_GPHY_ID_MT7988)
+-		bias = -1;
+-
+-	val = clamp_val(bias + tx_r50_cal_val, 0, 63);
+-
+-	switch (txg_calen_x) {
+-	case PAIR_A:
+-		reg = MTK_PHY_DA_TX_R50_PAIR_A;
+-		break;
+-	case PAIR_B:
+-		reg = MTK_PHY_DA_TX_R50_PAIR_B;
+-		break;
+-	case PAIR_C:
+-		reg = MTK_PHY_DA_TX_R50_PAIR_C;
+-		break;
+-	case PAIR_D:
+-		reg = MTK_PHY_DA_TX_R50_PAIR_D;
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
+-
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, reg, val | val << 8);
+-
+-	return 0;
+-}
+-
+-static int tx_r50_cal_efuse(struct phy_device *phydev, u32 *buf,
+-			    u8 txg_calen_x)
+-{
+-	u16 tx_r50_cal_val;
+-
+-	switch (txg_calen_x) {
+-	case PAIR_A:
+-		tx_r50_cal_val = EFS_DA_TX_R50_A(buf[1]);
+-		break;
+-	case PAIR_B:
+-		tx_r50_cal_val = EFS_DA_TX_R50_B(buf[1]);
+-		break;
+-	case PAIR_C:
+-		tx_r50_cal_val = EFS_DA_TX_R50_C(buf[2]);
+-		break;
+-	case PAIR_D:
+-		tx_r50_cal_val = EFS_DA_TX_R50_D(buf[2]);
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
+-	tx_r50_fill_result(phydev, tx_r50_cal_val, txg_calen_x);
+-
+-	return 0;
+-}
+-
+-static int tx_vcm_cal_sw(struct phy_device *phydev, u8 rg_txreserve_x)
+-{
+-	u8 lower_idx, upper_idx, txreserve_val;
+-	u8 lower_ret, upper_ret;
+-	int ret;
+-
+-	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
+-			 MTK_PHY_RG_ANA_CALEN);
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
+-			   MTK_PHY_RG_CAL_CKINV);
+-	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG1,
+-			 MTK_PHY_RG_TXVOS_CALEN);
+-
+-	switch (rg_txreserve_x) {
+-	case PAIR_A:
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN0_A,
+-				   MTK_PHY_DASN_DAC_IN0_A_MASK);
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN1_A,
+-				   MTK_PHY_DASN_DAC_IN1_A_MASK);
+-		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				 MTK_PHY_RG_ANA_CAL_RG0,
+-				 MTK_PHY_RG_ZCALEN_A);
+-		break;
+-	case PAIR_B:
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN0_B,
+-				   MTK_PHY_DASN_DAC_IN0_B_MASK);
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN1_B,
+-				   MTK_PHY_DASN_DAC_IN1_B_MASK);
+-		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				 MTK_PHY_RG_ANA_CAL_RG1,
+-				 MTK_PHY_RG_ZCALEN_B);
+-		break;
+-	case PAIR_C:
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN0_C,
+-				   MTK_PHY_DASN_DAC_IN0_C_MASK);
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN1_C,
+-				   MTK_PHY_DASN_DAC_IN1_C_MASK);
+-		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				 MTK_PHY_RG_ANA_CAL_RG1,
+-				 MTK_PHY_RG_ZCALEN_C);
+-		break;
+-	case PAIR_D:
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN0_D,
+-				   MTK_PHY_DASN_DAC_IN0_D_MASK);
+-		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				   MTK_PHY_RG_DASN_DAC_IN1_D,
+-				   MTK_PHY_DASN_DAC_IN1_D_MASK);
+-		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
+-				 MTK_PHY_RG_ANA_CAL_RG1,
+-				 MTK_PHY_RG_ZCALEN_D);
+-		break;
+-	default:
+-		ret = -EINVAL;
+-		goto restore;
+-	}
+-
+-	lower_idx = TXRESERVE_MIN;
+-	upper_idx = TXRESERVE_MAX;
+-
+-	phydev_dbg(phydev, "Start TX-VCM SW cal.\n");
+-	while ((upper_idx - lower_idx) > 1) {
+-		txreserve_val = DIV_ROUND_CLOSEST(lower_idx + upper_idx, 2);
+-		ret = cal_cycle(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG9,
+-				MTK_PHY_DA_RX_PSBN_TBT_MASK |
+-				MTK_PHY_DA_RX_PSBN_HBT_MASK |
+-				MTK_PHY_DA_RX_PSBN_GBE_MASK |
+-				MTK_PHY_DA_RX_PSBN_LP_MASK,
+-				txreserve_val << 12 | txreserve_val << 8 |
+-				txreserve_val << 4 | txreserve_val);
+-		if (ret == 1) {
+-			upper_idx = txreserve_val;
+-			upper_ret = ret;
+-		} else if (ret == 0) {
+-			lower_idx = txreserve_val;
+-			lower_ret = ret;
+-		} else {
+-			goto restore;
+-		}
+-	}
+-
+-	if (lower_idx == TXRESERVE_MIN) {
+-		lower_ret = cal_cycle(phydev, MDIO_MMD_VEND1,
+-				      MTK_PHY_RXADC_CTRL_RG9,
+-				      MTK_PHY_DA_RX_PSBN_TBT_MASK |
+-				      MTK_PHY_DA_RX_PSBN_HBT_MASK |
+-				      MTK_PHY_DA_RX_PSBN_GBE_MASK |
+-				      MTK_PHY_DA_RX_PSBN_LP_MASK,
+-				      lower_idx << 12 | lower_idx << 8 |
+-				      lower_idx << 4 | lower_idx);
+-		ret = lower_ret;
+-	} else if (upper_idx == TXRESERVE_MAX) {
+-		upper_ret = cal_cycle(phydev, MDIO_MMD_VEND1,
+-				      MTK_PHY_RXADC_CTRL_RG9,
+-				      MTK_PHY_DA_RX_PSBN_TBT_MASK |
+-				      MTK_PHY_DA_RX_PSBN_HBT_MASK |
+-				      MTK_PHY_DA_RX_PSBN_GBE_MASK |
+-				      MTK_PHY_DA_RX_PSBN_LP_MASK,
+-				      upper_idx << 12 | upper_idx << 8 |
+-				      upper_idx << 4 | upper_idx);
+-		ret = upper_ret;
+-	}
+-	if (ret < 0)
+-		goto restore;
+-
+-	/* We calibrate TX-VCM in different logic. Check upper index and then
+-	 * lower index. If this calibration is valid, apply lower index's
+-	 * result.
+-	 */
+-	ret = upper_ret - lower_ret;
+-	if (ret == 1) {
+-		ret = 0;
+-		/* Make sure we use upper_idx in our calibration system */
+-		cal_cycle(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG9,
+-			  MTK_PHY_DA_RX_PSBN_TBT_MASK |
+-			  MTK_PHY_DA_RX_PSBN_HBT_MASK |
+-			  MTK_PHY_DA_RX_PSBN_GBE_MASK |
+-			  MTK_PHY_DA_RX_PSBN_LP_MASK,
+-			  upper_idx << 12 | upper_idx << 8 |
+-			  upper_idx << 4 | upper_idx);
+-		phydev_dbg(phydev, "TX-VCM SW cal result: 0x%x\n", upper_idx);
+-	} else if (lower_idx == TXRESERVE_MIN && upper_ret == 1 &&
+-		   lower_ret == 1) {
+-		ret = 0;
+-		cal_cycle(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG9,
+-			  MTK_PHY_DA_RX_PSBN_TBT_MASK |
+-			  MTK_PHY_DA_RX_PSBN_HBT_MASK |
+-			  MTK_PHY_DA_RX_PSBN_GBE_MASK |
+-			  MTK_PHY_DA_RX_PSBN_LP_MASK,
+-			  lower_idx << 12 | lower_idx << 8 |
+-			  lower_idx << 4 | lower_idx);
+-		phydev_warn(phydev, "TX-VCM SW cal result at low margin 0x%x\n",
+-			    lower_idx);
+-	} else if (upper_idx == TXRESERVE_MAX && upper_ret == 0 &&
+-		   lower_ret == 0) {
+-		ret = 0;
+-		phydev_warn(phydev,
+-			    "TX-VCM SW cal result at high margin 0x%x\n",
+-			    upper_idx);
+-	} else {
+-		ret = -EINVAL;
+-	}
+-
+-restore:
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
+-			   MTK_PHY_RG_ANA_CALEN);
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG1,
+-			   MTK_PHY_RG_TXVOS_CALEN);
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
+-			   MTK_PHY_RG_ZCALEN_A);
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG1,
+-			   MTK_PHY_RG_ZCALEN_B | MTK_PHY_RG_ZCALEN_C |
+-			   MTK_PHY_RG_ZCALEN_D);
+-
+-	return ret;
+-}
+-
+-static void mt798x_phy_common_finetune(struct phy_device *phydev)
+-{
+-	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
+-	/* SlvDSPreadyTime = 24, MasDSPreadyTime = 24 */
+-	__phy_write(phydev, 0x11, 0xc71);
+-	__phy_write(phydev, 0x12, 0xc);
+-	__phy_write(phydev, 0x10, 0x8fae);
+-
+-	/* EnabRandUpdTrig = 1 */
+-	__phy_write(phydev, 0x11, 0x2f00);
+-	__phy_write(phydev, 0x12, 0xe);
+-	__phy_write(phydev, 0x10, 0x8fb0);
+-
+-	/* NormMseLoThresh = 85 */
+-	__phy_write(phydev, 0x11, 0x55a0);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x83aa);
+-
+-	/* FfeUpdGainForce = 1(Enable), FfeUpdGainForceVal = 4 */
+-	__phy_write(phydev, 0x11, 0x240);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x9680);
+-
+-	/* TrFreeze = 0 (mt7988 default) */
+-	__phy_write(phydev, 0x11, 0x0);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x9686);
+-
+-	/* SSTrKp100 = 5 */
+-	/* SSTrKf100 = 6 */
+-	/* SSTrKp1000Mas = 5 */
+-	/* SSTrKf1000Mas = 6 */
+-	/* SSTrKp1000Slv = 5 */
+-	/* SSTrKf1000Slv = 6 */
+-	__phy_write(phydev, 0x11, 0xbaef);
+-	__phy_write(phydev, 0x12, 0x2e);
+-	__phy_write(phydev, 0x10, 0x968c);
+-	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
+-}
+-
+-static void mt7981_phy_finetune(struct phy_device *phydev)
+-{
+-	u16 val[8] = { 0x01ce, 0x01c1,
+-		       0x020f, 0x0202,
+-		       0x03d0, 0x03c0,
+-		       0x0013, 0x0005 };
+-	int i, k;
+-
+-	/* 100M eye finetune:
+-	 * Keep middle level of TX MLT3 shapper as default.
+-	 * Only change TX MLT3 overshoot level here.
+-	 */
+-	for (k = 0, i = 1; i < 12; i++) {
+-		if (i % 3 == 0)
+-			continue;
+-		phy_write_mmd(phydev, MDIO_MMD_VEND1, i, val[k++]);
+-	}
+-
+-	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
+-	/* ResetSyncOffset = 6 */
+-	__phy_write(phydev, 0x11, 0x600);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x8fc0);
+-
+-	/* VgaDecRate = 1 */
+-	__phy_write(phydev, 0x11, 0x4c2a);
+-	__phy_write(phydev, 0x12, 0x3e);
+-	__phy_write(phydev, 0x10, 0x8fa4);
+-
+-	/* MrvlTrFix100Kp = 3, MrvlTrFix100Kf = 2,
+-	 * MrvlTrFix1000Kp = 3, MrvlTrFix1000Kf = 2
+-	 */
+-	__phy_write(phydev, 0x11, 0xd10a);
+-	__phy_write(phydev, 0x12, 0x34);
+-	__phy_write(phydev, 0x10, 0x8f82);
+-
+-	/* VcoSlicerThreshBitsHigh */
+-	__phy_write(phydev, 0x11, 0x5555);
+-	__phy_write(phydev, 0x12, 0x55);
+-	__phy_write(phydev, 0x10, 0x8ec0);
+-	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
+-
+-	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 9 */
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG234,
+-		       MTK_PHY_TR_OPEN_LOOP_EN_MASK |
+-		       MTK_PHY_LPF_X_AVERAGE_MASK,
+-		       BIT(0) | FIELD_PREP(MTK_PHY_LPF_X_AVERAGE_MASK, 0x9));
+-
+-	/* rg_tr_lpf_cnt_val = 512 */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LPF_CNT_VAL, 0x200);
+-
+-	/* IIR2 related */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K1_L, 0x82);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K1_U, 0x0);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K2_L, 0x103);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K2_U, 0x0);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K3_L, 0x82);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K3_U, 0x0);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K4_L, 0xd177);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K4_U, 0x3);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K5_L, 0x2c82);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K5_U, 0xe);
+-
+-	/* FFE peaking */
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG27C,
+-		       MTK_PHY_VGASTATE_FFE_THR_ST1_MASK, 0x1b << 8);
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG27D,
+-		       MTK_PHY_VGASTATE_FFE_THR_ST2_MASK, 0x1e);
+-
+-	/* Disable LDO pump */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_LDO_PUMP_EN_PAIRAB, 0x0);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_LDO_PUMP_EN_PAIRCD, 0x0);
+-	/* Adjust LDO output voltage */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_LDO_OUTPUT_V, 0x2222);
+-}
+-
+-static void mt7988_phy_finetune(struct phy_device *phydev)
+-{
+-	u16 val[12] = { 0x0187, 0x01cd, 0x01c8, 0x0182,
+-			0x020d, 0x0206, 0x0384, 0x03d0,
+-			0x03c6, 0x030a, 0x0011, 0x0005 };
+-	int i;
+-
+-	/* Set default MLT3 shaper first */
+-	for (i = 0; i < 12; i++)
+-		phy_write_mmd(phydev, MDIO_MMD_VEND1, i, val[i]);
+-
+-	/* TCT finetune */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_TX_FILTER, 0x5);
+-
+-	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
+-	/* ResetSyncOffset = 5 */
+-	__phy_write(phydev, 0x11, 0x500);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x8fc0);
+-
+-	/* VgaDecRate is 1 at default on mt7988 */
+-
+-	/* MrvlTrFix100Kp = 6, MrvlTrFix100Kf = 7,
+-	 * MrvlTrFix1000Kp = 6, MrvlTrFix1000Kf = 7
+-	 */
+-	__phy_write(phydev, 0x11, 0xb90a);
+-	__phy_write(phydev, 0x12, 0x6f);
+-	__phy_write(phydev, 0x10, 0x8f82);
+-
+-	/* RemAckCntLimitCtrl = 1 */
+-	__phy_write(phydev, 0x11, 0xfbba);
+-	__phy_write(phydev, 0x12, 0xc3);
+-	__phy_write(phydev, 0x10, 0x87f8);
+-
+-	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
+-
+-	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 10 */
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG234,
+-		       MTK_PHY_TR_OPEN_LOOP_EN_MASK |
+-		       MTK_PHY_LPF_X_AVERAGE_MASK,
+-		       BIT(0) | FIELD_PREP(MTK_PHY_LPF_X_AVERAGE_MASK, 0xa));
+-
+-	/* rg_tr_lpf_cnt_val = 1023 */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LPF_CNT_VAL, 0x3ff);
+-}
+-
+-static void mt798x_phy_eee(struct phy_device *phydev)
+-{
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
+-		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG120,
+-		       MTK_PHY_LPI_SIG_EN_LO_THRESH1000_MASK |
+-		       MTK_PHY_LPI_SIG_EN_HI_THRESH1000_MASK,
+-		       FIELD_PREP(MTK_PHY_LPI_SIG_EN_LO_THRESH1000_MASK, 0x0) |
+-		       FIELD_PREP(MTK_PHY_LPI_SIG_EN_HI_THRESH1000_MASK, 0x14));
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
+-		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122,
+-		       MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
+-		       FIELD_PREP(MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
+-				  0xff));
+-
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-			   MTK_PHY_RG_TESTMUX_ADC_CTRL,
+-			   MTK_PHY_RG_TXEN_DIG_MASK);
+-
+-	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
+-			 MTK_PHY_RG_DEV1E_REG19b, MTK_PHY_BYPASS_DSP_LPI_READY);
+-
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
+-			   MTK_PHY_RG_DEV1E_REG234, MTK_PHY_TR_LP_IIR_EEE_EN);
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG238,
+-		       MTK_PHY_LPI_SLV_SEND_TX_TIMER_MASK |
+-		       MTK_PHY_LPI_SLV_SEND_TX_EN,
+-		       FIELD_PREP(MTK_PHY_LPI_SLV_SEND_TX_TIMER_MASK, 0x120));
+-
+-	/* Keep MTK_PHY_LPI_SEND_LOC_TIMER as 375 */
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG239,
+-			   MTK_PHY_LPI_TXPCS_LOC_RCV);
+-
+-	/* This also fixes some IoT issues, such as CH340 */
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG2C7,
+-		       MTK_PHY_MAX_GAIN_MASK | MTK_PHY_MIN_GAIN_MASK,
+-		       FIELD_PREP(MTK_PHY_MAX_GAIN_MASK, 0x8) |
+-		       FIELD_PREP(MTK_PHY_MIN_GAIN_MASK, 0x13));
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG2D1,
+-		       MTK_PHY_VCO_SLICER_THRESH_BITS_HIGH_EEE_MASK,
+-		       FIELD_PREP(MTK_PHY_VCO_SLICER_THRESH_BITS_HIGH_EEE_MASK,
+-				  0x33) |
+-		       MTK_PHY_LPI_SKIP_SD_SLV_TR | MTK_PHY_LPI_TR_READY |
+-		       MTK_PHY_LPI_VCO_EEE_STG0_EN);
+-
+-	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG323,
+-			 MTK_PHY_EEE_WAKE_MAS_INT_DC |
+-			 MTK_PHY_EEE_WAKE_SLV_INT_DC);
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG324,
+-		       MTK_PHY_SMI_DETCNT_MAX_MASK,
+-		       FIELD_PREP(MTK_PHY_SMI_DETCNT_MAX_MASK, 0x3f) |
+-		       MTK_PHY_SMI_DET_MAX_EN);
+-
+-	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG326,
+-			 MTK_PHY_LPI_MODE_SD_ON | MTK_PHY_RESET_RANDUPD_CNT |
+-			 MTK_PHY_TREC_UPDATE_ENAB_CLR |
+-			 MTK_PHY_LPI_QUIT_WAIT_DFE_SIG_DET_OFF |
+-			 MTK_PHY_TR_READY_SKIP_AFE_WAKEUP);
+-
+-	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
+-	/* Regsigdet_sel_1000 = 0 */
+-	__phy_write(phydev, 0x11, 0xb);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x9690);
+-
+-	/* REG_EEE_st2TrKf1000 = 2 */
+-	__phy_write(phydev, 0x11, 0x114f);
+-	__phy_write(phydev, 0x12, 0x2);
+-	__phy_write(phydev, 0x10, 0x969a);
+-
+-	/* RegEEE_slv_wake_tr_timer_tar = 6, RegEEE_slv_remtx_timer_tar = 20 */
+-	__phy_write(phydev, 0x11, 0x3028);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x969e);
+-
+-	/* RegEEE_slv_wake_int_timer_tar = 8 */
+-	__phy_write(phydev, 0x11, 0x5010);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x96a0);
+-
+-	/* RegEEE_trfreeze_timer2 = 586 */
+-	__phy_write(phydev, 0x11, 0x24a);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x96a8);
+-
+-	/* RegEEE100Stg1_tar = 16 */
+-	__phy_write(phydev, 0x11, 0x3210);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x96b8);
+-
+-	/* REGEEE_wake_slv_tr_wait_dfesigdet_en = 0 */
+-	__phy_write(phydev, 0x11, 0x1463);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x96ca);
+-
+-	/* DfeTailEnableVgaThresh1000 = 27 */
+-	__phy_write(phydev, 0x11, 0x36);
+-	__phy_write(phydev, 0x12, 0x0);
+-	__phy_write(phydev, 0x10, 0x8f80);
+-	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
+-
+-	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_3);
+-	__phy_modify(phydev, MTK_PHY_LPI_REG_14,
+-		     MTK_PHY_LPI_WAKE_TIMER_1000_MASK,
+-		     FIELD_PREP(MTK_PHY_LPI_WAKE_TIMER_1000_MASK, 0x19c));
+-
+-	__phy_modify(phydev, MTK_PHY_LPI_REG_1c, MTK_PHY_SMI_DET_ON_THRESH_MASK,
+-		     FIELD_PREP(MTK_PHY_SMI_DET_ON_THRESH_MASK, 0xc));
+-	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
+-
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
+-		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122,
+-		       MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
+-		       FIELD_PREP(MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
+-				  0xff));
+-}
+-
+-static int cal_sw(struct phy_device *phydev, enum CAL_ITEM cal_item,
+-		  u8 start_pair, u8 end_pair)
+-{
+-	u8 pair_n;
+-	int ret;
+-
+-	for (pair_n = start_pair; pair_n <= end_pair; pair_n++) {
+-		/* TX_OFFSET & TX_AMP have no SW calibration. */
+-		switch (cal_item) {
+-		case TX_VCM:
+-			ret = tx_vcm_cal_sw(phydev, pair_n);
+-			break;
+-		default:
+-			return -EINVAL;
+-		}
+-		if (ret)
+-			return ret;
+-	}
+-	return 0;
+-}
+-
+-static int cal_efuse(struct phy_device *phydev, enum CAL_ITEM cal_item,
+-		     u8 start_pair, u8 end_pair, u32 *buf)
+-{
+-	u8 pair_n;
+-	int ret;
+-
+-	for (pair_n = start_pair; pair_n <= end_pair; pair_n++) {
+-		/* TX_VCM has no efuse calibration. */
+-		switch (cal_item) {
+-		case REXT:
+-			ret = rext_cal_efuse(phydev, buf);
+-			break;
+-		case TX_OFFSET:
+-			ret = tx_offset_cal_efuse(phydev, buf);
+-			break;
+-		case TX_AMP:
+-			ret = tx_amp_cal_efuse(phydev, buf);
+-			break;
+-		case TX_R50:
+-			ret = tx_r50_cal_efuse(phydev, buf, pair_n);
+-			break;
+-		default:
+-			return -EINVAL;
+-		}
+-		if (ret)
+-			return ret;
+-	}
+-
+-	return 0;
+-}
+-
+-static int start_cal(struct phy_device *phydev, enum CAL_ITEM cal_item,
+-		     enum CAL_MODE cal_mode, u8 start_pair,
+-		     u8 end_pair, u32 *buf)
+-{
+-	int ret;
+-
+-	switch (cal_mode) {
+-	case EFUSE_M:
+-		ret = cal_efuse(phydev, cal_item, start_pair,
+-				end_pair, buf);
+-		break;
+-	case SW_M:
+-		ret = cal_sw(phydev, cal_item, start_pair, end_pair);
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
+-
+-	if (ret) {
+-		phydev_err(phydev, "cal %d failed\n", cal_item);
+-		return -EIO;
+-	}
+-
+-	return 0;
+-}
+-
+-static int mt798x_phy_calibration(struct phy_device *phydev)
+-{
+-	struct nvmem_cell *cell;
+-	int ret = 0;
+-	size_t len;
+-	u32 *buf;
+-
+-	cell = nvmem_cell_get(&phydev->mdio.dev, "phy-cal-data");
+-	if (IS_ERR(cell)) {
+-		if (PTR_ERR(cell) == -EPROBE_DEFER)
+-			return PTR_ERR(cell);
+-		return 0;
+-	}
+-
+-	buf = (u32 *)nvmem_cell_read(cell, &len);
+-	if (IS_ERR(buf))
+-		return PTR_ERR(buf);
+-	nvmem_cell_put(cell);
+-
+-	if (!buf[0] || !buf[1] || !buf[2] || !buf[3] || len < 4 * sizeof(u32)) {
+-		phydev_err(phydev, "invalid efuse data\n");
+-		ret = -EINVAL;
+-		goto out;
+-	}
+-
+-	ret = start_cal(phydev, REXT, EFUSE_M, NO_PAIR, NO_PAIR, buf);
+-	if (ret)
+-		goto out;
+-	ret = start_cal(phydev, TX_OFFSET, EFUSE_M, NO_PAIR, NO_PAIR, buf);
+-	if (ret)
+-		goto out;
+-	ret = start_cal(phydev, TX_AMP, EFUSE_M, NO_PAIR, NO_PAIR, buf);
+-	if (ret)
+-		goto out;
+-	ret = start_cal(phydev, TX_R50, EFUSE_M, PAIR_A, PAIR_D, buf);
+-	if (ret)
+-		goto out;
+-	ret = start_cal(phydev, TX_VCM, SW_M, PAIR_A, PAIR_A, buf);
+-	if (ret)
+-		goto out;
+-
+-out:
+-	kfree(buf);
+-	return ret;
+-}
+-
+-static int mt798x_phy_config_init(struct phy_device *phydev)
+-{
+-	switch (phydev->drv->phy_id) {
+-	case MTK_GPHY_ID_MT7981:
+-		mt7981_phy_finetune(phydev);
+-		break;
+-	case MTK_GPHY_ID_MT7988:
+-		mt7988_phy_finetune(phydev);
+-		break;
+-	}
+-
+-	mt798x_phy_common_finetune(phydev);
+-	mt798x_phy_eee(phydev);
+-
+-	return mt798x_phy_calibration(phydev);
+-}
+-
+-static int mt798x_phy_hw_led_on_set(struct phy_device *phydev, u8 index,
+-				    bool on)
+-{
+-	unsigned int bit_on = MTK_PHY_LED_STATE_FORCE_ON + (index ? 16 : 0);
+-	struct mtk_socphy_priv *priv = phydev->priv;
+-	bool changed;
+-
+-	if (on)
+-		changed = !test_and_set_bit(bit_on, &priv->led_state);
+-	else
+-		changed = !!test_and_clear_bit(bit_on, &priv->led_state);
+-
+-	changed |= !!test_and_clear_bit(MTK_PHY_LED_STATE_NETDEV +
+-					(index ? 16 : 0), &priv->led_state);
+-	if (changed)
+-		return phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
+-				      MTK_PHY_LED1_ON_CTRL :
+-				      MTK_PHY_LED0_ON_CTRL,
+-				      MTK_PHY_LED_ON_MASK,
+-				      on ? MTK_PHY_LED_ON_FORCE_ON : 0);
+-	else
+-		return 0;
+-}
+-
+-static int mt798x_phy_hw_led_blink_set(struct phy_device *phydev, u8 index,
+-				       bool blinking)
+-{
+-	unsigned int bit_blink = MTK_PHY_LED_STATE_FORCE_BLINK +
+-				 (index ? 16 : 0);
+-	struct mtk_socphy_priv *priv = phydev->priv;
+-	bool changed;
+-
+-	if (blinking)
+-		changed = !test_and_set_bit(bit_blink, &priv->led_state);
+-	else
+-		changed = !!test_and_clear_bit(bit_blink, &priv->led_state);
+-
+-	changed |= !!test_bit(MTK_PHY_LED_STATE_NETDEV +
+-			      (index ? 16 : 0), &priv->led_state);
+-	if (changed)
+-		return phy_write_mmd(phydev, MDIO_MMD_VEND2, index ?
+-				     MTK_PHY_LED1_BLINK_CTRL :
+-				     MTK_PHY_LED0_BLINK_CTRL,
+-				     blinking ?
+-				     MTK_PHY_LED_BLINK_FORCE_BLINK : 0);
+-	else
+-		return 0;
+-}
+-
+-static int mt798x_phy_led_blink_set(struct phy_device *phydev, u8 index,
+-				    unsigned long *delay_on,
+-				    unsigned long *delay_off)
+-{
+-	bool blinking = false;
+-	int err = 0;
+-
+-	if (index > 1)
+-		return -EINVAL;
+-
+-	if (delay_on && delay_off && (*delay_on > 0) && (*delay_off > 0)) {
+-		blinking = true;
+-		*delay_on = 50;
+-		*delay_off = 50;
+-	}
+-
+-	err = mt798x_phy_hw_led_blink_set(phydev, index, blinking);
+-	if (err)
+-		return err;
+-
+-	return mt798x_phy_hw_led_on_set(phydev, index, false);
+-}
+-
+-static int mt798x_phy_led_brightness_set(struct phy_device *phydev,
+-					 u8 index, enum led_brightness value)
+-{
+-	int err;
+-
+-	err = mt798x_phy_hw_led_blink_set(phydev, index, false);
+-	if (err)
+-		return err;
+-
+-	return mt798x_phy_hw_led_on_set(phydev, index, (value != LED_OFF));
+-}
+-
+-static const unsigned long supported_triggers =
+-	BIT(TRIGGER_NETDEV_FULL_DUPLEX) |
+-	BIT(TRIGGER_NETDEV_HALF_DUPLEX) |
+-	BIT(TRIGGER_NETDEV_LINK)        |
+-	BIT(TRIGGER_NETDEV_LINK_10)     |
+-	BIT(TRIGGER_NETDEV_LINK_100)    |
+-	BIT(TRIGGER_NETDEV_LINK_1000)   |
+-	BIT(TRIGGER_NETDEV_RX)          |
+-	BIT(TRIGGER_NETDEV_TX);
+-
+-static int mt798x_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
+-					  unsigned long rules)
+-{
+-	if (index > 1)
+-		return -EINVAL;
+-
+-	/* All combinations of the supported triggers are allowed */
+-	if (rules & ~supported_triggers)
+-		return -EOPNOTSUPP;
+-
+-	return 0;
+-};
+-
+-static int mt798x_phy_led_hw_control_get(struct phy_device *phydev, u8 index,
+-					 unsigned long *rules)
+-{
+-	unsigned int bit_blink = MTK_PHY_LED_STATE_FORCE_BLINK +
+-				 (index ? 16 : 0);
+-	unsigned int bit_netdev = MTK_PHY_LED_STATE_NETDEV + (index ? 16 : 0);
+-	unsigned int bit_on = MTK_PHY_LED_STATE_FORCE_ON + (index ? 16 : 0);
+-	struct mtk_socphy_priv *priv = phydev->priv;
+-	int on, blink;
+-
+-	if (index > 1)
+-		return -EINVAL;
+-
+-	on = phy_read_mmd(phydev, MDIO_MMD_VEND2,
+-			  index ? MTK_PHY_LED1_ON_CTRL : MTK_PHY_LED0_ON_CTRL);
+-
+-	if (on < 0)
+-		return -EIO;
+-
+-	blink = phy_read_mmd(phydev, MDIO_MMD_VEND2,
+-			     index ? MTK_PHY_LED1_BLINK_CTRL :
+-				     MTK_PHY_LED0_BLINK_CTRL);
+-	if (blink < 0)
+-		return -EIO;
+-
+-	if ((on & (MTK_PHY_LED_ON_LINK | MTK_PHY_LED_ON_FDX |
+-		   MTK_PHY_LED_ON_HDX | MTK_PHY_LED_ON_LINKDOWN)) ||
+-	    (blink & (MTK_PHY_LED_BLINK_RX | MTK_PHY_LED_BLINK_TX)))
+-		set_bit(bit_netdev, &priv->led_state);
+-	else
+-		clear_bit(bit_netdev, &priv->led_state);
+-
+-	if (on & MTK_PHY_LED_ON_FORCE_ON)
+-		set_bit(bit_on, &priv->led_state);
+-	else
+-		clear_bit(bit_on, &priv->led_state);
+-
+-	if (blink & MTK_PHY_LED_BLINK_FORCE_BLINK)
+-		set_bit(bit_blink, &priv->led_state);
+-	else
+-		clear_bit(bit_blink, &priv->led_state);
+-
+-	if (!rules)
+-		return 0;
+-
+-	if (on & MTK_PHY_LED_ON_LINK)
+-		*rules |= BIT(TRIGGER_NETDEV_LINK);
+-
+-	if (on & MTK_PHY_LED_ON_LINK10)
+-		*rules |= BIT(TRIGGER_NETDEV_LINK_10);
+-
+-	if (on & MTK_PHY_LED_ON_LINK100)
+-		*rules |= BIT(TRIGGER_NETDEV_LINK_100);
+-
+-	if (on & MTK_PHY_LED_ON_LINK1000)
+-		*rules |= BIT(TRIGGER_NETDEV_LINK_1000);
+-
+-	if (on & MTK_PHY_LED_ON_FDX)
+-		*rules |= BIT(TRIGGER_NETDEV_FULL_DUPLEX);
+-
+-	if (on & MTK_PHY_LED_ON_HDX)
+-		*rules |= BIT(TRIGGER_NETDEV_HALF_DUPLEX);
+-
+-	if (blink & MTK_PHY_LED_BLINK_RX)
+-		*rules |= BIT(TRIGGER_NETDEV_RX);
+-
+-	if (blink & MTK_PHY_LED_BLINK_TX)
+-		*rules |= BIT(TRIGGER_NETDEV_TX);
+-
+-	return 0;
+-};
+-
+-static int mt798x_phy_led_hw_control_set(struct phy_device *phydev, u8 index,
+-					 unsigned long rules)
+-{
+-	unsigned int bit_netdev = MTK_PHY_LED_STATE_NETDEV + (index ? 16 : 0);
+-	struct mtk_socphy_priv *priv = phydev->priv;
+-	u16 on = 0, blink = 0;
+-	int ret;
+-
+-	if (index > 1)
+-		return -EINVAL;
+-
+-	if (rules & BIT(TRIGGER_NETDEV_FULL_DUPLEX))
+-		on |= MTK_PHY_LED_ON_FDX;
+-
+-	if (rules & BIT(TRIGGER_NETDEV_HALF_DUPLEX))
+-		on |= MTK_PHY_LED_ON_HDX;
+-
+-	if (rules & (BIT(TRIGGER_NETDEV_LINK_10) | BIT(TRIGGER_NETDEV_LINK)))
+-		on |= MTK_PHY_LED_ON_LINK10;
+-
+-	if (rules & (BIT(TRIGGER_NETDEV_LINK_100) | BIT(TRIGGER_NETDEV_LINK)))
+-		on |= MTK_PHY_LED_ON_LINK100;
+-
+-	if (rules & (BIT(TRIGGER_NETDEV_LINK_1000) | BIT(TRIGGER_NETDEV_LINK)))
+-		on |= MTK_PHY_LED_ON_LINK1000;
+-
+-	if (rules & BIT(TRIGGER_NETDEV_RX)) {
+-		blink |= (on & MTK_PHY_LED_ON_LINK) ?
+-			  (((on & MTK_PHY_LED_ON_LINK10) ?
+-			    MTK_PHY_LED_BLINK_10RX : 0) |
+-			   ((on & MTK_PHY_LED_ON_LINK100) ?
+-			    MTK_PHY_LED_BLINK_100RX : 0) |
+-			   ((on & MTK_PHY_LED_ON_LINK1000) ?
+-			    MTK_PHY_LED_BLINK_1000RX : 0)) :
+-			  MTK_PHY_LED_BLINK_RX;
+-	}
+-
+-	if (rules & BIT(TRIGGER_NETDEV_TX)) {
+-		blink |= (on & MTK_PHY_LED_ON_LINK) ?
+-			  (((on & MTK_PHY_LED_ON_LINK10) ?
+-			    MTK_PHY_LED_BLINK_10TX : 0) |
+-			   ((on & MTK_PHY_LED_ON_LINK100) ?
+-			    MTK_PHY_LED_BLINK_100TX : 0) |
+-			   ((on & MTK_PHY_LED_ON_LINK1000) ?
+-			    MTK_PHY_LED_BLINK_1000TX : 0)) :
+-			  MTK_PHY_LED_BLINK_TX;
+-	}
+-
+-	if (blink || on)
+-		set_bit(bit_netdev, &priv->led_state);
+-	else
+-		clear_bit(bit_netdev, &priv->led_state);
+-
+-	ret = phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
+-				MTK_PHY_LED1_ON_CTRL :
+-				MTK_PHY_LED0_ON_CTRL,
+-			     MTK_PHY_LED_ON_FDX     |
+-			     MTK_PHY_LED_ON_HDX     |
+-			     MTK_PHY_LED_ON_LINK,
+-			     on);
+-
+-	if (ret)
+-		return ret;
+-
+-	return phy_write_mmd(phydev, MDIO_MMD_VEND2, index ?
+-				MTK_PHY_LED1_BLINK_CTRL :
+-				MTK_PHY_LED0_BLINK_CTRL, blink);
+-};
+-
+-static bool mt7988_phy_led_get_polarity(struct phy_device *phydev, int led_num)
+-{
+-	struct mtk_socphy_shared *priv = phydev->shared->priv;
+-	u32 polarities;
+-
+-	if (led_num == 0)
+-		polarities = ~(priv->boottrap);
+-	else
+-		polarities = MTK_PHY_LED1_DEFAULT_POLARITIES;
+-
+-	if (polarities & BIT(phydev->mdio.addr))
+-		return true;
+-
+-	return false;
+-}
+-
+-static int mt7988_phy_fix_leds_polarities(struct phy_device *phydev)
+-{
+-	struct pinctrl *pinctrl;
+-	int index;
+-
+-	/* Setup LED polarity according to bootstrap use of LED pins */
+-	for (index = 0; index < 2; ++index)
+-		phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
+-				MTK_PHY_LED1_ON_CTRL : MTK_PHY_LED0_ON_CTRL,
+-			       MTK_PHY_LED_ON_POLARITY,
+-			       mt7988_phy_led_get_polarity(phydev, index) ?
+-				MTK_PHY_LED_ON_POLARITY : 0);
+-
+-	/* Only now setup pinctrl to avoid bogus blinking */
+-	pinctrl = devm_pinctrl_get_select(&phydev->mdio.dev, "gbe-led");
+-	if (IS_ERR(pinctrl))
+-		dev_err(&phydev->mdio.bus->dev,
+-			"Failed to setup PHY LED pinctrl\n");
+-
+-	return 0;
+-}
+-
+-static int mt7988_phy_probe_shared(struct phy_device *phydev)
+-{
+-	struct device_node *np = dev_of_node(&phydev->mdio.bus->dev);
+-	struct mtk_socphy_shared *shared = phydev->shared->priv;
+-	struct regmap *regmap;
+-	u32 reg;
+-	int ret;
+-
+-	/* The LED0 of the 4 PHYs in MT7988 are wired to SoC pins LED_A, LED_B,
+-	 * LED_C and LED_D respectively. At the same time those pins are used to
+-	 * bootstrap configuration of the reference clock source (LED_A),
+-	 * DRAM DDRx16b x2/x1 (LED_B) and boot device (LED_C, LED_D).
+-	 * In practice this is done using a LED and a resistor pulling the pin
+-	 * either to GND or to VIO.
+-	 * The detected value at boot time is accessible at run-time using the
+-	 * TPBANK0 register located in the gpio base of the pinctrl, in order
+-	 * to read it here it needs to be referenced by a phandle called
+-	 * 'mediatek,pio' in the MDIO bus hosting the PHY.
+-	 * The 4 bits in TPBANK0 are kept as package shared data and are used to
+-	 * set LED polarity for each of the LED0.
+-	 */
+-	regmap = syscon_regmap_lookup_by_phandle(np, "mediatek,pio");
+-	if (IS_ERR(regmap))
+-		return PTR_ERR(regmap);
+-
+-	ret = regmap_read(regmap, RG_GPIO_MISC_TPBANK0, &reg);
+-	if (ret)
+-		return ret;
+-
+-	shared->boottrap = FIELD_GET(RG_GPIO_MISC_TPBANK0_BOOTMODE, reg);
+-
+-	return 0;
+-}
+-
+-static void mt798x_phy_leds_state_init(struct phy_device *phydev)
+-{
+-	int i;
+-
+-	for (i = 0; i < 2; ++i)
+-		mt798x_phy_led_hw_control_get(phydev, i, NULL);
+-}
+-
+-static int mt7988_phy_probe(struct phy_device *phydev)
+-{
+-	struct mtk_socphy_shared *shared;
+-	struct mtk_socphy_priv *priv;
+-	int err;
+-
+-	if (phydev->mdio.addr > 3)
+-		return -EINVAL;
+-
+-	err = devm_phy_package_join(&phydev->mdio.dev, phydev, 0,
+-				    sizeof(struct mtk_socphy_shared));
+-	if (err)
+-		return err;
+-
+-	if (phy_package_probe_once(phydev)) {
+-		err = mt7988_phy_probe_shared(phydev);
+-		if (err)
+-			return err;
+-	}
+-
+-	shared = phydev->shared->priv;
+-	priv = &shared->priv[phydev->mdio.addr];
+-
+-	phydev->priv = priv;
+-
+-	mt798x_phy_leds_state_init(phydev);
+-
+-	err = mt7988_phy_fix_leds_polarities(phydev);
+-	if (err)
+-		return err;
+-
+-	/* Disable TX power saving at probing to:
+-	 * 1. Meet common mode compliance test criteria
+-	 * 2. Make sure that TX-VCM calibration works fine
+-	 */
+-	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG7,
+-		       MTK_PHY_DA_AD_BUF_BIAS_LP_MASK, 0x3 << 8);
+-
+-	return mt798x_phy_calibration(phydev);
+-}
+-
+-static int mt7981_phy_probe(struct phy_device *phydev)
+-{
+-	struct mtk_socphy_priv *priv;
+-
+-	priv = devm_kzalloc(&phydev->mdio.dev, sizeof(struct mtk_socphy_priv),
+-			    GFP_KERNEL);
+-	if (!priv)
+-		return -ENOMEM;
+-
+-	phydev->priv = priv;
+-
+-	mt798x_phy_leds_state_init(phydev);
+-
+-	return mt798x_phy_calibration(phydev);
+-}
+-
+-static struct phy_driver mtk_socphy_driver[] = {
+-	{
+-		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981),
+-		.name		= "MediaTek MT7981 PHY",
+-		.config_init	= mt798x_phy_config_init,
+-		.config_intr	= genphy_no_config_intr,
+-		.handle_interrupt = genphy_handle_interrupt_no_ack,
+-		.probe		= mt7981_phy_probe,
+-		.suspend	= genphy_suspend,
+-		.resume		= genphy_resume,
+-		.read_page	= mtk_socphy_read_page,
+-		.write_page	= mtk_socphy_write_page,
+-		.led_blink_set	= mt798x_phy_led_blink_set,
+-		.led_brightness_set = mt798x_phy_led_brightness_set,
+-		.led_hw_is_supported = mt798x_phy_led_hw_is_supported,
+-		.led_hw_control_set = mt798x_phy_led_hw_control_set,
+-		.led_hw_control_get = mt798x_phy_led_hw_control_get,
+-	},
+-	{
+-		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7988),
+-		.name		= "MediaTek MT7988 PHY",
+-		.config_init	= mt798x_phy_config_init,
+-		.config_intr	= genphy_no_config_intr,
+-		.handle_interrupt = genphy_handle_interrupt_no_ack,
+-		.probe		= mt7988_phy_probe,
+-		.suspend	= genphy_suspend,
+-		.resume		= genphy_resume,
+-		.read_page	= mtk_socphy_read_page,
+-		.write_page	= mtk_socphy_write_page,
+-		.led_blink_set	= mt798x_phy_led_blink_set,
+-		.led_brightness_set = mt798x_phy_led_brightness_set,
+-		.led_hw_is_supported = mt798x_phy_led_hw_is_supported,
+-		.led_hw_control_set = mt798x_phy_led_hw_control_set,
+-		.led_hw_control_get = mt798x_phy_led_hw_control_get,
+-	},
+-};
+-
+-module_phy_driver(mtk_socphy_driver);
+-
+-static struct mdio_device_id __maybe_unused mtk_socphy_tbl[] = {
+-	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981) },
+-	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7988) },
+-	{ }
+-};
+-
+-MODULE_DESCRIPTION("MediaTek SoC Gigabit Ethernet PHY driver");
+-MODULE_AUTHOR("Daniel Golle <daniel@makrotopia.org>");
+-MODULE_AUTHOR("SkyLake Huang <SkyLake.Huang@mediatek.com>");
+-MODULE_LICENSE("GPL");
+-
+-MODULE_DEVICE_TABLE(mdio, mtk_socphy_tbl);
+--- a/drivers/net/phy/mediatek-ge.c
++++ /dev/null
+@@ -1,148 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0+
+-#include <linux/of.h>
+-#include <linux/bitfield.h>
+-#include <linux/module.h>
+-#include <linux/phy.h>
+-
+-#define MTK_EXT_PAGE_ACCESS		0x1f
+-#define MTK_PHY_PAGE_STANDARD		0x0000
+-#define MTK_PHY_PAGE_EXTENDED		0x0001
+-#define MTK_PHY_PAGE_EXTENDED_2		0x0002
+-#define MTK_PHY_PAGE_EXTENDED_3		0x0003
+-#define MTK_PHY_PAGE_EXTENDED_2A30	0x2a30
+-#define MTK_PHY_PAGE_EXTENDED_52B5	0x52b5
+-
+-static int mtk_gephy_read_page(struct phy_device *phydev)
+-{
+-	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
+-}
+-
+-static int mtk_gephy_write_page(struct phy_device *phydev, int page)
+-{
+-	return __phy_write(phydev, MTK_EXT_PAGE_ACCESS, page);
+-}
+-
+-static void mtk_gephy_config_init(struct phy_device *phydev)
+-{
+-	/* Disable EEE */
+-	phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV, 0);
+-
+-	/* Enable HW auto downshift */
+-	phy_modify_paged(phydev, MTK_PHY_PAGE_EXTENDED, 0x14, 0, BIT(4));
+-
+-	/* Increase SlvDPSready time */
+-	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
+-	__phy_write(phydev, 0x10, 0xafae);
+-	__phy_write(phydev, 0x12, 0x2f);
+-	__phy_write(phydev, 0x10, 0x8fae);
+-	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
+-
+-	/* Adjust 100_mse_threshold */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x123, 0xffff);
+-
+-	/* Disable mcc */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0xa6, 0x300);
+-}
+-
+-static int mt7530_phy_config_init(struct phy_device *phydev)
+-{
+-	mtk_gephy_config_init(phydev);
+-
+-	/* Increase post_update_timer */
+-	phy_write_paged(phydev, MTK_PHY_PAGE_EXTENDED_3, 0x11, 0x4b);
+-
+-	return 0;
+-}
+-
+-static int mt7530_led_config_of(struct phy_device *phydev)
+-{
+-	struct device_node *np = phydev->mdio.dev.of_node;
+-	const __be32 *paddr;
+-	int len;
+-	int i;
+-
+-	paddr = of_get_property(np, "mediatek,led-config", &len);
+-	if (!paddr)
+-		return 0;
+-
+-	if (len < (2 * sizeof(*paddr)))
+-		return -EINVAL;
+-
+-	len /= sizeof(*paddr);
+-
+-	phydev_warn(phydev, "Configure LED registers (num=%d)\n", len);
+-	for (i = 0; i < len - 1; i += 2) {
+-		u32 reg;
+-		u32 val;
+-
+-		reg = be32_to_cpup(paddr + i);
+-		val = be32_to_cpup(paddr + i + 1);
+-
+-		phy_write_mmd(phydev, MDIO_MMD_VEND2, reg, val);
+-	}
+-
+-	return 0;
+-}
+-
+-static int mt7531_phy_config_init(struct phy_device *phydev)
+-{
+-	mtk_gephy_config_init(phydev);
+-
+-	/* PHY link down power saving enable */
+-	phy_set_bits(phydev, 0x17, BIT(4));
+-	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, 0xc6, 0x300);
+-
+-	/* Set TX Pair delay selection */
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x13, 0x404);
+-	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x14, 0x404);
+-
+-	/* LED Config*/
+-	mt7530_led_config_of(phydev);
+-
+-	return 0;
+-}
+-
+-static struct phy_driver mtk_gephy_driver[] = {
+-	{
+-		PHY_ID_MATCH_EXACT(0x03a29412),
+-		.name		= "MediaTek MT7530 PHY",
+-		.config_init	= mt7530_phy_config_init,
+-		/* Interrupts are handled by the switch, not the PHY
+-		 * itself.
+-		 */
+-		.config_intr	= genphy_no_config_intr,
+-		.handle_interrupt = genphy_handle_interrupt_no_ack,
+-		.suspend	= genphy_suspend,
+-		.resume		= genphy_resume,
+-		.read_page	= mtk_gephy_read_page,
+-		.write_page	= mtk_gephy_write_page,
+-	},
+-	{
+-		PHY_ID_MATCH_EXACT(0x03a29441),
+-		.name		= "MediaTek MT7531 PHY",
+-		.config_init	= mt7531_phy_config_init,
+-		/* Interrupts are handled by the switch, not the PHY
+-		 * itself.
+-		 */
+-		.config_intr	= genphy_no_config_intr,
+-		.handle_interrupt = genphy_handle_interrupt_no_ack,
+-		.suspend	= genphy_suspend,
+-		.resume		= genphy_resume,
+-		.read_page	= mtk_gephy_read_page,
+-		.write_page	= mtk_gephy_write_page,
+-	},
+-};
+-
+-module_phy_driver(mtk_gephy_driver);
+-
+-static struct mdio_device_id __maybe_unused mtk_gephy_tbl[] = {
+-	{ PHY_ID_MATCH_EXACT(0x03a29441) },
+-	{ PHY_ID_MATCH_EXACT(0x03a29412) },
+-	{ }
+-};
+-
+-MODULE_DESCRIPTION("MediaTek Gigabit Ethernet PHY driver");
+-MODULE_AUTHOR("DENG, Qingfang <dqfext@gmail.com>");
+-MODULE_LICENSE("GPL");
+-
+-MODULE_DEVICE_TABLE(mdio, mtk_gephy_tbl);
+--- /dev/null
++++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
+@@ -0,0 +1,1610 @@
++// SPDX-License-Identifier: GPL-2.0+
++#include <linux/bitfield.h>
++#include <linux/bitmap.h>
++#include <linux/mfd/syscon.h>
++#include <linux/module.h>
++#include <linux/nvmem-consumer.h>
++#include <linux/pinctrl/consumer.h>
++#include <linux/phy.h>
++#include <linux/regmap.h>
++
++#define MTK_GPHY_ID_MT7981			0x03a29461
++#define MTK_GPHY_ID_MT7988			0x03a29481
++
++#define MTK_EXT_PAGE_ACCESS			0x1f
++#define MTK_PHY_PAGE_STANDARD			0x0000
++#define MTK_PHY_PAGE_EXTENDED_3			0x0003
++
++#define MTK_PHY_LPI_REG_14			0x14
++#define MTK_PHY_LPI_WAKE_TIMER_1000_MASK	GENMASK(8, 0)
++
++#define MTK_PHY_LPI_REG_1c			0x1c
++#define MTK_PHY_SMI_DET_ON_THRESH_MASK		GENMASK(13, 8)
++
++#define MTK_PHY_PAGE_EXTENDED_2A30		0x2a30
++#define MTK_PHY_PAGE_EXTENDED_52B5		0x52b5
++
++#define ANALOG_INTERNAL_OPERATION_MAX_US	20
++#define TXRESERVE_MIN				0
++#define TXRESERVE_MAX				7
++
++#define MTK_PHY_ANARG_RG			0x10
++#define   MTK_PHY_TCLKOFFSET_MASK		GENMASK(12, 8)
++
++/* Registers on MDIO_MMD_VEND1 */
++#define MTK_PHY_TXVLD_DA_RG			0x12
++#define   MTK_PHY_DA_TX_I2MPB_A_GBE_MASK	GENMASK(15, 10)
++#define   MTK_PHY_DA_TX_I2MPB_A_TBT_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_A2		0x16
++#define   MTK_PHY_DA_TX_I2MPB_A_HBT_MASK	GENMASK(15, 10)
++#define   MTK_PHY_DA_TX_I2MPB_A_TST_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_B1		0x17
++#define   MTK_PHY_DA_TX_I2MPB_B_GBE_MASK	GENMASK(13, 8)
++#define   MTK_PHY_DA_TX_I2MPB_B_TBT_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_B2		0x18
++#define   MTK_PHY_DA_TX_I2MPB_B_HBT_MASK	GENMASK(13, 8)
++#define   MTK_PHY_DA_TX_I2MPB_B_TST_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_C1		0x19
++#define   MTK_PHY_DA_TX_I2MPB_C_GBE_MASK	GENMASK(13, 8)
++#define   MTK_PHY_DA_TX_I2MPB_C_TBT_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_C2		0x20
++#define   MTK_PHY_DA_TX_I2MPB_C_HBT_MASK	GENMASK(13, 8)
++#define   MTK_PHY_DA_TX_I2MPB_C_TST_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_D1		0x21
++#define   MTK_PHY_DA_TX_I2MPB_D_GBE_MASK	GENMASK(13, 8)
++#define   MTK_PHY_DA_TX_I2MPB_D_TBT_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_TX_I2MPB_TEST_MODE_D2		0x22
++#define   MTK_PHY_DA_TX_I2MPB_D_HBT_MASK	GENMASK(13, 8)
++#define   MTK_PHY_DA_TX_I2MPB_D_TST_MASK	GENMASK(5, 0)
++
++#define MTK_PHY_RXADC_CTRL_RG7			0xc6
++#define   MTK_PHY_DA_AD_BUF_BIAS_LP_MASK	GENMASK(9, 8)
++
++#define MTK_PHY_RXADC_CTRL_RG9			0xc8
++#define   MTK_PHY_DA_RX_PSBN_TBT_MASK		GENMASK(14, 12)
++#define   MTK_PHY_DA_RX_PSBN_HBT_MASK		GENMASK(10, 8)
++#define   MTK_PHY_DA_RX_PSBN_GBE_MASK		GENMASK(6, 4)
++#define   MTK_PHY_DA_RX_PSBN_LP_MASK		GENMASK(2, 0)
++
++#define MTK_PHY_LDO_OUTPUT_V			0xd7
++
++#define MTK_PHY_RG_ANA_CAL_RG0			0xdb
++#define   MTK_PHY_RG_CAL_CKINV			BIT(12)
++#define   MTK_PHY_RG_ANA_CALEN			BIT(8)
++#define   MTK_PHY_RG_ZCALEN_A			BIT(0)
++
++#define MTK_PHY_RG_ANA_CAL_RG1			0xdc
++#define   MTK_PHY_RG_ZCALEN_B			BIT(12)
++#define   MTK_PHY_RG_ZCALEN_C			BIT(8)
++#define   MTK_PHY_RG_ZCALEN_D			BIT(4)
++#define   MTK_PHY_RG_TXVOS_CALEN		BIT(0)
++
++#define MTK_PHY_RG_ANA_CAL_RG5			0xe0
++#define   MTK_PHY_RG_REXT_TRIM_MASK		GENMASK(13, 8)
++
++#define MTK_PHY_RG_TX_FILTER			0xfe
++
++#define MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG120	0x120
++#define   MTK_PHY_LPI_SIG_EN_LO_THRESH1000_MASK	GENMASK(12, 8)
++#define   MTK_PHY_LPI_SIG_EN_HI_THRESH1000_MASK	GENMASK(4, 0)
++
++#define MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122	0x122
++#define   MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK	GENMASK(7, 0)
++
++#define MTK_PHY_RG_TESTMUX_ADC_CTRL		0x144
++#define   MTK_PHY_RG_TXEN_DIG_MASK		GENMASK(5, 5)
++
++#define MTK_PHY_RG_CR_TX_AMP_OFFSET_A_B		0x172
++#define   MTK_PHY_CR_TX_AMP_OFFSET_A_MASK	GENMASK(13, 8)
++#define   MTK_PHY_CR_TX_AMP_OFFSET_B_MASK	GENMASK(6, 0)
++
++#define MTK_PHY_RG_CR_TX_AMP_OFFSET_C_D		0x173
++#define   MTK_PHY_CR_TX_AMP_OFFSET_C_MASK	GENMASK(13, 8)
++#define   MTK_PHY_CR_TX_AMP_OFFSET_D_MASK	GENMASK(6, 0)
++
++#define MTK_PHY_RG_AD_CAL_COMP			0x17a
++#define   MTK_PHY_AD_CAL_COMP_OUT_MASK		GENMASK(8, 8)
++
++#define MTK_PHY_RG_AD_CAL_CLK			0x17b
++#define   MTK_PHY_DA_CAL_CLK			BIT(0)
++
++#define MTK_PHY_RG_AD_CALIN			0x17c
++#define   MTK_PHY_DA_CALIN_FLAG			BIT(0)
++
++#define MTK_PHY_RG_DASN_DAC_IN0_A		0x17d
++#define   MTK_PHY_DASN_DAC_IN0_A_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN0_B		0x17e
++#define   MTK_PHY_DASN_DAC_IN0_B_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN0_C		0x17f
++#define   MTK_PHY_DASN_DAC_IN0_C_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN0_D		0x180
++#define   MTK_PHY_DASN_DAC_IN0_D_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN1_A		0x181
++#define   MTK_PHY_DASN_DAC_IN1_A_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN1_B		0x182
++#define   MTK_PHY_DASN_DAC_IN1_B_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN1_C		0x183
++#define   MTK_PHY_DASN_DAC_IN1_C_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DASN_DAC_IN1_D		0x184
++#define   MTK_PHY_DASN_DAC_IN1_D_MASK		GENMASK(9, 0)
++
++#define MTK_PHY_RG_DEV1E_REG19b			0x19b
++#define   MTK_PHY_BYPASS_DSP_LPI_READY		BIT(8)
++
++#define MTK_PHY_RG_LP_IIR2_K1_L			0x22a
++#define MTK_PHY_RG_LP_IIR2_K1_U			0x22b
++#define MTK_PHY_RG_LP_IIR2_K2_L			0x22c
++#define MTK_PHY_RG_LP_IIR2_K2_U			0x22d
++#define MTK_PHY_RG_LP_IIR2_K3_L			0x22e
++#define MTK_PHY_RG_LP_IIR2_K3_U			0x22f
++#define MTK_PHY_RG_LP_IIR2_K4_L			0x230
++#define MTK_PHY_RG_LP_IIR2_K4_U			0x231
++#define MTK_PHY_RG_LP_IIR2_K5_L			0x232
++#define MTK_PHY_RG_LP_IIR2_K5_U			0x233
++
++#define MTK_PHY_RG_DEV1E_REG234			0x234
++#define   MTK_PHY_TR_OPEN_LOOP_EN_MASK		GENMASK(0, 0)
++#define   MTK_PHY_LPF_X_AVERAGE_MASK		GENMASK(7, 4)
++#define   MTK_PHY_TR_LP_IIR_EEE_EN		BIT(12)
++
++#define MTK_PHY_RG_LPF_CNT_VAL			0x235
++
++#define MTK_PHY_RG_DEV1E_REG238			0x238
++#define   MTK_PHY_LPI_SLV_SEND_TX_TIMER_MASK	GENMASK(8, 0)
++#define   MTK_PHY_LPI_SLV_SEND_TX_EN		BIT(12)
++
++#define MTK_PHY_RG_DEV1E_REG239			0x239
++#define   MTK_PHY_LPI_SEND_LOC_TIMER_MASK	GENMASK(8, 0)
++#define   MTK_PHY_LPI_TXPCS_LOC_RCV		BIT(12)
++
++#define MTK_PHY_RG_DEV1E_REG27C			0x27c
++#define   MTK_PHY_VGASTATE_FFE_THR_ST1_MASK	GENMASK(12, 8)
++#define MTK_PHY_RG_DEV1E_REG27D			0x27d
++#define   MTK_PHY_VGASTATE_FFE_THR_ST2_MASK	GENMASK(4, 0)
++
++#define MTK_PHY_RG_DEV1E_REG2C7			0x2c7
++#define   MTK_PHY_MAX_GAIN_MASK			GENMASK(4, 0)
++#define   MTK_PHY_MIN_GAIN_MASK			GENMASK(12, 8)
++
++#define MTK_PHY_RG_DEV1E_REG2D1			0x2d1
++#define   MTK_PHY_VCO_SLICER_THRESH_BITS_HIGH_EEE_MASK	GENMASK(7, 0)
++#define   MTK_PHY_LPI_SKIP_SD_SLV_TR		BIT(8)
++#define   MTK_PHY_LPI_TR_READY			BIT(9)
++#define   MTK_PHY_LPI_VCO_EEE_STG0_EN		BIT(10)
++
++#define MTK_PHY_RG_DEV1E_REG323			0x323
++#define   MTK_PHY_EEE_WAKE_MAS_INT_DC		BIT(0)
++#define   MTK_PHY_EEE_WAKE_SLV_INT_DC		BIT(4)
++
++#define MTK_PHY_RG_DEV1E_REG324			0x324
++#define   MTK_PHY_SMI_DETCNT_MAX_MASK		GENMASK(5, 0)
++#define   MTK_PHY_SMI_DET_MAX_EN		BIT(8)
++
++#define MTK_PHY_RG_DEV1E_REG326			0x326
++#define   MTK_PHY_LPI_MODE_SD_ON		BIT(0)
++#define   MTK_PHY_RESET_RANDUPD_CNT		BIT(1)
++#define   MTK_PHY_TREC_UPDATE_ENAB_CLR		BIT(2)
++#define   MTK_PHY_LPI_QUIT_WAIT_DFE_SIG_DET_OFF	BIT(4)
++#define   MTK_PHY_TR_READY_SKIP_AFE_WAKEUP	BIT(5)
++
++#define MTK_PHY_LDO_PUMP_EN_PAIRAB		0x502
++#define MTK_PHY_LDO_PUMP_EN_PAIRCD		0x503
++
++#define MTK_PHY_DA_TX_R50_PAIR_A		0x53d
++#define MTK_PHY_DA_TX_R50_PAIR_B		0x53e
++#define MTK_PHY_DA_TX_R50_PAIR_C		0x53f
++#define MTK_PHY_DA_TX_R50_PAIR_D		0x540
++
++/* Registers on MDIO_MMD_VEND2 */
++#define MTK_PHY_LED0_ON_CTRL			0x24
++#define MTK_PHY_LED1_ON_CTRL			0x26
++#define   MTK_PHY_LED_ON_MASK			GENMASK(6, 0)
++#define   MTK_PHY_LED_ON_LINK1000		BIT(0)
++#define   MTK_PHY_LED_ON_LINK100		BIT(1)
++#define   MTK_PHY_LED_ON_LINK10			BIT(2)
++#define   MTK_PHY_LED_ON_LINK			(MTK_PHY_LED_ON_LINK10 |\
++						 MTK_PHY_LED_ON_LINK100 |\
++						 MTK_PHY_LED_ON_LINK1000)
++#define   MTK_PHY_LED_ON_LINKDOWN		BIT(3)
++#define   MTK_PHY_LED_ON_FDX			BIT(4) /* Full duplex */
++#define   MTK_PHY_LED_ON_HDX			BIT(5) /* Half duplex */
++#define   MTK_PHY_LED_ON_FORCE_ON		BIT(6)
++#define   MTK_PHY_LED_ON_POLARITY		BIT(14)
++#define   MTK_PHY_LED_ON_ENABLE			BIT(15)
++
++#define MTK_PHY_LED0_BLINK_CTRL			0x25
++#define MTK_PHY_LED1_BLINK_CTRL			0x27
++#define   MTK_PHY_LED_BLINK_1000TX		BIT(0)
++#define   MTK_PHY_LED_BLINK_1000RX		BIT(1)
++#define   MTK_PHY_LED_BLINK_100TX		BIT(2)
++#define   MTK_PHY_LED_BLINK_100RX		BIT(3)
++#define   MTK_PHY_LED_BLINK_10TX		BIT(4)
++#define   MTK_PHY_LED_BLINK_10RX		BIT(5)
++#define   MTK_PHY_LED_BLINK_RX			(MTK_PHY_LED_BLINK_10RX |\
++						 MTK_PHY_LED_BLINK_100RX |\
++						 MTK_PHY_LED_BLINK_1000RX)
++#define   MTK_PHY_LED_BLINK_TX			(MTK_PHY_LED_BLINK_10TX |\
++						 MTK_PHY_LED_BLINK_100TX |\
++						 MTK_PHY_LED_BLINK_1000TX)
++#define   MTK_PHY_LED_BLINK_COLLISION		BIT(6)
++#define   MTK_PHY_LED_BLINK_RX_CRC_ERR		BIT(7)
++#define   MTK_PHY_LED_BLINK_RX_IDLE_ERR		BIT(8)
++#define   MTK_PHY_LED_BLINK_FORCE_BLINK		BIT(9)
++
++#define MTK_PHY_LED1_DEFAULT_POLARITIES		BIT(1)
++
++#define MTK_PHY_RG_BG_RASEL			0x115
++#define   MTK_PHY_RG_BG_RASEL_MASK		GENMASK(2, 0)
++
++/* 'boottrap' register reflecting the configuration of the 4 PHY LEDs */
++#define RG_GPIO_MISC_TPBANK0			0x6f0
++#define   RG_GPIO_MISC_TPBANK0_BOOTMODE		GENMASK(11, 8)
++
++/* These macro privides efuse parsing for internal phy. */
++#define EFS_DA_TX_I2MPB_A(x)			(((x) >> 0) & GENMASK(5, 0))
++#define EFS_DA_TX_I2MPB_B(x)			(((x) >> 6) & GENMASK(5, 0))
++#define EFS_DA_TX_I2MPB_C(x)			(((x) >> 12) & GENMASK(5, 0))
++#define EFS_DA_TX_I2MPB_D(x)			(((x) >> 18) & GENMASK(5, 0))
++#define EFS_DA_TX_AMP_OFFSET_A(x)		(((x) >> 24) & GENMASK(5, 0))
++
++#define EFS_DA_TX_AMP_OFFSET_B(x)		(((x) >> 0) & GENMASK(5, 0))
++#define EFS_DA_TX_AMP_OFFSET_C(x)		(((x) >> 6) & GENMASK(5, 0))
++#define EFS_DA_TX_AMP_OFFSET_D(x)		(((x) >> 12) & GENMASK(5, 0))
++#define EFS_DA_TX_R50_A(x)			(((x) >> 18) & GENMASK(5, 0))
++#define EFS_DA_TX_R50_B(x)			(((x) >> 24) & GENMASK(5, 0))
++
++#define EFS_DA_TX_R50_C(x)			(((x) >> 0) & GENMASK(5, 0))
++#define EFS_DA_TX_R50_D(x)			(((x) >> 6) & GENMASK(5, 0))
++
++#define EFS_RG_BG_RASEL(x)			(((x) >> 4) & GENMASK(2, 0))
++#define EFS_RG_REXT_TRIM(x)			(((x) >> 7) & GENMASK(5, 0))
++
++enum {
++	NO_PAIR,
++	PAIR_A,
++	PAIR_B,
++	PAIR_C,
++	PAIR_D,
++};
++
++enum calibration_mode {
++	EFUSE_K,
++	SW_K
++};
++
++enum CAL_ITEM {
++	REXT,
++	TX_OFFSET,
++	TX_AMP,
++	TX_R50,
++	TX_VCM
++};
++
++enum CAL_MODE {
++	EFUSE_M,
++	SW_M
++};
++
++#define MTK_PHY_LED_STATE_FORCE_ON	0
++#define MTK_PHY_LED_STATE_FORCE_BLINK	1
++#define MTK_PHY_LED_STATE_NETDEV	2
++
++struct mtk_socphy_priv {
++	unsigned long		led_state;
++};
++
++struct mtk_socphy_shared {
++	u32			boottrap;
++	struct mtk_socphy_priv	priv[4];
++};
++
++static int mtk_socphy_read_page(struct phy_device *phydev)
++{
++	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
++}
++
++static int mtk_socphy_write_page(struct phy_device *phydev, int page)
++{
++	return __phy_write(phydev, MTK_EXT_PAGE_ACCESS, page);
++}
++
++/* One calibration cycle consists of:
++ * 1.Set DA_CALIN_FLAG high to start calibration. Keep it high
++ *   until AD_CAL_COMP is ready to output calibration result.
++ * 2.Wait until DA_CAL_CLK is available.
++ * 3.Fetch AD_CAL_COMP_OUT.
++ */
++static int cal_cycle(struct phy_device *phydev, int devad,
++		     u32 regnum, u16 mask, u16 cal_val)
++{
++	int reg_val;
++	int ret;
++
++	phy_modify_mmd(phydev, devad, regnum,
++		       mask, cal_val);
++	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CALIN,
++			 MTK_PHY_DA_CALIN_FLAG);
++
++	ret = phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND1,
++					MTK_PHY_RG_AD_CAL_CLK, reg_val,
++					reg_val & MTK_PHY_DA_CAL_CLK, 500,
++					ANALOG_INTERNAL_OPERATION_MAX_US,
++					false);
++	if (ret) {
++		phydev_err(phydev, "Calibration cycle timeout\n");
++		return ret;
++	}
++
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CALIN,
++			   MTK_PHY_DA_CALIN_FLAG);
++	ret = phy_read_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CAL_COMP);
++	if (ret < 0)
++		return ret;
++	ret = FIELD_GET(MTK_PHY_AD_CAL_COMP_OUT_MASK, ret);
++	phydev_dbg(phydev, "cal_val: 0x%x, ret: %d\n", cal_val, ret);
++
++	return ret;
++}
++
++static int rext_fill_result(struct phy_device *phydev, u16 *buf)
++{
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG5,
++		       MTK_PHY_RG_REXT_TRIM_MASK, buf[0] << 8);
++	phy_modify_mmd(phydev, MDIO_MMD_VEND2, MTK_PHY_RG_BG_RASEL,
++		       MTK_PHY_RG_BG_RASEL_MASK, buf[1]);
++
++	return 0;
++}
++
++static int rext_cal_efuse(struct phy_device *phydev, u32 *buf)
++{
++	u16 rext_cal_val[2];
++
++	rext_cal_val[0] = EFS_RG_REXT_TRIM(buf[3]);
++	rext_cal_val[1] = EFS_RG_BG_RASEL(buf[3]);
++	rext_fill_result(phydev, rext_cal_val);
++
++	return 0;
++}
++
++static int tx_offset_fill_result(struct phy_device *phydev, u16 *buf)
++{
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_A_B,
++		       MTK_PHY_CR_TX_AMP_OFFSET_A_MASK, buf[0] << 8);
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_A_B,
++		       MTK_PHY_CR_TX_AMP_OFFSET_B_MASK, buf[1]);
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_C_D,
++		       MTK_PHY_CR_TX_AMP_OFFSET_C_MASK, buf[2] << 8);
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_CR_TX_AMP_OFFSET_C_D,
++		       MTK_PHY_CR_TX_AMP_OFFSET_D_MASK, buf[3]);
++
++	return 0;
++}
++
++static int tx_offset_cal_efuse(struct phy_device *phydev, u32 *buf)
++{
++	u16 tx_offset_cal_val[4];
++
++	tx_offset_cal_val[0] = EFS_DA_TX_AMP_OFFSET_A(buf[0]);
++	tx_offset_cal_val[1] = EFS_DA_TX_AMP_OFFSET_B(buf[1]);
++	tx_offset_cal_val[2] = EFS_DA_TX_AMP_OFFSET_C(buf[1]);
++	tx_offset_cal_val[3] = EFS_DA_TX_AMP_OFFSET_D(buf[1]);
++
++	tx_offset_fill_result(phydev, tx_offset_cal_val);
++
++	return 0;
++}
++
++static int tx_amp_fill_result(struct phy_device *phydev, u16 *buf)
++{
++	const int vals_9481[16] = { 10, 6, 6, 10,
++				    10, 6, 6, 10,
++				    10, 6, 6, 10,
++				    10, 6, 6, 10 };
++	const int vals_9461[16] = { 7, 1, 4, 7,
++				    7, 1, 4, 7,
++				    7, 1, 4, 7,
++				    7, 1, 4, 7 };
++	int bias[16] = {};
++	int i;
++
++	switch (phydev->drv->phy_id) {
++	case MTK_GPHY_ID_MT7981:
++		/* We add some calibration to efuse values
++		 * due to board level influence.
++		 * GBE: +7, TBT: +1, HBT: +4, TST: +7
++		 */
++		memcpy(bias, (const void *)vals_9461, sizeof(bias));
++		break;
++	case MTK_GPHY_ID_MT7988:
++		memcpy(bias, (const void *)vals_9481, sizeof(bias));
++		break;
++	}
++
++	/* Prevent overflow */
++	for (i = 0; i < 12; i++) {
++		if (buf[i >> 2] + bias[i] > 63) {
++			buf[i >> 2] = 63;
++			bias[i] = 0;
++		}
++	}
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TXVLD_DA_RG,
++		       MTK_PHY_DA_TX_I2MPB_A_GBE_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_GBE_MASK,
++				  buf[0] + bias[0]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TXVLD_DA_RG,
++		       MTK_PHY_DA_TX_I2MPB_A_TBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_TBT_MASK,
++				  buf[0] + bias[1]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_A2,
++		       MTK_PHY_DA_TX_I2MPB_A_HBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_HBT_MASK,
++				  buf[0] + bias[2]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_A2,
++		       MTK_PHY_DA_TX_I2MPB_A_TST_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_A_TST_MASK,
++				  buf[0] + bias[3]));
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B1,
++		       MTK_PHY_DA_TX_I2MPB_B_GBE_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_GBE_MASK,
++				  buf[1] + bias[4]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B1,
++		       MTK_PHY_DA_TX_I2MPB_B_TBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_TBT_MASK,
++				  buf[1] + bias[5]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B2,
++		       MTK_PHY_DA_TX_I2MPB_B_HBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_HBT_MASK,
++				  buf[1] + bias[6]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_B2,
++		       MTK_PHY_DA_TX_I2MPB_B_TST_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_B_TST_MASK,
++				  buf[1] + bias[7]));
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C1,
++		       MTK_PHY_DA_TX_I2MPB_C_GBE_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_GBE_MASK,
++				  buf[2] + bias[8]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C1,
++		       MTK_PHY_DA_TX_I2MPB_C_TBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_TBT_MASK,
++				  buf[2] + bias[9]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C2,
++		       MTK_PHY_DA_TX_I2MPB_C_HBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_HBT_MASK,
++				  buf[2] + bias[10]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_C2,
++		       MTK_PHY_DA_TX_I2MPB_C_TST_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_C_TST_MASK,
++				  buf[2] + bias[11]));
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D1,
++		       MTK_PHY_DA_TX_I2MPB_D_GBE_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_GBE_MASK,
++				  buf[3] + bias[12]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D1,
++		       MTK_PHY_DA_TX_I2MPB_D_TBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_TBT_MASK,
++				  buf[3] + bias[13]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D2,
++		       MTK_PHY_DA_TX_I2MPB_D_HBT_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_HBT_MASK,
++				  buf[3] + bias[14]));
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_TX_I2MPB_TEST_MODE_D2,
++		       MTK_PHY_DA_TX_I2MPB_D_TST_MASK,
++		       FIELD_PREP(MTK_PHY_DA_TX_I2MPB_D_TST_MASK,
++				  buf[3] + bias[15]));
++
++	return 0;
++}
++
++static int tx_amp_cal_efuse(struct phy_device *phydev, u32 *buf)
++{
++	u16 tx_amp_cal_val[4];
++
++	tx_amp_cal_val[0] = EFS_DA_TX_I2MPB_A(buf[0]);
++	tx_amp_cal_val[1] = EFS_DA_TX_I2MPB_B(buf[0]);
++	tx_amp_cal_val[2] = EFS_DA_TX_I2MPB_C(buf[0]);
++	tx_amp_cal_val[3] = EFS_DA_TX_I2MPB_D(buf[0]);
++	tx_amp_fill_result(phydev, tx_amp_cal_val);
++
++	return 0;
++}
++
++static int tx_r50_fill_result(struct phy_device *phydev, u16 tx_r50_cal_val,
++			      u8 txg_calen_x)
++{
++	int bias = 0;
++	u16 reg, val;
++
++	if (phydev->drv->phy_id == MTK_GPHY_ID_MT7988)
++		bias = -1;
++
++	val = clamp_val(bias + tx_r50_cal_val, 0, 63);
++
++	switch (txg_calen_x) {
++	case PAIR_A:
++		reg = MTK_PHY_DA_TX_R50_PAIR_A;
++		break;
++	case PAIR_B:
++		reg = MTK_PHY_DA_TX_R50_PAIR_B;
++		break;
++	case PAIR_C:
++		reg = MTK_PHY_DA_TX_R50_PAIR_C;
++		break;
++	case PAIR_D:
++		reg = MTK_PHY_DA_TX_R50_PAIR_D;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, reg, val | val << 8);
++
++	return 0;
++}
++
++static int tx_r50_cal_efuse(struct phy_device *phydev, u32 *buf,
++			    u8 txg_calen_x)
++{
++	u16 tx_r50_cal_val;
++
++	switch (txg_calen_x) {
++	case PAIR_A:
++		tx_r50_cal_val = EFS_DA_TX_R50_A(buf[1]);
++		break;
++	case PAIR_B:
++		tx_r50_cal_val = EFS_DA_TX_R50_B(buf[1]);
++		break;
++	case PAIR_C:
++		tx_r50_cal_val = EFS_DA_TX_R50_C(buf[2]);
++		break;
++	case PAIR_D:
++		tx_r50_cal_val = EFS_DA_TX_R50_D(buf[2]);
++		break;
++	default:
++		return -EINVAL;
++	}
++	tx_r50_fill_result(phydev, tx_r50_cal_val, txg_calen_x);
++
++	return 0;
++}
++
++static int tx_vcm_cal_sw(struct phy_device *phydev, u8 rg_txreserve_x)
++{
++	u8 lower_idx, upper_idx, txreserve_val;
++	u8 lower_ret, upper_ret;
++	int ret;
++
++	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
++			 MTK_PHY_RG_ANA_CALEN);
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
++			   MTK_PHY_RG_CAL_CKINV);
++	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG1,
++			 MTK_PHY_RG_TXVOS_CALEN);
++
++	switch (rg_txreserve_x) {
++	case PAIR_A:
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN0_A,
++				   MTK_PHY_DASN_DAC_IN0_A_MASK);
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN1_A,
++				   MTK_PHY_DASN_DAC_IN1_A_MASK);
++		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
++				 MTK_PHY_RG_ANA_CAL_RG0,
++				 MTK_PHY_RG_ZCALEN_A);
++		break;
++	case PAIR_B:
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN0_B,
++				   MTK_PHY_DASN_DAC_IN0_B_MASK);
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN1_B,
++				   MTK_PHY_DASN_DAC_IN1_B_MASK);
++		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
++				 MTK_PHY_RG_ANA_CAL_RG1,
++				 MTK_PHY_RG_ZCALEN_B);
++		break;
++	case PAIR_C:
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN0_C,
++				   MTK_PHY_DASN_DAC_IN0_C_MASK);
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN1_C,
++				   MTK_PHY_DASN_DAC_IN1_C_MASK);
++		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
++				 MTK_PHY_RG_ANA_CAL_RG1,
++				 MTK_PHY_RG_ZCALEN_C);
++		break;
++	case PAIR_D:
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN0_D,
++				   MTK_PHY_DASN_DAC_IN0_D_MASK);
++		phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++				   MTK_PHY_RG_DASN_DAC_IN1_D,
++				   MTK_PHY_DASN_DAC_IN1_D_MASK);
++		phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
++				 MTK_PHY_RG_ANA_CAL_RG1,
++				 MTK_PHY_RG_ZCALEN_D);
++		break;
++	default:
++		ret = -EINVAL;
++		goto restore;
++	}
++
++	lower_idx = TXRESERVE_MIN;
++	upper_idx = TXRESERVE_MAX;
++
++	phydev_dbg(phydev, "Start TX-VCM SW cal.\n");
++	while ((upper_idx - lower_idx) > 1) {
++		txreserve_val = DIV_ROUND_CLOSEST(lower_idx + upper_idx, 2);
++		ret = cal_cycle(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG9,
++				MTK_PHY_DA_RX_PSBN_TBT_MASK |
++				MTK_PHY_DA_RX_PSBN_HBT_MASK |
++				MTK_PHY_DA_RX_PSBN_GBE_MASK |
++				MTK_PHY_DA_RX_PSBN_LP_MASK,
++				txreserve_val << 12 | txreserve_val << 8 |
++				txreserve_val << 4 | txreserve_val);
++		if (ret == 1) {
++			upper_idx = txreserve_val;
++			upper_ret = ret;
++		} else if (ret == 0) {
++			lower_idx = txreserve_val;
++			lower_ret = ret;
++		} else {
++			goto restore;
++		}
++	}
++
++	if (lower_idx == TXRESERVE_MIN) {
++		lower_ret = cal_cycle(phydev, MDIO_MMD_VEND1,
++				      MTK_PHY_RXADC_CTRL_RG9,
++				      MTK_PHY_DA_RX_PSBN_TBT_MASK |
++				      MTK_PHY_DA_RX_PSBN_HBT_MASK |
++				      MTK_PHY_DA_RX_PSBN_GBE_MASK |
++				      MTK_PHY_DA_RX_PSBN_LP_MASK,
++				      lower_idx << 12 | lower_idx << 8 |
++				      lower_idx << 4 | lower_idx);
++		ret = lower_ret;
++	} else if (upper_idx == TXRESERVE_MAX) {
++		upper_ret = cal_cycle(phydev, MDIO_MMD_VEND1,
++				      MTK_PHY_RXADC_CTRL_RG9,
++				      MTK_PHY_DA_RX_PSBN_TBT_MASK |
++				      MTK_PHY_DA_RX_PSBN_HBT_MASK |
++				      MTK_PHY_DA_RX_PSBN_GBE_MASK |
++				      MTK_PHY_DA_RX_PSBN_LP_MASK,
++				      upper_idx << 12 | upper_idx << 8 |
++				      upper_idx << 4 | upper_idx);
++		ret = upper_ret;
++	}
++	if (ret < 0)
++		goto restore;
++
++	/* We calibrate TX-VCM in different logic. Check upper index and then
++	 * lower index. If this calibration is valid, apply lower index's
++	 * result.
++	 */
++	ret = upper_ret - lower_ret;
++	if (ret == 1) {
++		ret = 0;
++		/* Make sure we use upper_idx in our calibration system */
++		cal_cycle(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG9,
++			  MTK_PHY_DA_RX_PSBN_TBT_MASK |
++			  MTK_PHY_DA_RX_PSBN_HBT_MASK |
++			  MTK_PHY_DA_RX_PSBN_GBE_MASK |
++			  MTK_PHY_DA_RX_PSBN_LP_MASK,
++			  upper_idx << 12 | upper_idx << 8 |
++			  upper_idx << 4 | upper_idx);
++		phydev_dbg(phydev, "TX-VCM SW cal result: 0x%x\n", upper_idx);
++	} else if (lower_idx == TXRESERVE_MIN && upper_ret == 1 &&
++		   lower_ret == 1) {
++		ret = 0;
++		cal_cycle(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG9,
++			  MTK_PHY_DA_RX_PSBN_TBT_MASK |
++			  MTK_PHY_DA_RX_PSBN_HBT_MASK |
++			  MTK_PHY_DA_RX_PSBN_GBE_MASK |
++			  MTK_PHY_DA_RX_PSBN_LP_MASK,
++			  lower_idx << 12 | lower_idx << 8 |
++			  lower_idx << 4 | lower_idx);
++		phydev_warn(phydev, "TX-VCM SW cal result at low margin 0x%x\n",
++			    lower_idx);
++	} else if (upper_idx == TXRESERVE_MAX && upper_ret == 0 &&
++		   lower_ret == 0) {
++		ret = 0;
++		phydev_warn(phydev,
++			    "TX-VCM SW cal result at high margin 0x%x\n",
++			    upper_idx);
++	} else {
++		ret = -EINVAL;
++	}
++
++restore:
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
++			   MTK_PHY_RG_ANA_CALEN);
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG1,
++			   MTK_PHY_RG_TXVOS_CALEN);
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG0,
++			   MTK_PHY_RG_ZCALEN_A);
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_ANA_CAL_RG1,
++			   MTK_PHY_RG_ZCALEN_B | MTK_PHY_RG_ZCALEN_C |
++			   MTK_PHY_RG_ZCALEN_D);
++
++	return ret;
++}
++
++static void mt798x_phy_common_finetune(struct phy_device *phydev)
++{
++	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
++	/* SlvDSPreadyTime = 24, MasDSPreadyTime = 24 */
++	__phy_write(phydev, 0x11, 0xc71);
++	__phy_write(phydev, 0x12, 0xc);
++	__phy_write(phydev, 0x10, 0x8fae);
++
++	/* EnabRandUpdTrig = 1 */
++	__phy_write(phydev, 0x11, 0x2f00);
++	__phy_write(phydev, 0x12, 0xe);
++	__phy_write(phydev, 0x10, 0x8fb0);
++
++	/* NormMseLoThresh = 85 */
++	__phy_write(phydev, 0x11, 0x55a0);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x83aa);
++
++	/* FfeUpdGainForce = 1(Enable), FfeUpdGainForceVal = 4 */
++	__phy_write(phydev, 0x11, 0x240);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x9680);
++
++	/* TrFreeze = 0 (mt7988 default) */
++	__phy_write(phydev, 0x11, 0x0);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x9686);
++
++	/* SSTrKp100 = 5 */
++	/* SSTrKf100 = 6 */
++	/* SSTrKp1000Mas = 5 */
++	/* SSTrKf1000Mas = 6 */
++	/* SSTrKp1000Slv = 5 */
++	/* SSTrKf1000Slv = 6 */
++	__phy_write(phydev, 0x11, 0xbaef);
++	__phy_write(phydev, 0x12, 0x2e);
++	__phy_write(phydev, 0x10, 0x968c);
++	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++}
++
++static void mt7981_phy_finetune(struct phy_device *phydev)
++{
++	u16 val[8] = { 0x01ce, 0x01c1,
++		       0x020f, 0x0202,
++		       0x03d0, 0x03c0,
++		       0x0013, 0x0005 };
++	int i, k;
++
++	/* 100M eye finetune:
++	 * Keep middle level of TX MLT3 shapper as default.
++	 * Only change TX MLT3 overshoot level here.
++	 */
++	for (k = 0, i = 1; i < 12; i++) {
++		if (i % 3 == 0)
++			continue;
++		phy_write_mmd(phydev, MDIO_MMD_VEND1, i, val[k++]);
++	}
++
++	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
++	/* ResetSyncOffset = 6 */
++	__phy_write(phydev, 0x11, 0x600);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x8fc0);
++
++	/* VgaDecRate = 1 */
++	__phy_write(phydev, 0x11, 0x4c2a);
++	__phy_write(phydev, 0x12, 0x3e);
++	__phy_write(phydev, 0x10, 0x8fa4);
++
++	/* MrvlTrFix100Kp = 3, MrvlTrFix100Kf = 2,
++	 * MrvlTrFix1000Kp = 3, MrvlTrFix1000Kf = 2
++	 */
++	__phy_write(phydev, 0x11, 0xd10a);
++	__phy_write(phydev, 0x12, 0x34);
++	__phy_write(phydev, 0x10, 0x8f82);
++
++	/* VcoSlicerThreshBitsHigh */
++	__phy_write(phydev, 0x11, 0x5555);
++	__phy_write(phydev, 0x12, 0x55);
++	__phy_write(phydev, 0x10, 0x8ec0);
++	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++
++	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 9 */
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG234,
++		       MTK_PHY_TR_OPEN_LOOP_EN_MASK |
++		       MTK_PHY_LPF_X_AVERAGE_MASK,
++		       BIT(0) | FIELD_PREP(MTK_PHY_LPF_X_AVERAGE_MASK, 0x9));
++
++	/* rg_tr_lpf_cnt_val = 512 */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LPF_CNT_VAL, 0x200);
++
++	/* IIR2 related */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K1_L, 0x82);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K1_U, 0x0);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K2_L, 0x103);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K2_U, 0x0);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K3_L, 0x82);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K3_U, 0x0);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K4_L, 0xd177);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K4_U, 0x3);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K5_L, 0x2c82);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LP_IIR2_K5_U, 0xe);
++
++	/* FFE peaking */
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG27C,
++		       MTK_PHY_VGASTATE_FFE_THR_ST1_MASK, 0x1b << 8);
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG27D,
++		       MTK_PHY_VGASTATE_FFE_THR_ST2_MASK, 0x1e);
++
++	/* Disable LDO pump */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_LDO_PUMP_EN_PAIRAB, 0x0);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_LDO_PUMP_EN_PAIRCD, 0x0);
++	/* Adjust LDO output voltage */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_LDO_OUTPUT_V, 0x2222);
++}
++
++static void mt7988_phy_finetune(struct phy_device *phydev)
++{
++	u16 val[12] = { 0x0187, 0x01cd, 0x01c8, 0x0182,
++			0x020d, 0x0206, 0x0384, 0x03d0,
++			0x03c6, 0x030a, 0x0011, 0x0005 };
++	int i;
++
++	/* Set default MLT3 shaper first */
++	for (i = 0; i < 12; i++)
++		phy_write_mmd(phydev, MDIO_MMD_VEND1, i, val[i]);
++
++	/* TCT finetune */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_TX_FILTER, 0x5);
++
++	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
++	/* ResetSyncOffset = 5 */
++	__phy_write(phydev, 0x11, 0x500);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x8fc0);
++
++	/* VgaDecRate is 1 at default on mt7988 */
++
++	/* MrvlTrFix100Kp = 6, MrvlTrFix100Kf = 7,
++	 * MrvlTrFix1000Kp = 6, MrvlTrFix1000Kf = 7
++	 */
++	__phy_write(phydev, 0x11, 0xb90a);
++	__phy_write(phydev, 0x12, 0x6f);
++	__phy_write(phydev, 0x10, 0x8f82);
++
++	/* RemAckCntLimitCtrl = 1 */
++	__phy_write(phydev, 0x11, 0xfbba);
++	__phy_write(phydev, 0x12, 0xc3);
++	__phy_write(phydev, 0x10, 0x87f8);
++
++	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++
++	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 10 */
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG234,
++		       MTK_PHY_TR_OPEN_LOOP_EN_MASK |
++		       MTK_PHY_LPF_X_AVERAGE_MASK,
++		       BIT(0) | FIELD_PREP(MTK_PHY_LPF_X_AVERAGE_MASK, 0xa));
++
++	/* rg_tr_lpf_cnt_val = 1023 */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_LPF_CNT_VAL, 0x3ff);
++}
++
++static void mt798x_phy_eee(struct phy_device *phydev)
++{
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
++		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG120,
++		       MTK_PHY_LPI_SIG_EN_LO_THRESH1000_MASK |
++		       MTK_PHY_LPI_SIG_EN_HI_THRESH1000_MASK,
++		       FIELD_PREP(MTK_PHY_LPI_SIG_EN_LO_THRESH1000_MASK, 0x0) |
++		       FIELD_PREP(MTK_PHY_LPI_SIG_EN_HI_THRESH1000_MASK, 0x14));
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
++		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122,
++		       MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
++		       FIELD_PREP(MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
++				  0xff));
++
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++			   MTK_PHY_RG_TESTMUX_ADC_CTRL,
++			   MTK_PHY_RG_TXEN_DIG_MASK);
++
++	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
++			 MTK_PHY_RG_DEV1E_REG19b, MTK_PHY_BYPASS_DSP_LPI_READY);
++
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1,
++			   MTK_PHY_RG_DEV1E_REG234, MTK_PHY_TR_LP_IIR_EEE_EN);
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG238,
++		       MTK_PHY_LPI_SLV_SEND_TX_TIMER_MASK |
++		       MTK_PHY_LPI_SLV_SEND_TX_EN,
++		       FIELD_PREP(MTK_PHY_LPI_SLV_SEND_TX_TIMER_MASK, 0x120));
++
++	/* Keep MTK_PHY_LPI_SEND_LOC_TIMER as 375 */
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG239,
++			   MTK_PHY_LPI_TXPCS_LOC_RCV);
++
++	/* This also fixes some IoT issues, such as CH340 */
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG2C7,
++		       MTK_PHY_MAX_GAIN_MASK | MTK_PHY_MIN_GAIN_MASK,
++		       FIELD_PREP(MTK_PHY_MAX_GAIN_MASK, 0x8) |
++		       FIELD_PREP(MTK_PHY_MIN_GAIN_MASK, 0x13));
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG2D1,
++		       MTK_PHY_VCO_SLICER_THRESH_BITS_HIGH_EEE_MASK,
++		       FIELD_PREP(MTK_PHY_VCO_SLICER_THRESH_BITS_HIGH_EEE_MASK,
++				  0x33) |
++		       MTK_PHY_LPI_SKIP_SD_SLV_TR | MTK_PHY_LPI_TR_READY |
++		       MTK_PHY_LPI_VCO_EEE_STG0_EN);
++
++	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG323,
++			 MTK_PHY_EEE_WAKE_MAS_INT_DC |
++			 MTK_PHY_EEE_WAKE_SLV_INT_DC);
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG324,
++		       MTK_PHY_SMI_DETCNT_MAX_MASK,
++		       FIELD_PREP(MTK_PHY_SMI_DETCNT_MAX_MASK, 0x3f) |
++		       MTK_PHY_SMI_DET_MAX_EN);
++
++	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_DEV1E_REG326,
++			 MTK_PHY_LPI_MODE_SD_ON | MTK_PHY_RESET_RANDUPD_CNT |
++			 MTK_PHY_TREC_UPDATE_ENAB_CLR |
++			 MTK_PHY_LPI_QUIT_WAIT_DFE_SIG_DET_OFF |
++			 MTK_PHY_TR_READY_SKIP_AFE_WAKEUP);
++
++	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
++	/* Regsigdet_sel_1000 = 0 */
++	__phy_write(phydev, 0x11, 0xb);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x9690);
++
++	/* REG_EEE_st2TrKf1000 = 2 */
++	__phy_write(phydev, 0x11, 0x114f);
++	__phy_write(phydev, 0x12, 0x2);
++	__phy_write(phydev, 0x10, 0x969a);
++
++	/* RegEEE_slv_wake_tr_timer_tar = 6, RegEEE_slv_remtx_timer_tar = 20 */
++	__phy_write(phydev, 0x11, 0x3028);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x969e);
++
++	/* RegEEE_slv_wake_int_timer_tar = 8 */
++	__phy_write(phydev, 0x11, 0x5010);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x96a0);
++
++	/* RegEEE_trfreeze_timer2 = 586 */
++	__phy_write(phydev, 0x11, 0x24a);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x96a8);
++
++	/* RegEEE100Stg1_tar = 16 */
++	__phy_write(phydev, 0x11, 0x3210);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x96b8);
++
++	/* REGEEE_wake_slv_tr_wait_dfesigdet_en = 0 */
++	__phy_write(phydev, 0x11, 0x1463);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x96ca);
++
++	/* DfeTailEnableVgaThresh1000 = 27 */
++	__phy_write(phydev, 0x11, 0x36);
++	__phy_write(phydev, 0x12, 0x0);
++	__phy_write(phydev, 0x10, 0x8f80);
++	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++
++	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_3);
++	__phy_modify(phydev, MTK_PHY_LPI_REG_14,
++		     MTK_PHY_LPI_WAKE_TIMER_1000_MASK,
++		     FIELD_PREP(MTK_PHY_LPI_WAKE_TIMER_1000_MASK, 0x19c));
++
++	__phy_modify(phydev, MTK_PHY_LPI_REG_1c, MTK_PHY_SMI_DET_ON_THRESH_MASK,
++		     FIELD_PREP(MTK_PHY_SMI_DET_ON_THRESH_MASK, 0xc));
++	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
++		       MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG122,
++		       MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
++		       FIELD_PREP(MTK_PHY_LPI_NORM_MSE_HI_THRESH1000_MASK,
++				  0xff));
++}
++
++static int cal_sw(struct phy_device *phydev, enum CAL_ITEM cal_item,
++		  u8 start_pair, u8 end_pair)
++{
++	u8 pair_n;
++	int ret;
++
++	for (pair_n = start_pair; pair_n <= end_pair; pair_n++) {
++		/* TX_OFFSET & TX_AMP have no SW calibration. */
++		switch (cal_item) {
++		case TX_VCM:
++			ret = tx_vcm_cal_sw(phydev, pair_n);
++			break;
++		default:
++			return -EINVAL;
++		}
++		if (ret)
++			return ret;
++	}
++	return 0;
++}
++
++static int cal_efuse(struct phy_device *phydev, enum CAL_ITEM cal_item,
++		     u8 start_pair, u8 end_pair, u32 *buf)
++{
++	u8 pair_n;
++	int ret;
++
++	for (pair_n = start_pair; pair_n <= end_pair; pair_n++) {
++		/* TX_VCM has no efuse calibration. */
++		switch (cal_item) {
++		case REXT:
++			ret = rext_cal_efuse(phydev, buf);
++			break;
++		case TX_OFFSET:
++			ret = tx_offset_cal_efuse(phydev, buf);
++			break;
++		case TX_AMP:
++			ret = tx_amp_cal_efuse(phydev, buf);
++			break;
++		case TX_R50:
++			ret = tx_r50_cal_efuse(phydev, buf, pair_n);
++			break;
++		default:
++			return -EINVAL;
++		}
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int start_cal(struct phy_device *phydev, enum CAL_ITEM cal_item,
++		     enum CAL_MODE cal_mode, u8 start_pair,
++		     u8 end_pair, u32 *buf)
++{
++	int ret;
++
++	switch (cal_mode) {
++	case EFUSE_M:
++		ret = cal_efuse(phydev, cal_item, start_pair,
++				end_pair, buf);
++		break;
++	case SW_M:
++		ret = cal_sw(phydev, cal_item, start_pair, end_pair);
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	if (ret) {
++		phydev_err(phydev, "cal %d failed\n", cal_item);
++		return -EIO;
++	}
++
++	return 0;
++}
++
++static int mt798x_phy_calibration(struct phy_device *phydev)
++{
++	struct nvmem_cell *cell;
++	int ret = 0;
++	size_t len;
++	u32 *buf;
++
++	cell = nvmem_cell_get(&phydev->mdio.dev, "phy-cal-data");
++	if (IS_ERR(cell)) {
++		if (PTR_ERR(cell) == -EPROBE_DEFER)
++			return PTR_ERR(cell);
++		return 0;
++	}
++
++	buf = (u32 *)nvmem_cell_read(cell, &len);
++	if (IS_ERR(buf))
++		return PTR_ERR(buf);
++	nvmem_cell_put(cell);
++
++	if (!buf[0] || !buf[1] || !buf[2] || !buf[3] || len < 4 * sizeof(u32)) {
++		phydev_err(phydev, "invalid efuse data\n");
++		ret = -EINVAL;
++		goto out;
++	}
++
++	ret = start_cal(phydev, REXT, EFUSE_M, NO_PAIR, NO_PAIR, buf);
++	if (ret)
++		goto out;
++	ret = start_cal(phydev, TX_OFFSET, EFUSE_M, NO_PAIR, NO_PAIR, buf);
++	if (ret)
++		goto out;
++	ret = start_cal(phydev, TX_AMP, EFUSE_M, NO_PAIR, NO_PAIR, buf);
++	if (ret)
++		goto out;
++	ret = start_cal(phydev, TX_R50, EFUSE_M, PAIR_A, PAIR_D, buf);
++	if (ret)
++		goto out;
++	ret = start_cal(phydev, TX_VCM, SW_M, PAIR_A, PAIR_A, buf);
++	if (ret)
++		goto out;
++
++out:
++	kfree(buf);
++	return ret;
++}
++
++static int mt798x_phy_config_init(struct phy_device *phydev)
++{
++	switch (phydev->drv->phy_id) {
++	case MTK_GPHY_ID_MT7981:
++		mt7981_phy_finetune(phydev);
++		break;
++	case MTK_GPHY_ID_MT7988:
++		mt7988_phy_finetune(phydev);
++		break;
++	}
++
++	mt798x_phy_common_finetune(phydev);
++	mt798x_phy_eee(phydev);
++
++	return mt798x_phy_calibration(phydev);
++}
++
++static int mt798x_phy_hw_led_on_set(struct phy_device *phydev, u8 index,
++				    bool on)
++{
++	unsigned int bit_on = MTK_PHY_LED_STATE_FORCE_ON + (index ? 16 : 0);
++	struct mtk_socphy_priv *priv = phydev->priv;
++	bool changed;
++
++	if (on)
++		changed = !test_and_set_bit(bit_on, &priv->led_state);
++	else
++		changed = !!test_and_clear_bit(bit_on, &priv->led_state);
++
++	changed |= !!test_and_clear_bit(MTK_PHY_LED_STATE_NETDEV +
++					(index ? 16 : 0), &priv->led_state);
++	if (changed)
++		return phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
++				      MTK_PHY_LED1_ON_CTRL :
++				      MTK_PHY_LED0_ON_CTRL,
++				      MTK_PHY_LED_ON_MASK,
++				      on ? MTK_PHY_LED_ON_FORCE_ON : 0);
++	else
++		return 0;
++}
++
++static int mt798x_phy_hw_led_blink_set(struct phy_device *phydev, u8 index,
++				       bool blinking)
++{
++	unsigned int bit_blink = MTK_PHY_LED_STATE_FORCE_BLINK +
++				 (index ? 16 : 0);
++	struct mtk_socphy_priv *priv = phydev->priv;
++	bool changed;
++
++	if (blinking)
++		changed = !test_and_set_bit(bit_blink, &priv->led_state);
++	else
++		changed = !!test_and_clear_bit(bit_blink, &priv->led_state);
++
++	changed |= !!test_bit(MTK_PHY_LED_STATE_NETDEV +
++			      (index ? 16 : 0), &priv->led_state);
++	if (changed)
++		return phy_write_mmd(phydev, MDIO_MMD_VEND2, index ?
++				     MTK_PHY_LED1_BLINK_CTRL :
++				     MTK_PHY_LED0_BLINK_CTRL,
++				     blinking ?
++				     MTK_PHY_LED_BLINK_FORCE_BLINK : 0);
++	else
++		return 0;
++}
++
++static int mt798x_phy_led_blink_set(struct phy_device *phydev, u8 index,
++				    unsigned long *delay_on,
++				    unsigned long *delay_off)
++{
++	bool blinking = false;
++	int err = 0;
++
++	if (index > 1)
++		return -EINVAL;
++
++	if (delay_on && delay_off && (*delay_on > 0) && (*delay_off > 0)) {
++		blinking = true;
++		*delay_on = 50;
++		*delay_off = 50;
++	}
++
++	err = mt798x_phy_hw_led_blink_set(phydev, index, blinking);
++	if (err)
++		return err;
++
++	return mt798x_phy_hw_led_on_set(phydev, index, false);
++}
++
++static int mt798x_phy_led_brightness_set(struct phy_device *phydev,
++					 u8 index, enum led_brightness value)
++{
++	int err;
++
++	err = mt798x_phy_hw_led_blink_set(phydev, index, false);
++	if (err)
++		return err;
++
++	return mt798x_phy_hw_led_on_set(phydev, index, (value != LED_OFF));
++}
++
++static const unsigned long supported_triggers =
++	BIT(TRIGGER_NETDEV_FULL_DUPLEX) |
++	BIT(TRIGGER_NETDEV_HALF_DUPLEX) |
++	BIT(TRIGGER_NETDEV_LINK)        |
++	BIT(TRIGGER_NETDEV_LINK_10)     |
++	BIT(TRIGGER_NETDEV_LINK_100)    |
++	BIT(TRIGGER_NETDEV_LINK_1000)   |
++	BIT(TRIGGER_NETDEV_RX)          |
++	BIT(TRIGGER_NETDEV_TX);
++
++static int mt798x_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
++					  unsigned long rules)
++{
++	if (index > 1)
++		return -EINVAL;
++
++	/* All combinations of the supported triggers are allowed */
++	if (rules & ~supported_triggers)
++		return -EOPNOTSUPP;
++
++	return 0;
++};
++
++static int mt798x_phy_led_hw_control_get(struct phy_device *phydev, u8 index,
++					 unsigned long *rules)
++{
++	unsigned int bit_blink = MTK_PHY_LED_STATE_FORCE_BLINK +
++				 (index ? 16 : 0);
++	unsigned int bit_netdev = MTK_PHY_LED_STATE_NETDEV + (index ? 16 : 0);
++	unsigned int bit_on = MTK_PHY_LED_STATE_FORCE_ON + (index ? 16 : 0);
++	struct mtk_socphy_priv *priv = phydev->priv;
++	int on, blink;
++
++	if (index > 1)
++		return -EINVAL;
++
++	on = phy_read_mmd(phydev, MDIO_MMD_VEND2,
++			  index ? MTK_PHY_LED1_ON_CTRL : MTK_PHY_LED0_ON_CTRL);
++
++	if (on < 0)
++		return -EIO;
++
++	blink = phy_read_mmd(phydev, MDIO_MMD_VEND2,
++			     index ? MTK_PHY_LED1_BLINK_CTRL :
++				     MTK_PHY_LED0_BLINK_CTRL);
++	if (blink < 0)
++		return -EIO;
++
++	if ((on & (MTK_PHY_LED_ON_LINK | MTK_PHY_LED_ON_FDX |
++		   MTK_PHY_LED_ON_HDX | MTK_PHY_LED_ON_LINKDOWN)) ||
++	    (blink & (MTK_PHY_LED_BLINK_RX | MTK_PHY_LED_BLINK_TX)))
++		set_bit(bit_netdev, &priv->led_state);
++	else
++		clear_bit(bit_netdev, &priv->led_state);
++
++	if (on & MTK_PHY_LED_ON_FORCE_ON)
++		set_bit(bit_on, &priv->led_state);
++	else
++		clear_bit(bit_on, &priv->led_state);
++
++	if (blink & MTK_PHY_LED_BLINK_FORCE_BLINK)
++		set_bit(bit_blink, &priv->led_state);
++	else
++		clear_bit(bit_blink, &priv->led_state);
++
++	if (!rules)
++		return 0;
++
++	if (on & MTK_PHY_LED_ON_LINK)
++		*rules |= BIT(TRIGGER_NETDEV_LINK);
++
++	if (on & MTK_PHY_LED_ON_LINK10)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_10);
++
++	if (on & MTK_PHY_LED_ON_LINK100)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_100);
++
++	if (on & MTK_PHY_LED_ON_LINK1000)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_1000);
++
++	if (on & MTK_PHY_LED_ON_FDX)
++		*rules |= BIT(TRIGGER_NETDEV_FULL_DUPLEX);
++
++	if (on & MTK_PHY_LED_ON_HDX)
++		*rules |= BIT(TRIGGER_NETDEV_HALF_DUPLEX);
++
++	if (blink & MTK_PHY_LED_BLINK_RX)
++		*rules |= BIT(TRIGGER_NETDEV_RX);
++
++	if (blink & MTK_PHY_LED_BLINK_TX)
++		*rules |= BIT(TRIGGER_NETDEV_TX);
++
++	return 0;
++};
++
++static int mt798x_phy_led_hw_control_set(struct phy_device *phydev, u8 index,
++					 unsigned long rules)
++{
++	unsigned int bit_netdev = MTK_PHY_LED_STATE_NETDEV + (index ? 16 : 0);
++	struct mtk_socphy_priv *priv = phydev->priv;
++	u16 on = 0, blink = 0;
++	int ret;
++
++	if (index > 1)
++		return -EINVAL;
++
++	if (rules & BIT(TRIGGER_NETDEV_FULL_DUPLEX))
++		on |= MTK_PHY_LED_ON_FDX;
++
++	if (rules & BIT(TRIGGER_NETDEV_HALF_DUPLEX))
++		on |= MTK_PHY_LED_ON_HDX;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_10) | BIT(TRIGGER_NETDEV_LINK)))
++		on |= MTK_PHY_LED_ON_LINK10;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_100) | BIT(TRIGGER_NETDEV_LINK)))
++		on |= MTK_PHY_LED_ON_LINK100;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_1000) | BIT(TRIGGER_NETDEV_LINK)))
++		on |= MTK_PHY_LED_ON_LINK1000;
++
++	if (rules & BIT(TRIGGER_NETDEV_RX)) {
++		blink |= (on & MTK_PHY_LED_ON_LINK) ?
++			  (((on & MTK_PHY_LED_ON_LINK10) ?
++			    MTK_PHY_LED_BLINK_10RX : 0) |
++			   ((on & MTK_PHY_LED_ON_LINK100) ?
++			    MTK_PHY_LED_BLINK_100RX : 0) |
++			   ((on & MTK_PHY_LED_ON_LINK1000) ?
++			    MTK_PHY_LED_BLINK_1000RX : 0)) :
++			  MTK_PHY_LED_BLINK_RX;
++	}
++
++	if (rules & BIT(TRIGGER_NETDEV_TX)) {
++		blink |= (on & MTK_PHY_LED_ON_LINK) ?
++			  (((on & MTK_PHY_LED_ON_LINK10) ?
++			    MTK_PHY_LED_BLINK_10TX : 0) |
++			   ((on & MTK_PHY_LED_ON_LINK100) ?
++			    MTK_PHY_LED_BLINK_100TX : 0) |
++			   ((on & MTK_PHY_LED_ON_LINK1000) ?
++			    MTK_PHY_LED_BLINK_1000TX : 0)) :
++			  MTK_PHY_LED_BLINK_TX;
++	}
++
++	if (blink || on)
++		set_bit(bit_netdev, &priv->led_state);
++	else
++		clear_bit(bit_netdev, &priv->led_state);
++
++	ret = phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
++				MTK_PHY_LED1_ON_CTRL :
++				MTK_PHY_LED0_ON_CTRL,
++			     MTK_PHY_LED_ON_FDX     |
++			     MTK_PHY_LED_ON_HDX     |
++			     MTK_PHY_LED_ON_LINK,
++			     on);
++
++	if (ret)
++		return ret;
++
++	return phy_write_mmd(phydev, MDIO_MMD_VEND2, index ?
++				MTK_PHY_LED1_BLINK_CTRL :
++				MTK_PHY_LED0_BLINK_CTRL, blink);
++};
++
++static bool mt7988_phy_led_get_polarity(struct phy_device *phydev, int led_num)
++{
++	struct mtk_socphy_shared *priv = phydev->shared->priv;
++	u32 polarities;
++
++	if (led_num == 0)
++		polarities = ~(priv->boottrap);
++	else
++		polarities = MTK_PHY_LED1_DEFAULT_POLARITIES;
++
++	if (polarities & BIT(phydev->mdio.addr))
++		return true;
++
++	return false;
++}
++
++static int mt7988_phy_fix_leds_polarities(struct phy_device *phydev)
++{
++	struct pinctrl *pinctrl;
++	int index;
++
++	/* Setup LED polarity according to bootstrap use of LED pins */
++	for (index = 0; index < 2; ++index)
++		phy_modify_mmd(phydev, MDIO_MMD_VEND2, index ?
++				MTK_PHY_LED1_ON_CTRL : MTK_PHY_LED0_ON_CTRL,
++			       MTK_PHY_LED_ON_POLARITY,
++			       mt7988_phy_led_get_polarity(phydev, index) ?
++				MTK_PHY_LED_ON_POLARITY : 0);
++
++	/* Only now setup pinctrl to avoid bogus blinking */
++	pinctrl = devm_pinctrl_get_select(&phydev->mdio.dev, "gbe-led");
++	if (IS_ERR(pinctrl))
++		dev_err(&phydev->mdio.bus->dev,
++			"Failed to setup PHY LED pinctrl\n");
++
++	return 0;
++}
++
++static int mt7988_phy_probe_shared(struct phy_device *phydev)
++{
++	struct device_node *np = dev_of_node(&phydev->mdio.bus->dev);
++	struct mtk_socphy_shared *shared = phydev->shared->priv;
++	struct regmap *regmap;
++	u32 reg;
++	int ret;
++
++	/* The LED0 of the 4 PHYs in MT7988 are wired to SoC pins LED_A, LED_B,
++	 * LED_C and LED_D respectively. At the same time those pins are used to
++	 * bootstrap configuration of the reference clock source (LED_A),
++	 * DRAM DDRx16b x2/x1 (LED_B) and boot device (LED_C, LED_D).
++	 * In practice this is done using a LED and a resistor pulling the pin
++	 * either to GND or to VIO.
++	 * The detected value at boot time is accessible at run-time using the
++	 * TPBANK0 register located in the gpio base of the pinctrl, in order
++	 * to read it here it needs to be referenced by a phandle called
++	 * 'mediatek,pio' in the MDIO bus hosting the PHY.
++	 * The 4 bits in TPBANK0 are kept as package shared data and are used to
++	 * set LED polarity for each of the LED0.
++	 */
++	regmap = syscon_regmap_lookup_by_phandle(np, "mediatek,pio");
++	if (IS_ERR(regmap))
++		return PTR_ERR(regmap);
++
++	ret = regmap_read(regmap, RG_GPIO_MISC_TPBANK0, &reg);
++	if (ret)
++		return ret;
++
++	shared->boottrap = FIELD_GET(RG_GPIO_MISC_TPBANK0_BOOTMODE, reg);
++
++	return 0;
++}
++
++static void mt798x_phy_leds_state_init(struct phy_device *phydev)
++{
++	int i;
++
++	for (i = 0; i < 2; ++i)
++		mt798x_phy_led_hw_control_get(phydev, i, NULL);
++}
++
++static int mt7988_phy_probe(struct phy_device *phydev)
++{
++	struct mtk_socphy_shared *shared;
++	struct mtk_socphy_priv *priv;
++	int err;
++
++	if (phydev->mdio.addr > 3)
++		return -EINVAL;
++
++	err = devm_phy_package_join(&phydev->mdio.dev, phydev, 0,
++				    sizeof(struct mtk_socphy_shared));
++	if (err)
++		return err;
++
++	if (phy_package_probe_once(phydev)) {
++		err = mt7988_phy_probe_shared(phydev);
++		if (err)
++			return err;
++	}
++
++	shared = phydev->shared->priv;
++	priv = &shared->priv[phydev->mdio.addr];
++
++	phydev->priv = priv;
++
++	mt798x_phy_leds_state_init(phydev);
++
++	err = mt7988_phy_fix_leds_polarities(phydev);
++	if (err)
++		return err;
++
++	/* Disable TX power saving at probing to:
++	 * 1. Meet common mode compliance test criteria
++	 * 2. Make sure that TX-VCM calibration works fine
++	 */
++	phy_modify_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RXADC_CTRL_RG7,
++		       MTK_PHY_DA_AD_BUF_BIAS_LP_MASK, 0x3 << 8);
++
++	return mt798x_phy_calibration(phydev);
++}
++
++static int mt7981_phy_probe(struct phy_device *phydev)
++{
++	struct mtk_socphy_priv *priv;
++
++	priv = devm_kzalloc(&phydev->mdio.dev, sizeof(struct mtk_socphy_priv),
++			    GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	phydev->priv = priv;
++
++	mt798x_phy_leds_state_init(phydev);
++
++	return mt798x_phy_calibration(phydev);
++}
++
++static struct phy_driver mtk_socphy_driver[] = {
++	{
++		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981),
++		.name		= "MediaTek MT7981 PHY",
++		.config_init	= mt798x_phy_config_init,
++		.config_intr	= genphy_no_config_intr,
++		.handle_interrupt = genphy_handle_interrupt_no_ack,
++		.probe		= mt7981_phy_probe,
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_page	= mtk_socphy_read_page,
++		.write_page	= mtk_socphy_write_page,
++		.led_blink_set	= mt798x_phy_led_blink_set,
++		.led_brightness_set = mt798x_phy_led_brightness_set,
++		.led_hw_is_supported = mt798x_phy_led_hw_is_supported,
++		.led_hw_control_set = mt798x_phy_led_hw_control_set,
++		.led_hw_control_get = mt798x_phy_led_hw_control_get,
++	},
++	{
++		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7988),
++		.name		= "MediaTek MT7988 PHY",
++		.config_init	= mt798x_phy_config_init,
++		.config_intr	= genphy_no_config_intr,
++		.handle_interrupt = genphy_handle_interrupt_no_ack,
++		.probe		= mt7988_phy_probe,
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_page	= mtk_socphy_read_page,
++		.write_page	= mtk_socphy_write_page,
++		.led_blink_set	= mt798x_phy_led_blink_set,
++		.led_brightness_set = mt798x_phy_led_brightness_set,
++		.led_hw_is_supported = mt798x_phy_led_hw_is_supported,
++		.led_hw_control_set = mt798x_phy_led_hw_control_set,
++		.led_hw_control_get = mt798x_phy_led_hw_control_get,
++	},
++};
++
++module_phy_driver(mtk_socphy_driver);
++
++static struct mdio_device_id __maybe_unused mtk_socphy_tbl[] = {
++	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981) },
++	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7988) },
++	{ }
++};
++
++MODULE_DESCRIPTION("MediaTek SoC Gigabit Ethernet PHY driver");
++MODULE_AUTHOR("Daniel Golle <daniel@makrotopia.org>");
++MODULE_AUTHOR("SkyLake Huang <SkyLake.Huang@mediatek.com>");
++MODULE_LICENSE("GPL");
++
++MODULE_DEVICE_TABLE(mdio, mtk_socphy_tbl);
+--- /dev/null
++++ b/drivers/net/phy/mediatek/mtk-ge.c
+@@ -0,0 +1,148 @@
++// SPDX-License-Identifier: GPL-2.0+
++#include <linux/of.h>
++#include <linux/bitfield.h>
++#include <linux/module.h>
++#include <linux/phy.h>
++
++#define MTK_EXT_PAGE_ACCESS		0x1f
++#define MTK_PHY_PAGE_STANDARD		0x0000
++#define MTK_PHY_PAGE_EXTENDED		0x0001
++#define MTK_PHY_PAGE_EXTENDED_2		0x0002
++#define MTK_PHY_PAGE_EXTENDED_3		0x0003
++#define MTK_PHY_PAGE_EXTENDED_2A30	0x2a30
++#define MTK_PHY_PAGE_EXTENDED_52B5	0x52b5
++
++static int mtk_gephy_read_page(struct phy_device *phydev)
++{
++	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
++}
++
++static int mtk_gephy_write_page(struct phy_device *phydev, int page)
++{
++	return __phy_write(phydev, MTK_EXT_PAGE_ACCESS, page);
++}
++
++static void mtk_gephy_config_init(struct phy_device *phydev)
++{
++	/* Disable EEE */
++	phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV, 0);
++
++	/* Enable HW auto downshift */
++	phy_modify_paged(phydev, MTK_PHY_PAGE_EXTENDED, 0x14, 0, BIT(4));
++
++	/* Increase SlvDPSready time */
++	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
++	__phy_write(phydev, 0x10, 0xafae);
++	__phy_write(phydev, 0x12, 0x2f);
++	__phy_write(phydev, 0x10, 0x8fae);
++	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
++
++	/* Adjust 100_mse_threshold */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x123, 0xffff);
++
++	/* Disable mcc */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0xa6, 0x300);
++}
++
++static int mt7530_phy_config_init(struct phy_device *phydev)
++{
++	mtk_gephy_config_init(phydev);
++
++	/* Increase post_update_timer */
++	phy_write_paged(phydev, MTK_PHY_PAGE_EXTENDED_3, 0x11, 0x4b);
++
++	return 0;
++}
++
++static int mt7530_led_config_of(struct phy_device *phydev)
++{
++	struct device_node *np = phydev->mdio.dev.of_node;
++	const __be32 *paddr;
++	int len;
++	int i;
++
++	paddr = of_get_property(np, "mediatek,led-config", &len);
++	if (!paddr)
++		return 0;
++
++	if (len < (2 * sizeof(*paddr)))
++		return -EINVAL;
++
++	len /= sizeof(*paddr);
++
++	phydev_warn(phydev, "Configure LED registers (num=%d)\n", len);
++	for (i = 0; i < len - 1; i += 2) {
++		u32 reg;
++		u32 val;
++
++		reg = be32_to_cpup(paddr + i);
++		val = be32_to_cpup(paddr + i + 1);
++
++		phy_write_mmd(phydev, MDIO_MMD_VEND2, reg, val);
++	}
++
++	return 0;
++}
++
++static int mt7531_phy_config_init(struct phy_device *phydev)
++{
++	mtk_gephy_config_init(phydev);
++
++	/* PHY link down power saving enable */
++	phy_set_bits(phydev, 0x17, BIT(4));
++	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, 0xc6, 0x300);
++
++	/* Set TX Pair delay selection */
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x13, 0x404);
++	phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x14, 0x404);
++
++	/* LED Config*/
++	mt7530_led_config_of(phydev);
++
++	return 0;
++}
++
++static struct phy_driver mtk_gephy_driver[] = {
++	{
++		PHY_ID_MATCH_EXACT(0x03a29412),
++		.name		= "MediaTek MT7530 PHY",
++		.config_init	= mt7530_phy_config_init,
++		/* Interrupts are handled by the switch, not the PHY
++		 * itself.
++		 */
++		.config_intr	= genphy_no_config_intr,
++		.handle_interrupt = genphy_handle_interrupt_no_ack,
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_page	= mtk_gephy_read_page,
++		.write_page	= mtk_gephy_write_page,
++	},
++	{
++		PHY_ID_MATCH_EXACT(0x03a29441),
++		.name		= "MediaTek MT7531 PHY",
++		.config_init	= mt7531_phy_config_init,
++		/* Interrupts are handled by the switch, not the PHY
++		 * itself.
++		 */
++		.config_intr	= genphy_no_config_intr,
++		.handle_interrupt = genphy_handle_interrupt_no_ack,
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_page	= mtk_gephy_read_page,
++		.write_page	= mtk_gephy_write_page,
++	},
++};
++
++module_phy_driver(mtk_gephy_driver);
++
++static struct mdio_device_id __maybe_unused mtk_gephy_tbl[] = {
++	{ PHY_ID_MATCH_EXACT(0x03a29441) },
++	{ PHY_ID_MATCH_EXACT(0x03a29412) },
++	{ }
++};
++
++MODULE_DESCRIPTION("MediaTek Gigabit Ethernet PHY driver");
++MODULE_AUTHOR("DENG, Qingfang <dqfext@gmail.com>");
++MODULE_LICENSE("GPL");
++
++MODULE_DEVICE_TABLE(mdio, mtk_gephy_tbl);

--- a/target/linux/airoha/patches-6.6/056-v6.13-net-phy-mediatek-Move-LED-helper-functions-into-mtk-.patch
+++ b/target/linux/airoha/patches-6.6/056-v6.13-net-phy-mediatek-Move-LED-helper-functions-into-mtk-.patch
@@ -22,8 +22,6 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  create mode 100644 drivers/net/phy/mediatek/mtk-phy-lib.c
  create mode 100644 drivers/net/phy/mediatek/mtk.h
 
-diff --git a/drivers/net/phy/mediatek/Kconfig b/drivers/net/phy/mediatek/Kconfig
-index 112d9c0f219c..19b5d23e7cd0 100644
 --- a/drivers/net/phy/mediatek/Kconfig
 +++ b/drivers/net/phy/mediatek/Kconfig
 @@ -1,4 +1,7 @@
@@ -42,8 +40,6 @@ index 112d9c0f219c..19b5d23e7cd0 100644
  	help
  	  Supports MediaTek SoC built-in Gigabit Ethernet PHYs.
  
-diff --git a/drivers/net/phy/mediatek/Makefile b/drivers/net/phy/mediatek/Makefile
-index 005bde26c1d7..814879d0abe5 100644
 --- a/drivers/net/phy/mediatek/Makefile
 +++ b/drivers/net/phy/mediatek/Makefile
 @@ -1,3 +1,4 @@
@@ -51,8 +47,6 @@ index 005bde26c1d7..814879d0abe5 100644
 +obj-$(CONFIG_MTK_NET_PHYLIB)		+= mtk-phy-lib.o
  obj-$(CONFIG_MEDIATEK_GE_PHY)		+= mtk-ge.o
  obj-$(CONFIG_MEDIATEK_GE_SOC_PHY)	+= mtk-ge-soc.o
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index a931832b1418..d3a8b3946056 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
 @@ -8,6 +8,8 @@
@@ -121,7 +115,7 @@ index a931832b1418..d3a8b3946056 100644
  struct mtk_socphy_shared {
  	u32			boottrap;
  	struct mtk_socphy_priv	priv[4];
-@@ -1172,76 +1131,23 @@ static int mt798x_phy_config_init(struct phy_device *phydev)
+@@ -1172,76 +1131,23 @@ static int mt798x_phy_config_init(struct
  	return mt798x_phy_calibration(phydev);
  }
  
@@ -205,7 +199,7 @@ index a931832b1418..d3a8b3946056 100644
  }
  
  static int mt798x_phy_led_brightness_set(struct phy_device *phydev,
-@@ -1249,11 +1155,12 @@ static int mt798x_phy_led_brightness_set(struct phy_device *phydev,
+@@ -1249,11 +1155,12 @@ static int mt798x_phy_led_brightness_set
  {
  	int err;
  
@@ -220,7 +214,7 @@ index a931832b1418..d3a8b3946056 100644
  }
  
  static const unsigned long supported_triggers =
-@@ -1269,155 +1176,26 @@ static const unsigned long supported_triggers =
+@@ -1269,155 +1176,26 @@ static const unsigned long supported_tri
  static int mt798x_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
  					  unsigned long rules)
  {
@@ -387,7 +381,7 @@ index a931832b1418..d3a8b3946056 100644
  };
  
  static bool mt7988_phy_led_get_polarity(struct phy_device *phydev, int led_num)
-@@ -1492,14 +1270,6 @@ static int mt7988_phy_probe_shared(struct phy_device *phydev)
+@@ -1492,14 +1270,6 @@ static int mt7988_phy_probe_shared(struc
  	return 0;
  }
  
@@ -402,7 +396,7 @@ index a931832b1418..d3a8b3946056 100644
  static int mt7988_phy_probe(struct phy_device *phydev)
  {
  	struct mtk_socphy_shared *shared;
-@@ -1525,7 +1295,7 @@ static int mt7988_phy_probe(struct phy_device *phydev)
+@@ -1525,7 +1295,7 @@ static int mt7988_phy_probe(struct phy_d
  
  	phydev->priv = priv;
  
@@ -411,7 +405,7 @@ index a931832b1418..d3a8b3946056 100644
  
  	err = mt7988_phy_fix_leds_polarities(phydev);
  	if (err)
-@@ -1552,7 +1322,7 @@ static int mt7981_phy_probe(struct phy_device *phydev)
+@@ -1552,7 +1322,7 @@ static int mt7981_phy_probe(struct phy_d
  
  	phydev->priv = priv;
  
@@ -420,9 +414,6 @@ index a931832b1418..d3a8b3946056 100644
  
  	return mt798x_phy_calibration(phydev);
  }
-diff --git a/drivers/net/phy/mediatek/mtk-phy-lib.c b/drivers/net/phy/mediatek/mtk-phy-lib.c
-new file mode 100644
-index 000000000000..34b0957b201b
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/mtk-phy-lib.c
 @@ -0,0 +1,254 @@
@@ -680,9 +671,6 @@ index 000000000000..34b0957b201b
 +MODULE_AUTHOR("Sky Huang <SkyLake.Huang@mediatek.com>");
 +MODULE_AUTHOR("Daniel Golle <daniel@makrotopia.org>");
 +MODULE_LICENSE("GPL");
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-new file mode 100644
-index 000000000000..9aaff2c2270d
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -0,0 +1,86 @@
@@ -772,6 +760,3 @@ index 000000000000..9aaff2c2270d
 +void mtk_phy_leds_state_init(struct phy_device *phydev);
 +
 +#endif /* _MTK_EPHY_H_ */
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/057-v6.13-net-phy-mediatek-Integrate-read-write-page-helper-fu.patch
+++ b/target/linux/airoha/patches-6.6/057-v6.13-net-phy-mediatek-Integrate-read-write-page-helper-fu.patch
@@ -17,8 +17,6 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  drivers/net/phy/mediatek/mtk.h         |  3 +++
  5 files changed, 26 insertions(+), 28 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/Kconfig b/drivers/net/phy/mediatek/Kconfig
-index 19b5d23e7cd0..2a8ac5aed0f8 100644
 --- a/drivers/net/phy/mediatek/Kconfig
 +++ b/drivers/net/phy/mediatek/Kconfig
 @@ -4,6 +4,7 @@ config MTK_NET_PHYLIB
@@ -29,8 +27,6 @@ index 19b5d23e7cd0..2a8ac5aed0f8 100644
  	help
  	  Supports the MediaTek non-built-in Gigabit Ethernet PHYs.
  
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index d3a8b3946056..38dc898eaf7b 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
 @@ -271,16 +271,6 @@ struct mtk_socphy_shared {
@@ -50,7 +46,7 @@ index d3a8b3946056..38dc898eaf7b 100644
  /* One calibration cycle consists of:
   * 1.Set DA_CALIN_FLAG high to start calibration. Keep it high
   *   until AD_CAL_COMP is ready to output calibration result.
-@@ -1337,8 +1327,8 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1337,8 +1327,8 @@ static struct phy_driver mtk_socphy_driv
  		.probe		= mt7981_phy_probe,
  		.suspend	= genphy_suspend,
  		.resume		= genphy_resume,
@@ -61,7 +57,7 @@ index d3a8b3946056..38dc898eaf7b 100644
  		.led_blink_set	= mt798x_phy_led_blink_set,
  		.led_brightness_set = mt798x_phy_led_brightness_set,
  		.led_hw_is_supported = mt798x_phy_led_hw_is_supported,
-@@ -1354,8 +1344,8 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1354,8 +1344,8 @@ static struct phy_driver mtk_socphy_driv
  		.probe		= mt7988_phy_probe,
  		.suspend	= genphy_suspend,
  		.resume		= genphy_resume,
@@ -72,11 +68,9 @@ index d3a8b3946056..38dc898eaf7b 100644
  		.led_blink_set	= mt798x_phy_led_blink_set,
  		.led_brightness_set = mt798x_phy_led_brightness_set,
  		.led_hw_is_supported = mt798x_phy_led_hw_is_supported,
-diff --git a/drivers/net/phy/mediatek/mtk-ge.c b/drivers/net/phy/mediatek/mtk-ge.c
-index 54ea64a37ab3..912289928fb3 100644
 --- a/drivers/net/phy/mediatek/mtk-ge.c
 +++ b/drivers/net/phy/mediatek/mtk-ge.c
-@@ -3,6 +3,8 @@
+@@ -4,6 +4,8 @@
  #include <linux/module.h>
  #include <linux/phy.h>
  
@@ -85,7 +79,7 @@ index 54ea64a37ab3..912289928fb3 100644
  #define MTK_EXT_PAGE_ACCESS		0x1f
  #define MTK_PHY_PAGE_STANDARD		0x0000
  #define MTK_PHY_PAGE_EXTENDED		0x0001
-@@ -11,16 +13,6 @@
+@@ -12,16 +14,6 @@
  #define MTK_PHY_PAGE_EXTENDED_2A30	0x2a30
  #define MTK_PHY_PAGE_EXTENDED_52B5	0x52b5
  
@@ -101,8 +95,8 @@ index 54ea64a37ab3..912289928fb3 100644
 -
  static void mtk_gephy_config_init(struct phy_device *phydev)
  {
- 	/* Enable HW auto downshift */
-@@ -77,8 +69,8 @@ static struct phy_driver mtk_gephy_driver[] = {
+ 	/* Disable EEE */
+@@ -114,8 +106,8 @@ static struct phy_driver mtk_gephy_drive
  		.handle_interrupt = genphy_handle_interrupt_no_ack,
  		.suspend	= genphy_suspend,
  		.resume		= genphy_resume,
@@ -113,7 +107,7 @@ index 54ea64a37ab3..912289928fb3 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(0x03a29441),
-@@ -91,8 +83,8 @@ static struct phy_driver mtk_gephy_driver[] = {
+@@ -128,8 +120,8 @@ static struct phy_driver mtk_gephy_drive
  		.handle_interrupt = genphy_handle_interrupt_no_ack,
  		.suspend	= genphy_suspend,
  		.resume		= genphy_resume,
@@ -124,8 +118,6 @@ index 54ea64a37ab3..912289928fb3 100644
  	},
  };
  
-diff --git a/drivers/net/phy/mediatek/mtk-phy-lib.c b/drivers/net/phy/mediatek/mtk-phy-lib.c
-index 8d795bcc8b2d..98a09d670e9c 100644
 --- a/drivers/net/phy/mediatek/mtk-phy-lib.c
 +++ b/drivers/net/phy/mediatek/mtk-phy-lib.c
 @@ -6,6 +6,18 @@
@@ -147,8 +139,6 @@ index 8d795bcc8b2d..98a09d670e9c 100644
  int mtk_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
  				unsigned long rules,
  				unsigned long supported_triggers)
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index 9aaff2c2270d..63d9fe179b8f 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -66,6 +66,9 @@ struct mtk_socphy_priv {
@@ -161,6 +151,3 @@ index 9aaff2c2270d..63d9fe179b8f 100644
  int mtk_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
  				unsigned long rules,
  				unsigned long supported_triggers);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/058-v6.13-net-phy-mediatek-add-MT7530-MT7531-s-PHY-ID-macros.patch
+++ b/target/linux/airoha/patches-6.6/058-v6.13-net-phy-mediatek-add-MT7530-MT7531-s-PHY-ID-macros.patch
@@ -13,11 +13,9 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  drivers/net/phy/mediatek/mtk-ge.c | 11 +++++++----
  1 file changed, 7 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge.c b/drivers/net/phy/mediatek/mtk-ge.c
-index 912289928fb3..ed2617bc20f4 100644
 --- a/drivers/net/phy/mediatek/mtk-ge.c
 +++ b/drivers/net/phy/mediatek/mtk-ge.c
-@@ -5,6 +5,9 @@
+@@ -6,6 +6,9 @@
  
  #include "mtk.h"
  
@@ -27,7 +25,7 @@ index 912289928fb3..ed2617bc20f4 100644
  #define MTK_EXT_PAGE_ACCESS		0x1f
  #define MTK_PHY_PAGE_STANDARD		0x0000
  #define MTK_PHY_PAGE_EXTENDED		0x0001
-@@ -59,7 +62,7 @@ static int mt7531_phy_config_init(struct phy_device *phydev)
+@@ -96,7 +99,7 @@ static int mt7531_phy_config_init(struct
  
  static struct phy_driver mtk_gephy_driver[] = {
  	{
@@ -36,7 +34,7 @@ index 912289928fb3..ed2617bc20f4 100644
  		.name		= "MediaTek MT7530 PHY",
  		.config_init	= mt7530_phy_config_init,
  		/* Interrupts are handled by the switch, not the PHY
-@@ -73,7 +76,7 @@ static struct phy_driver mtk_gephy_driver[] = {
+@@ -110,7 +113,7 @@ static struct phy_driver mtk_gephy_drive
  		.write_page	= mtk_phy_write_page,
  	},
  	{
@@ -45,7 +43,7 @@ index 912289928fb3..ed2617bc20f4 100644
  		.name		= "MediaTek MT7531 PHY",
  		.config_init	= mt7531_phy_config_init,
  		/* Interrupts are handled by the switch, not the PHY
-@@ -91,8 +94,8 @@ static struct phy_driver mtk_gephy_driver[] = {
+@@ -128,8 +131,8 @@ static struct phy_driver mtk_gephy_drive
  module_phy_driver(mtk_gephy_driver);
  
  static struct mdio_device_id __maybe_unused mtk_gephy_tbl[] = {
@@ -56,6 +54,3 @@ index 912289928fb3..ed2617bc20f4 100644
  	{ }
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/059-v6.15-01-net-phy-mediatek-Change-to-more-meaningful-macros.patch
+++ b/target/linux/airoha/patches-6.6/059-v6.15-01-net-phy-mediatek-Change-to-more-meaningful-macros.patch
@@ -16,8 +16,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk.h        |  2 +
  3 files changed, 57 insertions(+), 17 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index bdf99b327029..69cd6a1cbad4 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
 @@ -24,7 +24,6 @@
@@ -28,11 +26,9 @@ index bdf99b327029..69cd6a1cbad4 100644
  
  #define ANALOG_INTERNAL_OPERATION_MAX_US	20
  #define TXRESERVE_MIN				0
-diff --git a/drivers/net/phy/mediatek/mtk-ge.c b/drivers/net/phy/mediatek/mtk-ge.c
-index b517ca8573e7..75e1b0387710 100644
 --- a/drivers/net/phy/mediatek/mtk-ge.c
 +++ b/drivers/net/phy/mediatek/mtk-ge.c
-@@ -8,21 +8,41 @@
+@@ -9,13 +9,31 @@
  #define MTK_GPHY_ID_MT7530		0x03a29412
  #define MTK_GPHY_ID_MT7531		0x03a29441
  
@@ -71,7 +67,7 @@ index b517ca8573e7..75e1b0387710 100644
  
  static void mtk_gephy_config_init(struct phy_device *phydev)
  {
- 	/* Disable EEE */
+@@ -23,7 +41,9 @@ static void mtk_gephy_config_init(struct
  	phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV, 0);
  
  	/* Enable HW auto downshift */
@@ -82,7 +78,7 @@ index b517ca8573e7..75e1b0387710 100644
  
  	/* Increase SlvDPSready time */
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
-@@ -29,10 +49,20 @@ static void mtk_gephy_config_init(struct phy_device *phydev)
+@@ -33,10 +53,20 @@ static void mtk_gephy_config_init(struct
  	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
  
  	/* Adjust 100_mse_threshold */
@@ -107,7 +103,7 @@ index b517ca8573e7..75e1b0387710 100644
  }
  
  static int mt7530_phy_config_init(struct phy_device *phydev)
-@@ -40,7 +70,8 @@ static int mt7530_phy_config_init(struct phy_device *phydev)
+@@ -44,7 +74,8 @@ static int mt7530_phy_config_init(struct
  	mtk_gephy_config_init(phydev);
  
  	/* Increase post_update_timer */
@@ -117,7 +113,7 @@ index b517ca8573e7..75e1b0387710 100644
  
  	return 0;
  }
-@@ -51,11 +82,19 @@ static int mt7531_phy_config_init(struct phy_device *phydev)
+@@ -85,11 +116,19 @@ static int mt7531_phy_config_init(struct
  
  	/* PHY link down power saving enable */
  	phy_set_bits(phydev, 0x17, BIT(4));
@@ -138,10 +134,8 @@ index b517ca8573e7..75e1b0387710 100644
 +		       FIELD_PREP(MTK_TX_DELAY_PAIR_B_MASK, 0x4) |
 +		       FIELD_PREP(MTK_TX_DELAY_PAIR_D_MASK, 0x4));
  
- 	return 0;
- }
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index 63d9fe179b8f..a888e2e1dd6b 100644
+ 	/* LED Config*/
+ 	mt7530_led_config_of(phydev);
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -9,6 +9,8 @@
@@ -153,6 +147,3 @@ index 63d9fe179b8f..a888e2e1dd6b 100644
  
  /* Registers on MDIO_MMD_VEND2 */
  #define MTK_PHY_LED0_ON_CTRL			0x24
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/059-v6.15-02-net-phy-mediatek-Add-token-ring-access-helper-functi.patch
+++ b/target/linux/airoha/patches-6.6/059-v6.15-02-net-phy-mediatek-Add-token-ring-access-helper-functi.patch
@@ -26,8 +26,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk.h         |   5 +
  4 files changed, 230 insertions(+), 80 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index 69cd6a1cbad4..5d7373793659 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
 @@ -25,6 +25,90 @@
@@ -121,7 +119,7 @@ index 69cd6a1cbad4..5d7373793659 100644
  #define ANALOG_INTERNAL_OPERATION_MAX_US	20
  #define TXRESERVE_MIN				0
  #define TXRESERVE_MAX				7
-@@ -700,40 +784,41 @@ static int tx_vcm_cal_sw(struct phy_device *phydev, u8 rg_txreserve_x)
+@@ -700,40 +784,41 @@ restore:
  static void mt798x_phy_common_finetune(struct phy_device *phydev)
  {
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
@@ -143,14 +141,15 @@ index 69cd6a1cbad4..5d7373793659 100644
 -	__phy_write(phydev, 0x11, 0x55a0);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x83aa);
-+	__mtk_tr_modify(phydev, 0x0, 0x7, 0x15,
-+			NORMAL_MSE_LO_THRESH_MASK,
-+			FIELD_PREP(NORMAL_MSE_LO_THRESH_MASK, 0x55));
- 
+-
 -	/* FfeUpdGainForce = 1(Enable), FfeUpdGainForceVal = 4 */
 -	__phy_write(phydev, 0x11, 0x240);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x9680);
++	__mtk_tr_modify(phydev, 0x0, 0x7, 0x15,
++			NORMAL_MSE_LO_THRESH_MASK,
++			FIELD_PREP(NORMAL_MSE_LO_THRESH_MASK, 0x55));
++
 +	__mtk_tr_modify(phydev, 0x2, 0xd, 0x0,
 +			FFE_UPDATE_GAIN_FORCE_VAL_MASK,
 +			FIELD_PREP(FFE_UPDATE_GAIN_FORCE_VAL_MASK, 0x4) |
@@ -184,7 +183,7 @@ index 69cd6a1cbad4..5d7373793659 100644
  	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
  }
  
-@@ -756,27 +841,29 @@ static void mt7981_phy_finetune(struct phy_device *phydev)
+@@ -756,27 +841,29 @@ static void mt7981_phy_finetune(struct p
  	}
  
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
@@ -192,14 +191,15 @@ index 69cd6a1cbad4..5d7373793659 100644
 -	__phy_write(phydev, 0x11, 0x600);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x8fc0);
-+	__mtk_tr_modify(phydev, 0x1, 0xf, 0x20,
-+			RESET_SYNC_OFFSET_MASK,
-+			FIELD_PREP(RESET_SYNC_OFFSET_MASK, 0x6));
- 
+-
 -	/* VgaDecRate = 1 */
 -	__phy_write(phydev, 0x11, 0x4c2a);
 -	__phy_write(phydev, 0x12, 0x3e);
 -	__phy_write(phydev, 0x10, 0x8fa4);
++	__mtk_tr_modify(phydev, 0x1, 0xf, 0x20,
++			RESET_SYNC_OFFSET_MASK,
++			FIELD_PREP(RESET_SYNC_OFFSET_MASK, 0x6));
++
 +	__mtk_tr_modify(phydev, 0x1, 0xf, 0x12,
 +			VGA_DECIMATION_RATE_MASK,
 +			FIELD_PREP(VGA_DECIMATION_RATE_MASK, 0x1));
@@ -228,7 +228,7 @@ index 69cd6a1cbad4..5d7373793659 100644
  	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
  
  	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 9 */
-@@ -828,25 +915,23 @@ static void mt7988_phy_finetune(struct phy_device *phydev)
+@@ -828,25 +915,23 @@ static void mt7988_phy_finetune(struct p
  	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_TX_FILTER, 0x5);
  
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
@@ -268,7 +268,7 @@ index 69cd6a1cbad4..5d7373793659 100644
  	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
  
  	/* TR_OPEN_LOOP_EN = 1, lpf_x_average = 10 */
-@@ -927,40 +1012,36 @@ static void mt798x_phy_eee(struct phy_device *phydev)
+@@ -927,40 +1012,36 @@ static void mt798x_phy_eee(struct phy_de
  	__phy_write(phydev, 0x12, 0x0);
  	__phy_write(phydev, 0x10, 0x9690);
  
@@ -276,39 +276,43 @@ index 69cd6a1cbad4..5d7373793659 100644
 -	__phy_write(phydev, 0x11, 0x114f);
 -	__phy_write(phydev, 0x12, 0x2);
 -	__phy_write(phydev, 0x10, 0x969a);
-+	__mtk_tr_modify(phydev, 0x2, 0xd, 0xd,
-+			EEE1000_STAGE2_TR_KF_MASK,
-+			FIELD_PREP(EEE1000_STAGE2_TR_KF_MASK, 0x2));
- 
+-
 -	/* RegEEE_slv_wake_tr_timer_tar = 6, RegEEE_slv_remtx_timer_tar = 20 */
 -	__phy_write(phydev, 0x11, 0x3028);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x969e);
-+	__mtk_tr_modify(phydev, 0x2, 0xd, 0xf,
-+			SLAVE_WAKETR_TIMER_MASK | SLAVE_REMTX_TIMER_MASK,
-+			FIELD_PREP(SLAVE_WAKETR_TIMER_MASK, 0x6) |
-+			FIELD_PREP(SLAVE_REMTX_TIMER_MASK, 0x14));
- 
+-
 -	/* RegEEE_slv_wake_int_timer_tar = 8 */
 -	__phy_write(phydev, 0x11, 0x5010);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x96a0);
-+	__mtk_tr_modify(phydev, 0x2, 0xd, 0x10,
-+			SLAVE_WAKEINT_TIMER_MASK,
-+			FIELD_PREP(SLAVE_WAKEINT_TIMER_MASK, 0x8));
- 
+-
 -	/* RegEEE_trfreeze_timer2 = 586 */
 -	__phy_write(phydev, 0x11, 0x24a);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x96a8);
-+	__mtk_tr_modify(phydev, 0x2, 0xd, 0x14,
-+			TR_FREEZE_TIMER2_MASK,
-+			FIELD_PREP(TR_FREEZE_TIMER2_MASK, 0x24a));
- 
+-
 -	/* RegEEE100Stg1_tar = 16 */
 -	__phy_write(phydev, 0x11, 0x3210);
 -	__phy_write(phydev, 0x12, 0x0);
 -	__phy_write(phydev, 0x10, 0x96b8);
++	__mtk_tr_modify(phydev, 0x2, 0xd, 0xd,
++			EEE1000_STAGE2_TR_KF_MASK,
++			FIELD_PREP(EEE1000_STAGE2_TR_KF_MASK, 0x2));
++
++	__mtk_tr_modify(phydev, 0x2, 0xd, 0xf,
++			SLAVE_WAKETR_TIMER_MASK | SLAVE_REMTX_TIMER_MASK,
++			FIELD_PREP(SLAVE_WAKETR_TIMER_MASK, 0x6) |
++			FIELD_PREP(SLAVE_REMTX_TIMER_MASK, 0x14));
++
++	__mtk_tr_modify(phydev, 0x2, 0xd, 0x10,
++			SLAVE_WAKEINT_TIMER_MASK,
++			FIELD_PREP(SLAVE_WAKEINT_TIMER_MASK, 0x8));
++
++	__mtk_tr_modify(phydev, 0x2, 0xd, 0x14,
++			TR_FREEZE_TIMER2_MASK,
++			FIELD_PREP(TR_FREEZE_TIMER2_MASK, 0x24a));
++
 +	__mtk_tr_modify(phydev, 0x2, 0xd, 0x1c,
 +			EEE100_LPSYNC_STAGE1_UPDATE_TIMER_MASK,
 +			FIELD_PREP(EEE100_LPSYNC_STAGE1_UPDATE_TIMER_MASK,
@@ -329,11 +333,9 @@ index 69cd6a1cbad4..5d7373793659 100644
  	phy_restore_page(phydev, MTK_PHY_PAGE_STANDARD, 0);
  
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_3);
-diff --git a/drivers/net/phy/mediatek/mtk-ge.c b/drivers/net/phy/mediatek/mtk-ge.c
-index 75e1b0387710..a24c5ba469ba 100644
 --- a/drivers/net/phy/mediatek/mtk-ge.c
 +++ b/drivers/net/phy/mediatek/mtk-ge.c
-@@ -18,6 +18,10 @@
+@@ -19,6 +19,10 @@
  
  #define MTK_PHY_PAGE_EXTENDED_2A30		0x2a30
  
@@ -344,7 +346,7 @@ index 75e1b0387710..a24c5ba469ba 100644
  /* Registers on MDIO_MMD_VEND1 */
  #define MTK_PHY_GBE_MODE_TX_DELAY_SEL		0x13
  #define MTK_PHY_TEST_MODE_TX_DELAY_SEL		0x14
-@@ -42,11 +46,8 @@ static void mtk_gephy_config_init(struct phy_device *phydev)
+@@ -46,11 +50,8 @@ static void mtk_gephy_config_init(struct
  			 0, MTK_PHY_ENABLE_DOWNSHIFT);
  
  	/* Increase SlvDPSready time */
@@ -358,8 +360,6 @@ index 75e1b0387710..a24c5ba469ba 100644
  
  	/* Adjust 100_mse_threshold */
  	phy_modify_mmd(phydev, MDIO_MMD_VEND1,
-diff --git a/drivers/net/phy/mediatek/mtk-phy-lib.c b/drivers/net/phy/mediatek/mtk-phy-lib.c
-index 98a09d670e9c..7275e4ee2298 100644
 --- a/drivers/net/phy/mediatek/mtk-phy-lib.c
 +++ b/drivers/net/phy/mediatek/mtk-phy-lib.c
 @@ -6,6 +6,69 @@
@@ -432,8 +432,6 @@ index 98a09d670e9c..7275e4ee2298 100644
  int mtk_phy_read_page(struct phy_device *phydev)
  {
  	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index a888e2e1dd6b..af44d1ad8c9e 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -68,6 +68,11 @@ struct mtk_socphy_priv {
@@ -448,6 +446,3 @@ index a888e2e1dd6b..af44d1ad8c9e 100644
  int mtk_phy_read_page(struct phy_device *phydev);
  int mtk_phy_write_page(struct phy_device *phydev, int page);
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/059-v6.15-03-net-phy-mediatek-Add-token-ring-set-bit-operation-su.patch
+++ b/target/linux/airoha/patches-6.6/059-v6.15-03-net-phy-mediatek-Add-token-ring-set-bit-operation-su.patch
@@ -18,8 +18,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk.h         |  2 ++
  3 files changed, 15 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index 5d7373793659..37777ad104d8 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
 @@ -62,6 +62,10 @@
@@ -33,7 +31,7 @@ index 5d7373793659..37777ad104d8 100644
  /* ch_addr = 0x1, node_addr = 0xf, data_addr = 0x20 */
  /* ResetSyncOffset */
  #define RESET_SYNC_OFFSET_MASK			GENMASK(11, 8)
-@@ -789,10 +793,8 @@ static void mt798x_phy_common_finetune(struct phy_device *phydev)
+@@ -789,10 +793,8 @@ static void mt798x_phy_common_finetune(s
  			FIELD_PREP(SLAVE_DSP_READY_TIME_MASK, 0x18) |
  			FIELD_PREP(MASTER_DSP_READY_TIME_MASK, 0x18));
  
@@ -46,11 +44,9 @@ index 5d7373793659..37777ad104d8 100644
  
  	__mtk_tr_modify(phydev, 0x0, 0x7, 0x15,
  			NORMAL_MSE_LO_THRESH_MASK,
-diff --git a/drivers/net/phy/mediatek/mtk-phy-lib.c b/drivers/net/phy/mediatek/mtk-phy-lib.c
-index 7275e4ee2298..df8fdadcc0f4 100644
 --- a/drivers/net/phy/mediatek/mtk-phy-lib.c
 +++ b/drivers/net/phy/mediatek/mtk-phy-lib.c
-@@ -69,6 +69,13 @@ void mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
+@@ -69,6 +69,13 @@ void mtk_tr_modify(struct phy_device *ph
  }
  EXPORT_SYMBOL_GPL(mtk_tr_modify);
  
@@ -64,11 +60,9 @@ index 7275e4ee2298..df8fdadcc0f4 100644
  int mtk_phy_read_page(struct phy_device *phydev)
  {
  	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index af44d1ad8c9e..2d8e5b934a02 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
-@@ -72,6 +72,8 @@ void __mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
+@@ -72,6 +72,8 @@ void __mtk_tr_modify(struct phy_device *
  		     u8 data_addr, u32 mask, u32 set);
  void mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
  		   u8 data_addr, u32 mask, u32 set);
@@ -77,6 +71,3 @@ index af44d1ad8c9e..2d8e5b934a02 100644
  
  int mtk_phy_read_page(struct phy_device *phydev);
  int mtk_phy_write_page(struct phy_device *phydev, int page);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/059-v6.15-04-net-phy-mediatek-Add-token-ring-clear-bit-operation-.patch
+++ b/target/linux/airoha/patches-6.6/059-v6.15-04-net-phy-mediatek-Add-token-ring-clear-bit-operation-.patch
@@ -19,8 +19,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk.h         |  2 ++
  3 files changed, 27 insertions(+), 12 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index 37777ad104d8..9de6fbb45564 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
 @@ -76,6 +76,10 @@
@@ -57,7 +55,7 @@ index 37777ad104d8..9de6fbb45564 100644
  #define ANALOG_INTERNAL_OPERATION_MAX_US	20
  #define TXRESERVE_MIN				0
  #define TXRESERVE_MAX				7
-@@ -805,10 +818,7 @@ static void mt798x_phy_common_finetune(struct phy_device *phydev)
+@@ -805,10 +818,7 @@ static void mt798x_phy_common_finetune(s
  			FIELD_PREP(FFE_UPDATE_GAIN_FORCE_VAL_MASK, 0x4) |
  				   FFE_UPDATE_GAIN_FORCE);
  
@@ -69,7 +67,7 @@ index 37777ad104d8..9de6fbb45564 100644
  
  	__mtk_tr_modify(phydev, 0x2, 0xd, 0x6,
  			SS_TR_KP100_MASK | SS_TR_KF100_MASK |
-@@ -1009,10 +1019,8 @@ static void mt798x_phy_eee(struct phy_device *phydev)
+@@ -1009,10 +1019,8 @@ static void mt798x_phy_eee(struct phy_de
  			 MTK_PHY_TR_READY_SKIP_AFE_WAKEUP);
  
  	phy_select_page(phydev, MTK_PHY_PAGE_EXTENDED_52B5);
@@ -82,7 +80,7 @@ index 37777ad104d8..9de6fbb45564 100644
  
  	__mtk_tr_modify(phydev, 0x2, 0xd, 0xd,
  			EEE1000_STAGE2_TR_KF_MASK,
-@@ -1036,10 +1044,8 @@ static void mt798x_phy_eee(struct phy_device *phydev)
+@@ -1036,10 +1044,8 @@ static void mt798x_phy_eee(struct phy_de
  			FIELD_PREP(EEE100_LPSYNC_STAGE1_UPDATE_TIMER_MASK,
  				   0x10));
  
@@ -95,11 +93,9 @@ index 37777ad104d8..9de6fbb45564 100644
  
  	__mtk_tr_modify(phydev, 0x1, 0xf, 0x0,
  			DFE_TAIL_EANBLE_VGA_TRHESH_1000,
-diff --git a/drivers/net/phy/mediatek/mtk-phy-lib.c b/drivers/net/phy/mediatek/mtk-phy-lib.c
-index df8fdadcc0f4..dfd0f4e439a2 100644
 --- a/drivers/net/phy/mediatek/mtk-phy-lib.c
 +++ b/drivers/net/phy/mediatek/mtk-phy-lib.c
-@@ -76,6 +76,13 @@ void __mtk_tr_set_bits(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
+@@ -76,6 +76,13 @@ void __mtk_tr_set_bits(struct phy_device
  }
  EXPORT_SYMBOL_GPL(__mtk_tr_set_bits);
  
@@ -113,11 +109,9 @@ index df8fdadcc0f4..dfd0f4e439a2 100644
  int mtk_phy_read_page(struct phy_device *phydev)
  {
  	return __phy_read(phydev, MTK_EXT_PAGE_ACCESS);
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index 2d8e5b934a02..4e4468dc0234 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
-@@ -74,6 +74,8 @@ void mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
+@@ -74,6 +74,8 @@ void mtk_tr_modify(struct phy_device *ph
  		   u8 data_addr, u32 mask, u32 set);
  void __mtk_tr_set_bits(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
  		       u8 data_addr, u32 set);
@@ -126,6 +120,3 @@ index 2d8e5b934a02..4e4468dc0234 100644
  
  int mtk_phy_read_page(struct phy_device *phydev);
  int mtk_phy_write_page(struct phy_device *phydev, int page);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/059-v6.15-05-net-phy-mediatek-Move-some-macros-to-phy-lib-for-lat.patch
+++ b/target/linux/airoha/patches-6.6/059-v6.15-05-net-phy-mediatek-Move-some-macros-to-phy-lib-for-lat.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk.h    | 4 ++++
  2 files changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge.c b/drivers/net/phy/mediatek/mtk-ge.c
-index a24c5ba469ba..73d9b72f9d9e 100644
 --- a/drivers/net/phy/mediatek/mtk-ge.c
 +++ b/drivers/net/phy/mediatek/mtk-ge.c
-@@ -8,10 +8,6 @@
+@@ -9,10 +9,6 @@
  #define MTK_GPHY_ID_MT7530		0x03a29412
  #define MTK_GPHY_ID_MT7531		0x03a29441
  
@@ -31,8 +29,6 @@ index a24c5ba469ba..73d9b72f9d9e 100644
  #define MTK_PHY_PAGE_EXTENDED_2			0x0002
  #define MTK_PHY_PAGE_EXTENDED_3			0x0003
  #define MTK_PHY_RG_LPI_PCS_DSP_CTRL_REG11	0x11
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index 4e4468dc0234..320f76ffa81f 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -8,7 +8,11 @@
@@ -47,6 +43,3 @@ index 4e4468dc0234..320f76ffa81f 100644
  #define MTK_PHY_PAGE_STANDARD			0x0000
  #define MTK_PHY_PAGE_EXTENDED_52B5		0x52b5
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/060-v6.16-01-net-phy-mediatek-permit-to-compile-test-GE-SOC-PHY-d.patch
+++ b/target/linux/airoha/patches-6.6/060-v6.16-01-net-phy-mediatek-permit-to-compile-test-GE-SOC-PHY-d.patch
@@ -24,8 +24,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/Kconfig | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/Kconfig b/drivers/net/phy/mediatek/Kconfig
-index 2a8ac5aed0f8..6a4c2b328c41 100644
 --- a/drivers/net/phy/mediatek/Kconfig
 +++ b/drivers/net/phy/mediatek/Kconfig
 @@ -15,8 +15,7 @@ config MEDIATEK_GE_PHY
@@ -38,6 +36,3 @@ index 2a8ac5aed0f8..6a4c2b328c41 100644
  	select MTK_NET_PHYLIB
  	help
  	  Supports MediaTek SoC built-in Gigabit Ethernet PHYs.
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/060-v6.16-02-net-phy-mediatek-add-Airoha-PHY-ID-to-SoC-driver.patch
+++ b/target/linux/airoha/patches-6.6/060-v6.16-02-net-phy-mediatek-add-Airoha-PHY-ID-to-SoC-driver.patch
@@ -20,8 +20,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk-ge-soc.c | 62 +++++++++++++++++++++++++++
  2 files changed, 65 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/phy/mediatek/Kconfig b/drivers/net/phy/mediatek/Kconfig
-index 6a4c2b328c41..4308002bb82c 100644
 --- a/drivers/net/phy/mediatek/Kconfig
 +++ b/drivers/net/phy/mediatek/Kconfig
 @@ -15,7 +15,9 @@ config MEDIATEK_GE_PHY
@@ -35,12 +33,10 @@ index 6a4c2b328c41..4308002bb82c 100644
  	select MTK_NET_PHYLIB
  	help
  	  Supports MediaTek SoC built-in Gigabit Ethernet PHYs.
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index 175cf5239bba..fd0e447ffce7 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
-@@ -11,8 +11,11 @@
- #include "../phylib.h"
+@@ -10,8 +10,11 @@
+ 
  #include "mtk.h"
  
 +#define MTK_PHY_MAX_LEDS			2
@@ -51,7 +47,7 @@ index 175cf5239bba..fd0e447ffce7 100644
  
  #define MTK_EXT_PAGE_ACCESS			0x1f
  #define MTK_PHY_PAGE_STANDARD			0x0000
-@@ -1406,6 +1409,53 @@ static int mt7981_phy_probe(struct phy_device *phydev)
+@@ -1405,6 +1408,53 @@ static int mt7981_phy_probe(struct phy_d
  	return mt798x_phy_calibration(phydev);
  }
  
@@ -105,7 +101,7 @@ index 175cf5239bba..fd0e447ffce7 100644
  static struct phy_driver mtk_socphy_driver[] = {
  	{
  		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981),
-@@ -1441,6 +1491,17 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1440,6 +1490,17 @@ static struct phy_driver mtk_socphy_driv
  		.led_hw_control_set = mt798x_phy_led_hw_control_set,
  		.led_hw_control_get = mt798x_phy_led_hw_control_get,
  	},
@@ -123,14 +119,11 @@ index 175cf5239bba..fd0e447ffce7 100644
  };
  
  module_phy_driver(mtk_socphy_driver);
-@@ -1448,6 +1509,7 @@ module_phy_driver(mtk_socphy_driver);
- static const struct mdio_device_id __maybe_unused mtk_socphy_tbl[] = {
+@@ -1447,6 +1508,7 @@ module_phy_driver(mtk_socphy_driver);
+ static struct mdio_device_id __maybe_unused mtk_socphy_tbl[] = {
  	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981) },
  	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7988) },
 +	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581) },
  	{ }
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/061-v6.16-net-phy-mediatek-Add-Airoha-AN7583-PHY-support.patch
+++ b/target/linux/airoha/patches-6.6/061-v6.16-net-phy-mediatek-Add-Airoha-AN7583-PHY-support.patch
@@ -15,11 +15,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/mediatek/mtk-ge-soc.c | 20 ++++++++++++++++++++
  1 file changed, 20 insertions(+)
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index a284e8435cb6..cd09fbf92ef2 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
-@@ -17,6 +17,7 @@
+@@ -15,6 +15,7 @@
  #define MTK_GPHY_ID_MT7981			0x03a29461
  #define MTK_GPHY_ID_MT7988			0x03a29481
  #define MTK_GPHY_ID_AN7581			0x03a294c1
@@ -27,7 +25,7 @@ index a284e8435cb6..cd09fbf92ef2 100644
  
  #define MTK_EXT_PAGE_ACCESS			0x1f
  #define MTK_PHY_PAGE_STANDARD			0x0000
-@@ -1463,6 +1464,12 @@ static int an7581_phy_led_polarity_set(struct phy_device *phydev, int index,
+@@ -1455,6 +1456,12 @@ static int an7581_phy_led_polarity_set(s
  			      MTK_PHY_LED_ON_POLARITY, val);
  }
  
@@ -40,7 +38,7 @@ index a284e8435cb6..cd09fbf92ef2 100644
  static struct phy_driver mtk_socphy_driver[] = {
  	{
  		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981),
-@@ -1509,6 +1516,18 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1501,6 +1508,18 @@ static struct phy_driver mtk_socphy_driv
  		.led_hw_control_get = mt798x_phy_led_hw_control_get,
  		.led_polarity_set = an7581_phy_led_polarity_set,
  	},
@@ -59,7 +57,7 @@ index a284e8435cb6..cd09fbf92ef2 100644
  };
  
  module_phy_driver(mtk_socphy_driver);
-@@ -1517,6 +1536,7 @@ static const struct mdio_device_id __maybe_unused mtk_socphy_tbl[] = {
+@@ -1509,6 +1528,7 @@ static struct mdio_device_id __maybe_unu
  	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981) },
  	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7988) },
  	{ PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581) },
@@ -67,6 +65,3 @@ index a284e8435cb6..cd09fbf92ef2 100644
  	{ }
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/062-v6.11-i2c-mt7621-reword-according-to-newest-specification.patch
+++ b/target/linux/airoha/patches-6.6/062-v6.11-i2c-mt7621-reword-according-to-newest-specification.patch
@@ -15,11 +15,9 @@ Signed-off-by: Andi Shyti <andi.shyti@kernel.org>
  drivers/i2c/busses/i2c-mt7621.c | 26 +++++++++++++-------------
  1 file changed, 13 insertions(+), 13 deletions(-)
 
-diff --git a/drivers/i2c/busses/i2c-mt7621.c b/drivers/i2c/busses/i2c-mt7621.c
-index 81d46169bc1f..23d417ff5e71 100644
 --- a/drivers/i2c/busses/i2c-mt7621.c
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -117,27 +117,27 @@ static int mtk_i2c_check_ack(struct mtk_i2c *i2c, u32 expected)
+@@ -117,27 +117,27 @@ static int mtk_i2c_check_ack(struct mtk_
  	return ((ack & ack_expected) == ack_expected) ? 0 : -ENXIO;
  }
  
@@ -52,7 +50,7 @@ index 81d46169bc1f..23d417ff5e71 100644
  {
  	struct mtk_i2c *i2c;
  	struct i2c_msg *pmsg;
-@@ -157,7 +157,7 @@ static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -157,7 +157,7 @@ static int mtk_i2c_master_xfer(struct i2
  			goto err_timeout;
  
  		/* start sequence */
@@ -61,7 +59,7 @@ index 81d46169bc1f..23d417ff5e71 100644
  		if (ret)
  			goto err_timeout;
  
-@@ -169,14 +169,14 @@ static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -169,14 +169,14 @@ static int mtk_i2c_master_xfer(struct i2
  			if (pmsg->flags & I2C_M_RD)
  				addr |= 1;
  			iowrite32(addr, i2c->base + REG_SM0D0_REG);
@@ -78,7 +76,7 @@ index 81d46169bc1f..23d417ff5e71 100644
  			if (ret)
  				goto err_timeout;
  		}
-@@ -202,7 +202,7 @@ static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -202,7 +202,7 @@ static int mtk_i2c_master_xfer(struct i2
  				cmd = SM0CTL1_WRITE;
  			}
  
@@ -87,7 +85,7 @@ index 81d46169bc1f..23d417ff5e71 100644
  			if (ret)
  				goto err_timeout;
  
-@@ -222,7 +222,7 @@ static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -222,7 +222,7 @@ static int mtk_i2c_master_xfer(struct i2
  		}
  	}
  
@@ -96,7 +94,7 @@ index 81d46169bc1f..23d417ff5e71 100644
  	if (ret)
  		goto err_timeout;
  
-@@ -230,7 +230,7 @@ static int mtk_i2c_master_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -230,7 +230,7 @@ static int mtk_i2c_master_xfer(struct i2
  	return i;
  
  err_ack:
@@ -105,7 +103,7 @@ index 81d46169bc1f..23d417ff5e71 100644
  	if (ret)
  		goto err_timeout;
  	return -ENXIO;
-@@ -247,8 +247,8 @@ static u32 mtk_i2c_func(struct i2c_adapter *a)
+@@ -247,8 +247,8 @@ static u32 mtk_i2c_func(struct i2c_adapt
  }
  
  static const struct i2c_algorithm mtk_i2c_algo = {
@@ -116,6 +114,3 @@ index 81d46169bc1f..23d417ff5e71 100644
  };
  
  static const struct of_device_id i2c_mtk_dt_ids[] = {
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/063-01-v6.15-net-airoha-Move-min-max-packet-len-configuration-in-.patch
+++ b/target/linux/airoha/patches-6.6/063-01-v6.15-net-airoha-Move-min-max-packet-len-configuration-in-.patch
@@ -15,11 +15,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 14 +++++++-------
  1 file changed, 7 insertions(+), 7 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index ff837168845d..a9ed3fc2b519 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -138,15 +138,10 @@ static void airoha_fe_maccr_init(struct airoha_eth *eth)
+@@ -138,15 +138,10 @@ static void airoha_fe_maccr_init(struct
  {
  	int p;
  
@@ -36,7 +34,7 @@ index ff837168845d..a9ed3fc2b519 100644
  
  	airoha_fe_rmw(eth, REG_CDM1_VLAN_CTRL, CDM1_VLAN_MASK,
  		      FIELD_PREP(CDM1_VLAN_MASK, 0x8100));
-@@ -1520,9 +1515,9 @@ static void airoha_update_hw_stats(struct airoha_gdm_port *port)
+@@ -1521,9 +1516,9 @@ static void airoha_update_hw_stats(struc
  
  static int airoha_dev_open(struct net_device *dev)
  {
@@ -47,7 +45,7 @@ index ff837168845d..a9ed3fc2b519 100644
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1536,6 +1531,11 @@ static int airoha_dev_open(struct net_device *dev)
+@@ -1537,6 +1532,11 @@ static int airoha_dev_open(struct net_de
  		airoha_fe_clear(qdma->eth, REG_GDM_INGRESS_CFG(port->id),
  				GDM_STAG_EN_MASK);
  
@@ -59,6 +57,3 @@ index ff837168845d..a9ed3fc2b519 100644
  	airoha_qdma_set(qdma, REG_QDMA_GLOBAL_CFG,
  			GLOBAL_CFG_TX_DMA_EN_MASK |
  			GLOBAL_CFG_RX_DMA_EN_MASK);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/063-02-v6.15-net-airoha-Enable-Rx-Scatter-Gather.patch
+++ b/target/linux/airoha/patches-6.6/063-02-v6.15-net-airoha-Enable-Rx-Scatter-Gather.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_regs.h |  5 ++
  3 files changed, 48 insertions(+), 26 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index a9ed3fc2b519..54a239ab10aa 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -615,10 +615,10 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -615,10 +615,10 @@ static int airoha_qdma_rx_process(struct
  		struct airoha_qdma_desc *desc = &q->desc[q->tail];
  		u32 hash, reason, msg1 = le32_to_cpu(desc->msg1);
  		dma_addr_t dma_addr = le32_to_cpu(desc->addr);
@@ -33,7 +31,7 @@ index a9ed3fc2b519..54a239ab10aa 100644
  
  		if (!(desc_ctrl & QDMA_DESC_DONE_MASK))
  			break;
-@@ -636,30 +636,41 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -636,30 +636,41 @@ static int airoha_qdma_rx_process(struct
  		dma_sync_single_for_cpu(eth->dev, dma_addr,
  					SKB_WITH_OVERHEAD(q->buf_size), dir);
  
@@ -94,7 +92,7 @@ index a9ed3fc2b519..54a239ab10aa 100644
  
  		if (netdev_uses_dsa(port->dev)) {
  			/* PPE module requires untagged packets to work
-@@ -672,22 +683,27 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -672,22 +683,27 @@ static int airoha_qdma_rx_process(struct
  
  			if (sptag < ARRAY_SIZE(port->dsa_meta) &&
  			    port->dsa_meta[sptag])
@@ -126,7 +124,7 @@ index a9ed3fc2b519..54a239ab10aa 100644
  	}
  	airoha_qdma_fill_rx_queue(q);
  
-@@ -762,6 +778,7 @@ static int airoha_qdma_init_rx_queue(struct airoha_queue *q,
+@@ -763,6 +779,7 @@ static int airoha_qdma_init_rx_queue(str
  			FIELD_PREP(RX_RING_THR_MASK, thr));
  	airoha_qdma_rmw(qdma, REG_RX_DMA_IDX(qid), RX_RING_DMA_IDX_MASK,
  			FIELD_PREP(RX_RING_DMA_IDX_MASK, q->head));
@@ -134,7 +132,7 @@ index a9ed3fc2b519..54a239ab10aa 100644
  
  	airoha_qdma_fill_rx_queue(q);
  
-@@ -1161,7 +1178,6 @@ static int airoha_qdma_hw_init(struct airoha_qdma *qdma)
+@@ -1162,7 +1179,6 @@ static int airoha_qdma_hw_init(struct ai
  	}
  
  	airoha_qdma_wr(qdma, REG_QDMA_GLOBAL_CFG,
@@ -142,8 +140,6 @@ index a9ed3fc2b519..54a239ab10aa 100644
  		       FIELD_PREP(GLOBAL_CFG_DMA_PREFERENCE_MASK, 3) |
  		       GLOBAL_CFG_CPU_TXR_RR_MASK |
  		       GLOBAL_CFG_PAYLOAD_BYTE_SWAP_MASK |
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index b7a3bd7a76b7..dca96f1df67e 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -176,6 +176,7 @@ struct airoha_queue {
@@ -154,8 +150,6 @@ index b7a3bd7a76b7..dca96f1df67e 100644
  };
  
  struct airoha_tx_irq_queue {
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 1aa06cdffe23..8146cde4e8ba 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
 @@ -626,10 +626,15 @@
@@ -174,6 +168,3 @@ index 1aa06cdffe23..8146cde4e8ba 100644
  #define REG_INGRESS_TRTCM_CFG		0x0070
  #define INGRESS_TRTCM_EN_MASK		BIT(31)
  #define INGRESS_TRTCM_MODE_MASK		BIT(30)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/063-03-v6.15-net-airoha-Introduce-airoha_dev_change_mtu-callback.patch
+++ b/target/linux/airoha/patches-6.6/063-03-v6.15-net-airoha-Introduce-airoha_dev_change_mtu-callback.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 15 +++++++++++++++
  1 file changed, 15 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 54a239ab10aa..f3a61879e284 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1705,6 +1705,20 @@ static void airoha_dev_get_stats64(struct net_device *dev,
+@@ -1706,6 +1706,20 @@ static void airoha_dev_get_stats64(struc
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
  
@@ -39,7 +37,7 @@ index 54a239ab10aa..f3a61879e284 100644
  static u16 airoha_dev_select_queue(struct net_device *dev, struct sk_buff *skb,
  				   struct net_device *sb_dev)
  {
-@@ -2400,6 +2414,7 @@ static const struct net_device_ops airoha_netdev_ops = {
+@@ -2398,6 +2412,7 @@ static const struct net_device_ops airoh
  	.ndo_init		= airoha_dev_init,
  	.ndo_open		= airoha_dev_open,
  	.ndo_stop		= airoha_dev_stop,
@@ -47,6 +45,3 @@ index 54a239ab10aa..f3a61879e284 100644
  	.ndo_select_queue	= airoha_dev_select_queue,
  	.ndo_start_xmit		= airoha_dev_xmit,
  	.ndo_get_stats64        = airoha_dev_get_stats64,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/063-04-v6.15-net-airoha-Increase-max-mtu-to-9k.patch
+++ b/target/linux/airoha/patches-6.6/063-04-v6.15-net-airoha-Increase-max-mtu-to-9k.patch
@@ -13,8 +13,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index dca96f1df67e..f66b9b736b94 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -20,7 +20,7 @@
@@ -26,6 +24,3 @@ index dca96f1df67e..f66b9b736b94 100644
  #define AIROHA_MAX_PACKET_SIZE		2048
  #define AIROHA_NUM_QOS_CHANNELS		4
  #define AIROHA_NUM_QOS_QUEUES		8
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/063-05-v6.15-net-airoha-Fix-lan4-support-in-airoha_qdma_get_gdm_p.patch
+++ b/target/linux/airoha/patches-6.6/063-05-v6.15-net-airoha-Fix-lan4-support-in-airoha_qdma_get_gdm_p.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index f3a61879e284..347c11b1fff5 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -589,7 +589,7 @@ static int airoha_qdma_get_gdm_port(struct airoha_eth *eth,
+@@ -589,7 +589,7 @@ static int airoha_qdma_get_gdm_port(stru
  
  	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
  	switch (sport) {
@@ -29,6 +27,3 @@ index f3a61879e284..347c11b1fff5 100644
  		port = 0;
  		break;
  	case 0x2 ... 0x4:
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/063-06-v6.15-net-airoha-Enable-TSO-Scatter-Gather-for-LAN-port.patch
+++ b/target/linux/airoha/patches-6.6/063-06-v6.15-net-airoha-Enable-TSO-Scatter-Gather-for-LAN-port.patch
@@ -15,11 +15,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 347c11b1fff5..e4130576ad10 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2505,6 +2505,7 @@ static int airoha_alloc_gdm_port(struct airoha_eth *eth,
+@@ -2503,6 +2503,7 @@ static int airoha_alloc_gdm_port(struct
  			   NETIF_F_SG | NETIF_F_TSO |
  			   NETIF_F_HW_TC;
  	dev->features |= dev->hw_features;
@@ -27,6 +25,3 @@ index 347c11b1fff5..e4130576ad10 100644
  	dev->dev.of_node = np;
  	dev->irq = qdma->irq;
  	SET_NETDEV_DEV(dev, eth->dev);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/064-v6.15-net-airoha-Fix-dev-dsa_ptr-check-in-airoha_get_dsa_t.patch
+++ b/target/linux/airoha/patches-6.6/064-v6.15-net-airoha-Fix-dev-dsa_ptr-check-in-airoha_get_dsa_t.patch
@@ -23,11 +23,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 7 +------
  1 file changed, 1 insertion(+), 6 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index e4130576ad10..c0a642568ac1 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1741,18 +1741,13 @@ static u32 airoha_get_dsa_tag(struct sk_buff *skb, struct net_device *dev)
+@@ -1742,18 +1742,13 @@ static u32 airoha_get_dsa_tag(struct sk_
  {
  #if IS_ENABLED(CONFIG_NET_DSA)
  	struct ethhdr *ehdr;
@@ -47,6 +45,3 @@ index e4130576ad10..c0a642568ac1 100644
  		return 0;
  
  	if (skb_cow_head(skb, 0))
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/065-v6.15-net-airoha-fix-CONFIG_DEBUG_FS-check.patch
+++ b/target/linux/airoha/patches-6.6/065-v6.15-net-airoha-fix-CONFIG_DEBUG_FS-check.patch
@@ -22,11 +22,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_eth.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index f66b9b736b94..60690b685710 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -540,7 +540,7 @@ void airoha_ppe_deinit(struct airoha_eth *eth);
+@@ -540,7 +540,7 @@ void airoha_ppe_deinit(struct airoha_eth
  struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
  						  u32 hash);
  
@@ -35,6 +33,3 @@ index f66b9b736b94..60690b685710 100644
  int airoha_ppe_debugfs_init(struct airoha_ppe *ppe);
  #else
  static inline int airoha_ppe_debugfs_init(struct airoha_ppe *ppe)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/066-01-v6.15-net-airoha-Fix-qid-report-in-airoha_tc_get_htb_get_l.patch
+++ b/target/linux/airoha/patches-6.6/066-01-v6.15-net-airoha-Fix-qid-report-in-airoha_tc_get_htb_get_l.patch
@@ -64,11 +64,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index c0a642568ac1..20a96cafc748 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2358,7 +2358,7 @@ static int airoha_tc_get_htb_get_leaf_queue(struct airoha_gdm_port *port,
+@@ -2356,7 +2356,7 @@ static int airoha_tc_get_htb_get_leaf_qu
  		return -EINVAL;
  	}
  
@@ -77,6 +75,3 @@ index c0a642568ac1..20a96cafc748 100644
  
  	return 0;
  }
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/066-02-v6.15-net-airoha-Fix-ETS-priomap-validation.patch
+++ b/target/linux/airoha/patches-6.6/066-02-v6.15-net-airoha-Fix-ETS-priomap-validation.patch
@@ -20,11 +20,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 16 ++++++++--------
  1 file changed, 8 insertions(+), 8 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 20a96cafc748..69e523dd4186 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2028,7 +2028,7 @@ static int airoha_qdma_set_tx_ets_sched(struct airoha_gdm_port *port,
+@@ -2029,7 +2029,7 @@ static int airoha_qdma_set_tx_ets_sched(
  	struct tc_ets_qopt_offload_replace_params *p = &opt->replace_params;
  	enum tx_sched_mode mode = TC_SCH_SP;
  	u16 w[AIROHA_NUM_QOS_QUEUES] = {};
@@ -33,7 +31,7 @@ index 20a96cafc748..69e523dd4186 100644
  
  	if (p->bands > AIROHA_NUM_QOS_QUEUES)
  		return -EINVAL;
-@@ -2046,17 +2046,17 @@ static int airoha_qdma_set_tx_ets_sched(struct airoha_gdm_port *port,
+@@ -2047,17 +2047,17 @@ static int airoha_qdma_set_tx_ets_sched(
  	 * lowest priorities with respect to SP ones.
  	 * e.g: WRR0, WRR1, .., WRRm, SP0, SP1, .., SPn
  	 */
@@ -58,6 +56,3 @@ index 20a96cafc748..69e523dd4186 100644
  
  	if (!nstrict)
  		mode = TC_SCH_WRR8;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/067-v6.15-net-airoha-Validate-egress-gdm-port-in-airoha_ppe_fo.patch
+++ b/target/linux/airoha/patches-6.6/067-v6.15-net-airoha-Validate-egress-gdm-port-in-airoha_ppe_fo.patch
@@ -33,11 +33,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c |  8 ++++++--
  3 files changed, 22 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 69e523dd4186..d748dc6de923 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2454,6 +2454,19 @@ static void airoha_metadata_dst_free(struct airoha_gdm_port *port)
+@@ -2452,6 +2452,19 @@ static void airoha_metadata_dst_free(str
  	}
  }
  
@@ -57,11 +55,9 @@ index 69e523dd4186..d748dc6de923 100644
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np, int index)
  {
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 60690b685710..ec8908f904c6 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -532,6 +532,9 @@ u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val);
+@@ -532,6 +532,9 @@ u32 airoha_rmw(void __iomem *base, u32 o
  #define airoha_qdma_clear(qdma, offset, val)			\
  	airoha_rmw((qdma)->regs, (offset), (val), 0)
  
@@ -71,11 +67,9 @@ index 60690b685710..ec8908f904c6 100644
  void airoha_ppe_check_skb(struct airoha_ppe *ppe, u16 hash);
  int airoha_ppe_setup_tc_block_cb(enum tc_setup_type type, void *type_data,
  				 void *cb_priv);
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 8b55e871352d..f10dab935cab 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -197,7 +197,8 @@ static int airoha_get_dsa_port(struct net_device **dev)
+@@ -197,7 +197,8 @@ static int airoha_get_dsa_port(struct ne
  #endif
  }
  
@@ -85,7 +79,7 @@ index 8b55e871352d..f10dab935cab 100644
  					struct net_device *dev, int type,
  					struct airoha_flow_data *data,
  					int l4proto)
-@@ -225,6 +226,9 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_foe_entry *hwe,
+@@ -225,6 +226,9 @@ static int airoha_ppe_foe_entry_prepare(
  		struct airoha_gdm_port *port = netdev_priv(dev);
  		u8 pse_port;
  
@@ -95,7 +89,7 @@ index 8b55e871352d..f10dab935cab 100644
  		if (dsa_port >= 0)
  			pse_port = port->id == 4 ? FE_PSE_PORT_GDM4 : port->id;
  		else
-@@ -633,7 +637,7 @@ static int airoha_ppe_flow_offload_replace(struct airoha_gdm_port *port,
+@@ -633,7 +637,7 @@ static int airoha_ppe_flow_offload_repla
  	    !is_valid_ether_addr(data.eth.h_dest))
  		return -EINVAL;
  
@@ -104,6 +98,3 @@ index 8b55e871352d..f10dab935cab 100644
  					   &data, l4proto);
  	if (err)
  		return err;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/068-01-v6.16-net-airoha-Add-l2_flows-rhashtable.patch
+++ b/target/linux/airoha/patches-6.6/068-01-v6.16-net-airoha-Add-l2_flows-rhashtable.patch
@@ -16,8 +16,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 103 ++++++++++++++++++-----
  2 files changed, 98 insertions(+), 20 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index ec8908f904c6..86e08832246d 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -422,12 +422,23 @@ struct airoha_flow_data {
@@ -54,11 +52,9 @@ index ec8908f904c6..86e08832246d 100644
  	struct hlist_head *foe_flow;
  	u16 foe_check_time[PPE_NUM_ENTRIES];
  
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index f10dab935cab..7219125ade13 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -24,6 +24,13 @@ static const struct rhashtable_params airoha_flow_table_params = {
+@@ -24,6 +24,13 @@ static const struct rhashtable_params ai
  	.automatic_shrinking = true,
  };
  
@@ -72,7 +68,7 @@ index f10dab935cab..7219125ade13 100644
  static bool airoha_ppe2_is_enabled(struct airoha_eth *eth)
  {
  	return airoha_fe_rr(eth, REG_PPE_GLO_CFG(1)) & PPE_GLO_CFG_EN_MASK;
-@@ -476,6 +483,43 @@ static int airoha_ppe_foe_commit_entry(struct airoha_ppe *ppe,
+@@ -476,6 +483,43 @@ static int airoha_ppe_foe_commit_entry(s
  	return 0;
  }
  
@@ -116,7 +112,7 @@ index f10dab935cab..7219125ade13 100644
  static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe, u32 hash)
  {
  	struct airoha_flow_table_entry *e;
-@@ -505,11 +549,37 @@ static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe, u32 hash)
+@@ -505,11 +549,37 @@ unlock:
  	spin_unlock_bh(&ppe_lock);
  }
  
@@ -155,7 +151,7 @@ index f10dab935cab..7219125ade13 100644
  	e->hash = 0xffff;
  
  	spin_lock_bh(&ppe_lock);
-@@ -519,23 +589,6 @@ static int airoha_ppe_foe_flow_commit_entry(struct airoha_ppe *ppe,
+@@ -519,23 +589,6 @@ static int airoha_ppe_foe_flow_commit_en
  	return 0;
  }
  
@@ -179,7 +175,7 @@ index f10dab935cab..7219125ade13 100644
  static int airoha_ppe_flow_offload_replace(struct airoha_gdm_port *port,
  					   struct flow_cls_offload *f)
  {
-@@ -890,9 +943,20 @@ int airoha_ppe_init(struct airoha_eth *eth)
+@@ -890,9 +943,20 @@ int airoha_ppe_init(struct airoha_eth *e
  	if (err)
  		return err;
  
@@ -201,7 +197,7 @@ index f10dab935cab..7219125ade13 100644
  
  	return err;
  }
-@@ -909,6 +973,7 @@ void airoha_ppe_deinit(struct airoha_eth *eth)
+@@ -909,6 +973,7 @@ void airoha_ppe_deinit(struct airoha_eth
  	}
  	rcu_read_unlock();
  
@@ -209,6 +205,3 @@ index f10dab935cab..7219125ade13 100644
  	rhashtable_destroy(&eth->flow_table);
  	debugfs_remove(eth->ppe->debugfs_dir);
  }
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/068-02-v6.16-net-airoha-Add-L2-hw-acceleration-support.patch
+++ b/target/linux/airoha/patches-6.6/068-02-v6.16-net-airoha-Add-L2-hw-acceleration-support.patch
@@ -19,11 +19,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 121 ++++++++++++++++++++---
  3 files changed, 115 insertions(+), 17 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index d748dc6de923..723eba7cfa0c 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -694,7 +694,7 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -694,7 +694,7 @@ static int airoha_qdma_rx_process(struct
  
  		reason = FIELD_GET(AIROHA_RXD4_PPE_CPU_REASON, msg1);
  		if (reason == PPE_CPU_REASON_HIT_UNBIND_RATE_REACHED)
@@ -32,8 +30,6 @@ index d748dc6de923..723eba7cfa0c 100644
  
  		done++;
  		napi_gro_receive(&q->napi, q->skb);
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 86e08832246d..e82abfc1a67b 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -431,10 +431,14 @@ enum airoha_flow_entry_type {
@@ -52,7 +48,7 @@ index 86e08832246d..e82abfc1a67b 100644
  	u32 hash;
  
  	enum airoha_flow_entry_type type;
-@@ -548,7 +552,8 @@ u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val);
+@@ -548,7 +552,8 @@ u32 airoha_rmw(void __iomem *base, u32 o
  bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
  			      struct airoha_gdm_port *port);
  
@@ -62,11 +58,9 @@ index 86e08832246d..e82abfc1a67b 100644
  int airoha_ppe_setup_tc_block_cb(enum tc_setup_type type, void *type_data,
  				 void *cb_priv);
  int airoha_ppe_init(struct airoha_eth *eth);
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 7219125ade13..d4969c2a0352 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -204,6 +204,15 @@ static int airoha_get_dsa_port(struct net_device **dev)
+@@ -204,6 +204,15 @@ static int airoha_get_dsa_port(struct ne
  #endif
  }
  
@@ -82,7 +76,7 @@ index 7219125ade13..d4969c2a0352 100644
  static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
  					struct airoha_foe_entry *hwe,
  					struct net_device *dev, int type,
-@@ -254,13 +263,7 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -254,13 +263,7 @@ static int airoha_ppe_foe_entry_prepare(
  
  	qdata = FIELD_PREP(AIROHA_FOE_SHAPER_ID, 0x7f);
  	if (type == PPE_PKT_TYPE_BRIDGE) {
@@ -97,7 +91,7 @@ index 7219125ade13..d4969c2a0352 100644
  		hwe->bridge.data = qdata;
  		hwe->bridge.ib2 = val;
  		l2 = &hwe->bridge.l2.common;
-@@ -385,6 +388,19 @@ static u32 airoha_ppe_foe_get_entry_hash(struct airoha_foe_entry *hwe)
+@@ -385,6 +388,19 @@ static u32 airoha_ppe_foe_get_entry_hash
  		hv3 = hwe->ipv6.src_ip[1] ^ hwe->ipv6.dest_ip[1];
  		hv3 ^= hwe->ipv6.src_ip[0];
  		break;
@@ -117,7 +111,7 @@ index 7219125ade13..d4969c2a0352 100644
  	case PPE_PKT_TYPE_IPV4_DSLITE:
  	case PPE_PKT_TYPE_IPV6_6RD:
  	default:
-@@ -496,15 +512,24 @@ static void airoha_ppe_foe_remove_flow(struct airoha_ppe *ppe,
+@@ -496,15 +512,24 @@ static void airoha_ppe_foe_remove_flow(s
  		airoha_ppe_foe_commit_entry(ppe, &e->data, e->hash);
  		e->hash = 0xffff;
  	}
@@ -142,7 +136,7 @@ index 7219125ade13..d4969c2a0352 100644
  }
  
  static void airoha_ppe_foe_flow_remove_entry(struct airoha_ppe *ppe,
-@@ -520,10 +545,56 @@ static void airoha_ppe_foe_flow_remove_entry(struct airoha_ppe *ppe,
+@@ -520,10 +545,56 @@ static void airoha_ppe_foe_flow_remove_e
  	spin_unlock_bh(&ppe_lock);
  }
  
@@ -200,7 +194,7 @@ index 7219125ade13..d4969c2a0352 100644
  	struct hlist_node *n;
  	u32 index, state;
  
-@@ -539,12 +610,33 @@ static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe, u32 hash)
+@@ -539,12 +610,33 @@ static void airoha_ppe_foe_insert_entry(
  
  	index = airoha_ppe_foe_get_entry_hash(hwe);
  	hlist_for_each_entry_safe(e, n, &ppe->foe_flow[index], list) {
@@ -238,7 +232,7 @@ index 7219125ade13..d4969c2a0352 100644
  unlock:
  	spin_unlock_bh(&ppe_lock);
  }
-@@ -899,7 +991,8 @@ int airoha_ppe_setup_tc_block_cb(enum tc_setup_type type, void *type_data,
+@@ -899,7 +991,8 @@ int airoha_ppe_setup_tc_block_cb(enum tc
  	return err;
  }
  
@@ -248,7 +242,7 @@ index 7219125ade13..d4969c2a0352 100644
  {
  	u16 now, diff;
  
-@@ -912,7 +1005,7 @@ void airoha_ppe_check_skb(struct airoha_ppe *ppe, u16 hash)
+@@ -912,7 +1005,7 @@ void airoha_ppe_check_skb(struct airoha_
  		return;
  
  	ppe->foe_check_time[hash] = now;
@@ -257,6 +251,3 @@ index 7219125ade13..d4969c2a0352 100644
  }
  
  int airoha_ppe_init(struct airoha_eth *eth)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/069-v6.16-net-airoha-Add-matchall-filter-offload-support.patch
+++ b/target/linux/airoha/patches-6.6/069-v6.16-net-airoha-Add-matchall-filter-offload-support.patch
@@ -27,11 +27,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_regs.h |   7 +
  4 files changed, 286 insertions(+), 11 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 723eba7cfa0c..c773b5ea9c05 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -527,6 +527,25 @@ static int airoha_fe_init(struct airoha_eth *eth)
+@@ -527,6 +527,25 @@ static int airoha_fe_init(struct airoha_
  	/* disable IFC by default */
  	airoha_fe_clear(eth, REG_FE_CSR_IFC_CFG, FE_IFC_EN_MASK);
  
@@ -57,7 +55,7 @@ index 723eba7cfa0c..c773b5ea9c05 100644
  	/* enable 1:N vlan action, init vlan table */
  	airoha_fe_set(eth, REG_MC_VLAN_EN, MC_VLAN_EN_MASK);
  
-@@ -1631,7 +1650,6 @@ static void airhoha_set_gdm2_loopback(struct airoha_gdm_port *port)
+@@ -1632,7 +1651,6 @@ static void airhoha_set_gdm2_loopback(st
  
  	if (port->id == 3) {
  		/* FIXME: handle XSI_PCE1_PORT */
@@ -65,7 +63,7 @@ index 723eba7cfa0c..c773b5ea9c05 100644
  		airoha_fe_rmw(eth, REG_FE_WAN_PORT,
  			      WAN1_EN_MASK | WAN1_MASK | WAN0_MASK,
  			      FIELD_PREP(WAN0_MASK, HSGMII_LAN_PCIE0_SRCPORT));
-@@ -2109,6 +2127,125 @@ static int airoha_tc_setup_qdisc_ets(struct airoha_gdm_port *port,
+@@ -2107,6 +2125,125 @@ static int airoha_tc_setup_qdisc_ets(str
  	}
  }
  
@@ -191,7 +189,7 @@ index 723eba7cfa0c..c773b5ea9c05 100644
  static int airoha_qdma_get_trtcm_param(struct airoha_qdma *qdma, int channel,
  				       u32 addr, enum trtcm_param_type param,
  				       enum trtcm_mode_type mode,
-@@ -2273,10 +2410,142 @@ static int airoha_tc_htb_alloc_leaf_queue(struct airoha_gdm_port *port,
+@@ -2271,10 +2408,142 @@ static int airoha_tc_htb_alloc_leaf_queu
  	return 0;
  }
  
@@ -335,8 +333,6 @@ index 723eba7cfa0c..c773b5ea9c05 100644
  	static LIST_HEAD(block_cb_list);
  	struct flow_block_cb *block_cb;
  
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index e82abfc1a67b..da5371bcd147 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -127,6 +127,11 @@ enum tx_sched_mode {
@@ -351,7 +347,7 @@ index e82abfc1a67b..da5371bcd147 100644
  enum trtcm_param_type {
  	TRTCM_MISC_MODE, /* meter_en, pps_mode, tick_sel */
  	TRTCM_TOKEN_RATE_MODE,
-@@ -554,8 +559,7 @@ bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+@@ -554,8 +559,7 @@ bool airoha_is_valid_gdm_port(struct air
  
  void airoha_ppe_check_skb(struct airoha_ppe *ppe, struct sk_buff *skb,
  			  u16 hash);
@@ -361,11 +357,9 @@ index e82abfc1a67b..da5371bcd147 100644
  int airoha_ppe_init(struct airoha_eth *eth);
  void airoha_ppe_deinit(struct airoha_eth *eth);
  struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index d4969c2a0352..6e9787c2843b 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -967,18 +967,13 @@ static int airoha_ppe_offload_setup(struct airoha_eth *eth)
+@@ -967,18 +967,13 @@ error_npu_put:
  	return err;
  }
  
@@ -386,8 +380,6 @@ index d4969c2a0352..6e9787c2843b 100644
  	mutex_lock(&flow_offload_mutex);
  
  	if (!eth->npu)
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 8146cde4e8ba..29c8f046b991 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
 @@ -283,6 +283,7 @@
@@ -411,6 +403,3 @@ index 8146cde4e8ba..29c8f046b991 100644
  #define REG_TXWRR_MODE_CFG		0x1020
  #define TWRR_WEIGHT_SCALE_MASK		BIT(31)
  #define TWRR_WEIGHT_BASE_MASK		BIT(3)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/070-01-v6.16-net-airoha-Introduce-airoha_irq_bank-struct.patch
+++ b/target/linux/airoha/patches-6.6/070-01-v6.16-net-airoha-Introduce-airoha_irq_bank-struct.patch
@@ -18,11 +18,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_regs.h |  11 ++-
  3 files changed, 86 insertions(+), 44 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index c773b5ea9c05..e1c1cf965c2f 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -34,37 +34,40 @@ u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val)
+@@ -34,37 +34,40 @@ u32 airoha_rmw(void __iomem *base, u32 o
  	return val;
  }
  
@@ -78,7 +76,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  }
  
  static bool airhoa_is_lan_gdm_port(struct airoha_gdm_port *port)
-@@ -732,6 +735,7 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -732,6 +735,7 @@ free_frag:
  static int airoha_qdma_rx_napi_poll(struct napi_struct *napi, int budget)
  {
  	struct airoha_queue *q = container_of(napi, struct airoha_queue, napi);
@@ -86,7 +84,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  	int cur, done = 0;
  
  	do {
-@@ -740,7 +744,7 @@ static int airoha_qdma_rx_napi_poll(struct napi_struct *napi, int budget)
+@@ -740,7 +744,7 @@ static int airoha_qdma_rx_napi_poll(stru
  	} while (cur && done < budget);
  
  	if (done < budget && napi_complete(napi))
@@ -95,7 +93,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  				       RX_DONE_INT_MASK);
  
  	return done;
-@@ -944,7 +948,7 @@ static int airoha_qdma_tx_napi_poll(struct napi_struct *napi, int budget)
+@@ -945,7 +949,7 @@ unlock:
  	}
  
  	if (done < budget && napi_complete(napi))
@@ -104,7 +102,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  				       TX_DONE_INT_MASK(id));
  
  	return done;
-@@ -1175,13 +1179,16 @@ static int airoha_qdma_hw_init(struct airoha_qdma *qdma)
+@@ -1176,13 +1180,16 @@ static int airoha_qdma_hw_init(struct ai
  	int i;
  
  	/* clear pending irqs */
@@ -125,7 +123,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  
  	/* setup irq binding */
  	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
-@@ -1226,13 +1233,14 @@ static int airoha_qdma_hw_init(struct airoha_qdma *qdma)
+@@ -1227,13 +1234,14 @@ static int airoha_qdma_hw_init(struct ai
  
  static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
  {
@@ -144,7 +142,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  		airoha_qdma_wr(qdma, REG_INT_STATUS(i), intr[i]);
  	}
  
-@@ -1240,7 +1248,7 @@ static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
+@@ -1241,7 +1249,7 @@ static irqreturn_t airoha_irq_handler(in
  		return IRQ_NONE;
  
  	if (intr[1] & RX_DONE_INT_MASK) {
@@ -153,7 +151,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  					RX_DONE_INT_MASK);
  
  		for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
-@@ -1257,7 +1265,7 @@ static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
+@@ -1258,7 +1266,7 @@ static irqreturn_t airoha_irq_handler(in
  			if (!(intr[0] & TX_DONE_INT_MASK(i)))
  				continue;
  
@@ -162,7 +160,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  						TX_DONE_INT_MASK(i));
  			napi_schedule(&qdma->q_tx_irq[i].napi);
  		}
-@@ -1266,6 +1274,39 @@ static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
+@@ -1267,6 +1275,39 @@ static irqreturn_t airoha_irq_handler(in
  	return IRQ_HANDLED;
  }
  
@@ -202,7 +200,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  static int airoha_qdma_init(struct platform_device *pdev,
  			    struct airoha_eth *eth,
  			    struct airoha_qdma *qdma)
-@@ -1273,9 +1314,7 @@ static int airoha_qdma_init(struct platform_device *pdev,
+@@ -1274,9 +1315,7 @@ static int airoha_qdma_init(struct platf
  	int err, id = qdma - &eth->qdma[0];
  	const char *res;
  
@@ -212,7 +210,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  	res = devm_kasprintf(eth->dev, GFP_KERNEL, "qdma%d", id);
  	if (!res)
  		return -ENOMEM;
-@@ -1285,12 +1324,7 @@ static int airoha_qdma_init(struct platform_device *pdev,
+@@ -1286,12 +1325,7 @@ static int airoha_qdma_init(struct platf
  		return dev_err_probe(eth->dev, PTR_ERR(qdma->regs),
  				     "failed to iomap qdma%d regs\n", id);
  
@@ -226,7 +224,7 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  	if (err)
  		return err;
  
-@@ -2784,7 +2818,7 @@ static int airoha_alloc_gdm_port(struct airoha_eth *eth,
+@@ -2782,7 +2816,7 @@ static int airoha_alloc_gdm_port(struct
  	dev->features |= dev->hw_features;
  	dev->vlan_features = dev->hw_features;
  	dev->dev.of_node = np;
@@ -235,8 +233,6 @@ index c773b5ea9c05..e1c1cf965c2f 100644
  	SET_NETDEV_DEV(dev, eth->dev);
  
  	/* reserve hw queues for HTB offloading */
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index da5371bcd147..af263203d488 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -17,6 +17,7 @@
@@ -274,8 +270,6 @@ index da5371bcd147..af263203d488 100644
  	struct airoha_tx_irq_queue q_tx_irq[AIROHA_NUM_TX_IRQ];
  
  	struct airoha_queue q_tx[AIROHA_NUM_TX_RING];
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 29c8f046b991..1d99fe9f8112 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
 @@ -423,11 +423,12 @@
@@ -296,6 +290,3 @@ index 29c8f046b991..1d99fe9f8112 100644
  
  /* QDMA_CSR_INT_ENABLE1 */
  #define RX15_COHERENT_INT_MASK		BIT(31)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/070-02-v6.16-net-airoha-Enable-multiple-IRQ-lines-support-in-airo.patch
+++ b/target/linux/airoha/patches-6.6/070-02-v6.16-net-airoha-Enable-multiple-IRQ-lines-support-in-airo.patch
@@ -24,11 +24,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_regs.h | 185 +++++++++++++++++-----
  3 files changed, 206 insertions(+), 59 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index e1c1cf965c2f..16c7896f931f 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -735,7 +735,6 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -735,7 +735,6 @@ free_frag:
  static int airoha_qdma_rx_napi_poll(struct napi_struct *napi, int budget)
  {
  	struct airoha_queue *q = container_of(napi, struct airoha_queue, napi);
@@ -36,7 +34,7 @@ index e1c1cf965c2f..16c7896f931f 100644
  	int cur, done = 0;
  
  	do {
-@@ -743,9 +742,20 @@ static int airoha_qdma_rx_napi_poll(struct napi_struct *napi, int budget)
+@@ -743,9 +742,20 @@ static int airoha_qdma_rx_napi_poll(stru
  		done += cur;
  	} while (cur && done < budget);
  
@@ -60,7 +58,7 @@ index e1c1cf965c2f..16c7896f931f 100644
  
  	return done;
  }
-@@ -1178,17 +1188,24 @@ static int airoha_qdma_hw_init(struct airoha_qdma *qdma)
+@@ -1179,17 +1189,24 @@ static int airoha_qdma_hw_init(struct ai
  {
  	int i;
  
@@ -93,7 +91,7 @@ index e1c1cf965c2f..16c7896f931f 100644
  
  	/* setup irq binding */
  	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
-@@ -1235,6 +1252,7 @@ static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
+@@ -1236,6 +1253,7 @@ static irqreturn_t airoha_irq_handler(in
  {
  	struct airoha_irq_bank *irq_bank = dev_instance;
  	struct airoha_qdma *qdma = irq_bank->qdma;
@@ -101,7 +99,7 @@ index e1c1cf965c2f..16c7896f931f 100644
  	u32 intr[ARRAY_SIZE(irq_bank->irqmask)];
  	int i;
  
-@@ -1247,17 +1265,24 @@ static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
+@@ -1248,17 +1266,24 @@ static irqreturn_t airoha_irq_handler(in
  	if (!test_bit(DEV_STATE_INITIALIZED, &qdma->eth->state))
  		return IRQ_NONE;
  
@@ -135,8 +133,6 @@ index e1c1cf965c2f..16c7896f931f 100644
  	}
  
  	if (intr[0] & INT_TX_MASK) {
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index af263203d488..53f39083a8b0 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -17,7 +17,7 @@
@@ -166,8 +162,6 @@ index af263203d488..53f39083a8b0 100644
  struct airoha_irq_bank {
  	struct airoha_qdma *qdma;
  
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 1d99fe9f8112..d931530fc96f 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
 @@ -463,6 +463,26 @@
@@ -383,6 +377,3 @@ index 1d99fe9f8112..d931530fc96f 100644
  
  #define REG_TX_IRQ_BASE(_n)		((_n) ? 0x0048 : 0x0050)
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/071-v6.15-net-airoha-Add-missing-field-to-ppe_mbox_data-struct.patch
+++ b/target/linux/airoha/patches-6.6/071-v6.15-net-airoha-Add-missing-field-to-ppe_mbox_data-struct.patch
@@ -25,8 +25,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.c | 10 ++++++----
  1 file changed, 6 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 7a5710f9ccf6..ead0625e781f 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
 @@ -104,12 +104,14 @@ struct ppe_mbox_data {
@@ -48,6 +46,3 @@ index 7a5710f9ccf6..ead0625e781f 100644
  			u32 size;
  			u32 data;
  		} set_info;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/072-v6.15-net-airoha-Fix-page-recycling-in-airoha_qdma_rx_proc.patch
+++ b/target/linux/airoha/patches-6.6/072-v6.15-net-airoha-Fix-page-recycling-in-airoha_qdma_rx_proc.patch
@@ -18,11 +18,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 22 +++++++++-------------
  1 file changed, 9 insertions(+), 13 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index d748dc6de923..1e9ab65218ff 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -614,7 +614,6 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -636,7 +636,6 @@ static int airoha_qdma_rx_process(struct
  		struct airoha_queue_entry *e = &q->entry[q->tail];
  		struct airoha_qdma_desc *desc = &q->desc[q->tail];
  		u32 hash, reason, msg1 = le32_to_cpu(desc->msg1);
@@ -30,7 +28,7 @@ index d748dc6de923..1e9ab65218ff 100644
  		struct page *page = virt_to_head_page(e->buf);
  		u32 desc_ctrl = le32_to_cpu(desc->ctrl);
  		struct airoha_gdm_port *port;
-@@ -623,22 +622,16 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -645,22 +644,16 @@ static int airoha_qdma_rx_process(struct
  		if (!(desc_ctrl & QDMA_DESC_DONE_MASK))
  			break;
  
@@ -56,7 +54,7 @@ index d748dc6de923..1e9ab65218ff 100644
  			goto free_frag;
  
  		p = airoha_qdma_get_gdm_port(eth, desc);
-@@ -701,9 +694,12 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -723,9 +716,12 @@ static int airoha_qdma_rx_process(struct
  		q->skb = NULL;
  		continue;
  free_frag:
@@ -72,6 +70,3 @@ index d748dc6de923..1e9ab65218ff 100644
  	}
  	airoha_qdma_fill_rx_queue(q);
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/073-01-v6.16-net-airoha-npu-Move-memory-allocation-in-airoha_npu_.patch
+++ b/target/linux/airoha/patches-6.6/073-01-v6.16-net-airoha-npu-Move-memory-allocation-in-airoha_npu_.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.c | 126 +++++++++++++----------
  1 file changed, 72 insertions(+), 54 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index ead0625e781f..51c6fbd7b7b7 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
-@@ -124,17 +124,12 @@ static int airoha_npu_send_msg(struct airoha_npu *npu, int func_id,
+@@ -124,17 +124,12 @@ static int airoha_npu_send_msg(struct ai
  	u16 core = 0; /* FIXME */
  	u32 val, offset = core << 4;
  	dma_addr_t dma_addr;
@@ -40,7 +38,7 @@ index ead0625e781f..51c6fbd7b7b7 100644
  
  	spin_lock_bh(&npu->cores[core].lock);
  
-@@ -155,8 +150,6 @@ static int airoha_npu_send_msg(struct airoha_npu *npu, int func_id,
+@@ -155,8 +150,6 @@ static int airoha_npu_send_msg(struct ai
  	spin_unlock_bh(&npu->cores[core].lock);
  
  	dma_unmap_single(npu->dev, dma_addr, size, DMA_TO_DEVICE);
@@ -49,7 +47,7 @@ index ead0625e781f..51c6fbd7b7b7 100644
  
  	return ret;
  }
-@@ -261,76 +254,101 @@ static irqreturn_t airoha_npu_wdt_handler(int irq, void *core_instance)
+@@ -261,76 +254,101 @@ static irqreturn_t airoha_npu_wdt_handle
  
  static int airoha_npu_ppe_init(struct airoha_npu *npu)
  {
@@ -63,13 +61,13 @@ index ead0625e781f..51c6fbd7b7b7 100644
 -	};
 +	struct ppe_mbox_data *ppe_data;
 +	int err;
-+
-+	ppe_data = kzalloc(sizeof(*ppe_data), GFP_KERNEL);
-+	if (!ppe_data)
-+		return -ENOMEM;
  
 -	return airoha_npu_send_msg(npu, NPU_FUNC_PPE, &ppe_data,
 -				   sizeof(struct ppe_mbox_data));
++	ppe_data = kzalloc(sizeof(*ppe_data), GFP_KERNEL);
++	if (!ppe_data)
++		return -ENOMEM;
++
 +	ppe_data->func_type = NPU_OP_SET;
 +	ppe_data->func_id = PPE_FUNC_SET_WAIT_HWNAT_INIT;
 +	ppe_data->init_info.ppe_type = PPE_TYPE_L2B_IPV4_IPV6;
@@ -94,12 +92,12 @@ index ead0625e781f..51c6fbd7b7b7 100644
 +	ppe_data = kzalloc(sizeof(*ppe_data), GFP_KERNEL);
 +	if (!ppe_data)
 +		return -ENOMEM;
-+
-+	ppe_data->func_type = NPU_OP_SET;
-+	ppe_data->func_id = PPE_FUNC_SET_WAIT_HWNAT_DEINIT;
  
 -	return airoha_npu_send_msg(npu, NPU_FUNC_PPE, &ppe_data,
 -				   sizeof(struct ppe_mbox_data));
++	ppe_data->func_type = NPU_OP_SET;
++	ppe_data->func_id = PPE_FUNC_SET_WAIT_HWNAT_DEINIT;
++
 +	err = airoha_npu_send_msg(npu, NPU_FUNC_PPE, ppe_data,
 +				  sizeof(*ppe_data));
 +	kfree(ppe_data);
@@ -177,14 +175,14 @@ index ead0625e781f..51c6fbd7b7b7 100644
  	if (err)
 -		return err;
 +		goto out;
-+
-+	ppe_data->set_info.func_id = PPE_SRAM_SET_VAL;
-+	ppe_data->set_info.data = hash;
-+	ppe_data->set_info.size = sizeof(u32);
  
 -	ppe_data.set_info.func_id = PPE_SRAM_SET_VAL;
 -	ppe_data.set_info.data = hash;
 -	ppe_data.set_info.size = sizeof(u32);
++	ppe_data->set_info.func_id = PPE_SRAM_SET_VAL;
++	ppe_data->set_info.data = hash;
++	ppe_data->set_info.size = sizeof(u32);
++
 +	err = airoha_npu_send_msg(npu, NPU_FUNC_PPE, ppe_data,
 +				  sizeof(*ppe_data));
 +out:
@@ -196,6 +194,3 @@ index ead0625e781f..51c6fbd7b7b7 100644
  }
  
  struct airoha_npu *airoha_npu_get(struct device *dev)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/073-02-v6.16-net-airoha-Add-FLOW_CLS_STATS-callback-support.patch
+++ b/target/linux/airoha/patches-6.6/073-02-v6.16-net-airoha-Add-FLOW_CLS_STATS-callback-support.patch
@@ -23,8 +23,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  .../net/ethernet/airoha/airoha_ppe_debugfs.c  |   9 +-
  6 files changed, 354 insertions(+), 20 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/Kconfig b/drivers/net/ethernet/airoha/Kconfig
-index 1a4cf6a259f6..ad3ce501e7a5 100644
 --- a/drivers/net/ethernet/airoha/Kconfig
 +++ b/drivers/net/ethernet/airoha/Kconfig
 @@ -24,4 +24,11 @@ config NET_AIROHA
@@ -39,8 +37,6 @@ index 1a4cf6a259f6..ad3ce501e7a5 100644
 +	  Enable Aiorha flowtable statistic counters.
 +
  endif #NET_VENDOR_AIROHA
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 53f39083a8b0..531a3c49c156 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -50,6 +50,14 @@
@@ -123,7 +119,7 @@ index 53f39083a8b0..531a3c49c156 100644
  	struct dentry *debugfs_dir;
  };
  
-@@ -582,6 +613,8 @@ int airoha_ppe_init(struct airoha_eth *eth);
+@@ -582,6 +613,8 @@ int airoha_ppe_init(struct airoha_eth *e
  void airoha_ppe_deinit(struct airoha_eth *eth);
  struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
  						  u32 hash);
@@ -132,8 +128,6 @@ index 53f39083a8b0..531a3c49c156 100644
  
  #ifdef CONFIG_DEBUG_FS
  int airoha_ppe_debugfs_init(struct airoha_ppe *ppe);
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 51c6fbd7b7b7..0e5b8c21b9aa 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
 @@ -12,6 +12,7 @@
@@ -163,7 +157,7 @@ index 51c6fbd7b7b7..0e5b8c21b9aa 100644
  	};
  };
  
-@@ -351,7 +357,40 @@ static int airoha_npu_foe_commit_entry(struct airoha_npu *npu,
+@@ -351,7 +357,40 @@ out:
  	return err;
  }
  
@@ -205,7 +199,7 @@ index 51c6fbd7b7b7..0e5b8c21b9aa 100644
  {
  	struct platform_device *pdev;
  	struct device_node *np;
-@@ -389,6 +428,17 @@ struct airoha_npu *airoha_npu_get(struct device *dev)
+@@ -389,6 +428,17 @@ struct airoha_npu *airoha_npu_get(struct
  		goto error_module_put;
  	}
  
@@ -223,8 +217,6 @@ index 51c6fbd7b7b7..0e5b8c21b9aa 100644
  	return npu;
  
  error_module_put:
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.h b/drivers/net/ethernet/airoha/airoha_npu.h
-index a2b8ae4d9473..98ec3be74ce4 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.h
 +++ b/drivers/net/ethernet/airoha/airoha_npu.h
 @@ -17,6 +17,8 @@ struct airoha_npu {
@@ -243,11 +235,9 @@ index a2b8ae4d9473..98ec3be74ce4 100644
 -struct airoha_npu *airoha_npu_get(struct device *dev);
 +struct airoha_npu *airoha_npu_get(struct device *dev, dma_addr_t *stats_addr);
  void airoha_npu_put(struct airoha_npu *npu);
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 6e9787c2843b..70598ba9f5ad 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -102,7 +102,7 @@ static void airoha_ppe_hw_init(struct airoha_ppe *ppe)
+@@ -102,7 +102,7 @@ static void airoha_ppe_hw_init(struct ai
  
  	if (airoha_ppe2_is_enabled(eth)) {
  		sram_num_entries =
@@ -256,7 +246,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  		airoha_fe_rmw(eth, REG_PPE_TB_CFG(0),
  			      PPE_SRAM_TB_NUM_ENTRY_MASK |
  			      PPE_DRAM_TB_NUM_ENTRY_MASK,
-@@ -119,7 +119,7 @@ static void airoha_ppe_hw_init(struct airoha_ppe *ppe)
+@@ -119,7 +119,7 @@ static void airoha_ppe_hw_init(struct ai
  					 dram_num_entries));
  	} else {
  		sram_num_entries =
@@ -265,7 +255,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  		airoha_fe_rmw(eth, REG_PPE_TB_CFG(0),
  			      PPE_SRAM_TB_NUM_ENTRY_MASK |
  			      PPE_DRAM_TB_NUM_ENTRY_MASK,
-@@ -417,6 +417,77 @@ static u32 airoha_ppe_foe_get_entry_hash(struct airoha_foe_entry *hwe)
+@@ -417,6 +417,77 @@ static u32 airoha_ppe_foe_get_entry_hash
  	return hash;
  }
  
@@ -343,7 +333,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
  						  u32 hash)
  {
-@@ -470,6 +541,8 @@ static int airoha_ppe_foe_commit_entry(struct airoha_ppe *ppe,
+@@ -470,6 +541,8 @@ static int airoha_ppe_foe_commit_entry(s
  	struct airoha_foe_entry *hwe = ppe->foe + hash * sizeof(*hwe);
  	u32 ts = airoha_ppe_get_timestamp(ppe);
  	struct airoha_eth *eth = ppe->eth;
@@ -352,7 +342,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  
  	memcpy(&hwe->d, &e->d, sizeof(*hwe) - sizeof(hwe->ib1));
  	wmb();
-@@ -478,25 +551,28 @@ static int airoha_ppe_foe_commit_entry(struct airoha_ppe *ppe,
+@@ -478,25 +551,28 @@ static int airoha_ppe_foe_commit_entry(s
  	e->ib1 |= FIELD_PREP(AIROHA_FOE_IB1_BIND_TIMESTAMP, ts);
  	hwe->ib1 = e->ib1;
  
@@ -372,7 +362,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  			    hash >= PPE1_SRAM_NUM_ENTRIES;
 -		struct airoha_npu *npu;
 -		int err = -ENODEV;
- 
+-
 -		rcu_read_lock();
 -		npu = rcu_dereference(eth->npu);
 -		if (npu)
@@ -380,7 +370,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
 -							    sizeof(*hwe), hash,
 -							    ppe2);
 -		rcu_read_unlock();
--
+ 
 -		return err;
 +		err = npu->ops.ppe_foe_commit_entry(npu, addr, sizeof(*hwe),
 +						    hash, ppe2);
@@ -393,7 +383,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  }
  
  static void airoha_ppe_foe_remove_flow(struct airoha_ppe *ppe,
-@@ -582,6 +658,7 @@ airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
+@@ -582,6 +658,7 @@ airoha_ppe_foe_commit_subflow_entry(stru
  		l2->common.etype = ETH_P_IPV6;
  
  	hwe.bridge.ib2 = e->data.bridge.ib2;
@@ -401,7 +391,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  	airoha_ppe_foe_commit_entry(ppe, &hwe, hash);
  
  	return 0;
-@@ -681,6 +758,98 @@ static int airoha_ppe_foe_flow_commit_entry(struct airoha_ppe *ppe,
+@@ -681,6 +758,98 @@ static int airoha_ppe_foe_flow_commit_en
  	return 0;
  }
  
@@ -500,7 +490,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  static int airoha_ppe_flow_offload_replace(struct airoha_gdm_port *port,
  					   struct flow_cls_offload *f)
  {
-@@ -896,6 +1065,60 @@ static int airoha_ppe_flow_offload_destroy(struct airoha_gdm_port *port,
+@@ -896,6 +1065,60 @@ static int airoha_ppe_flow_offload_destr
  	return 0;
  }
  
@@ -561,7 +551,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  static int airoha_ppe_flow_offload_cmd(struct airoha_gdm_port *port,
  				       struct flow_cls_offload *f)
  {
-@@ -904,6 +1127,8 @@ static int airoha_ppe_flow_offload_cmd(struct airoha_gdm_port *port,
+@@ -904,6 +1127,8 @@ static int airoha_ppe_flow_offload_cmd(s
  		return airoha_ppe_flow_offload_replace(port, f);
  	case FLOW_CLS_DESTROY:
  		return airoha_ppe_flow_offload_destroy(port, f);
@@ -570,7 +560,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  	default:
  		break;
  	}
-@@ -929,11 +1154,12 @@ static int airoha_ppe_flush_sram_entries(struct airoha_ppe *ppe,
+@@ -929,11 +1154,12 @@ static int airoha_ppe_flush_sram_entries
  
  static struct airoha_npu *airoha_ppe_npu_get(struct airoha_eth *eth)
  {
@@ -585,7 +575,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  	}
  
  	return npu;
-@@ -956,6 +1182,8 @@ static int airoha_ppe_offload_setup(struct airoha_eth *eth)
+@@ -956,6 +1182,8 @@ static int airoha_ppe_offload_setup(stru
  	if (err)
  		goto error_npu_put;
  
@@ -594,7 +584,7 @@ index 6e9787c2843b..70598ba9f5ad 100644
  	rcu_assign_pointer(eth->npu, npu);
  	synchronize_rcu();
  
-@@ -1027,6 +1255,15 @@ int airoha_ppe_init(struct airoha_eth *eth)
+@@ -1027,6 +1255,15 @@ int airoha_ppe_init(struct airoha_eth *e
  	if (!ppe->foe_flow)
  		return -ENOMEM;
  
@@ -610,11 +600,9 @@ index 6e9787c2843b..70598ba9f5ad 100644
  	err = rhashtable_init(&eth->flow_table, &airoha_flow_table_params);
  	if (err)
  		return err;
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c b/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
-index 3cdc6fd53fc7..05a756233f6a 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
-@@ -61,6 +61,7 @@ static int airoha_ppe_debugfs_foe_show(struct seq_file *m, void *private,
+@@ -61,6 +61,7 @@ static int airoha_ppe_debugfs_foe_show(s
  		u16 *src_port = NULL, *dest_port = NULL;
  		struct airoha_foe_mac_info_common *l2;
  		unsigned char h_source[ETH_ALEN] = {};
@@ -622,7 +610,7 @@ index 3cdc6fd53fc7..05a756233f6a 100644
  		unsigned char h_dest[ETH_ALEN];
  		struct airoha_foe_entry *hwe;
  		u32 type, state, ib2, data;
-@@ -144,14 +145,18 @@ static int airoha_ppe_debugfs_foe_show(struct seq_file *m, void *private,
+@@ -144,14 +145,18 @@ static int airoha_ppe_debugfs_foe_show(s
  				cpu_to_be16(hwe->ipv4.l2.src_mac_lo);
  		}
  
@@ -643,6 +631,3 @@ index 3cdc6fd53fc7..05a756233f6a 100644
  	}
  
  	return 0;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/073-03-v6.16-net-airoha-ppe-Disable-packet-keepalive.patch
+++ b/target/linux/airoha/patches-6.6/073-03-v6.16-net-airoha-ppe-Disable-packet-keepalive.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 70598ba9f5ad..2d273937f19c 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -84,6 +84,7 @@ static void airoha_ppe_hw_init(struct airoha_ppe *ppe)
+@@ -84,6 +84,7 @@ static void airoha_ppe_hw_init(struct ai
  
  		airoha_fe_rmw(eth, REG_PPE_TB_CFG(i),
  			      PPE_TB_CFG_SEARCH_MISS_MASK |
@@ -28,6 +26,3 @@ index 70598ba9f5ad..2d273937f19c 100644
  			      PPE_TB_ENTRY_SIZE_MASK,
  			      FIELD_PREP(PPE_TB_CFG_SEARCH_MISS_MASK, 3) |
  			      FIELD_PREP(PPE_TB_ENTRY_SIZE_MASK, 0));
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/074-01-v6.16-net-airoha-Do-not-store-hfwd-references-in-airoha_qd.patch
+++ b/target/linux/airoha/patches-6.6/074-01-v6.16-net-airoha-Do-not-store-hfwd-references-in-airoha_qd.patch
@@ -18,11 +18,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_eth.h | 6 ------
  2 files changed, 2 insertions(+), 12 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 0d627e511266..1ed43a5c629f 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1077,17 +1077,13 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1078,17 +1078,13 @@ static int airoha_qdma_init_hfwd_queues(
  	int size;
  
  	size = HW_DSCP_NUM * sizeof(struct airoha_qdma_fwd_desc);
@@ -42,8 +40,6 @@ index 0d627e511266..1ed43a5c629f 100644
  		return -ENOMEM;
  
  	airoha_qdma_wr(qdma, REG_FWD_BUF_BASE, dma_addr);
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 531a3c49c156..3e03ae9a5d0d 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -513,12 +513,6 @@ struct airoha_qdma {
@@ -59,6 +55,3 @@ index 531a3c49c156..3e03ae9a5d0d 100644
  };
  
  struct airoha_gdm_port {
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/074-02-v6.16-net-airoha-Add-the-capability-to-allocate-hwfd-buffe.patch
+++ b/target/linux/airoha/patches-6.6/074-02-v6.16-net-airoha-Add-the-capability-to-allocate-hwfd-buffe.patch
@@ -17,8 +17,6 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_eth.c | 33 +++++++++++++++++++++---
  1 file changed, 30 insertions(+), 3 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 1ed43a5c629f..8a8a6424c1dd 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
 @@ -5,6 +5,7 @@
@@ -29,7 +27,7 @@ index 1ed43a5c629f..8a8a6424c1dd 100644
  #include <linux/platform_device.h>
  #include <linux/tcp.h>
  #include <linux/u64_stats_sync.h>
-@@ -1072,9 +1073,11 @@ static void airoha_qdma_cleanup_tx_queue(struct airoha_queue *q)
+@@ -1073,9 +1074,11 @@ static void airoha_qdma_cleanup_tx_queue
  static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
  {
  	struct airoha_eth *eth = qdma->eth;
@@ -42,7 +40,7 @@ index 1ed43a5c629f..8a8a6424c1dd 100644
  
  	size = HW_DSCP_NUM * sizeof(struct airoha_qdma_fwd_desc);
  	if (!dmam_alloc_coherent(eth->dev, size, &dma_addr, GFP_KERNEL))
-@@ -1082,10 +1085,34 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1083,10 +1086,34 @@ static int airoha_qdma_init_hfwd_queues(
  
  	airoha_qdma_wr(qdma, REG_FWD_DSCP_BASE, dma_addr);
  
@@ -79,6 +77,3 @@ index 1ed43a5c629f..8a8a6424c1dd 100644
  	airoha_qdma_wr(qdma, REG_FWD_BUF_BASE, dma_addr);
  
  	airoha_qdma_rmw(qdma, REG_HW_FWD_DSCP_CFG,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/074-03-v6.16-net-airoha-Add-the-capability-to-allocate-hfwd-descr.patch
+++ b/target/linux/airoha/patches-6.6/074-03-v6.16-net-airoha-Add-the-capability-to-allocate-hfwd-descr.patch
@@ -20,11 +20,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_ppe.c |  6 ++++++
  3 files changed, 16 insertions(+), 10 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 8a8a6424c1dd..507ba046c719 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -71,15 +71,6 @@ static void airoha_qdma_irq_disable(struct airoha_irq_bank *irq_bank,
+@@ -71,15 +71,6 @@ static void airoha_qdma_irq_disable(stru
  	airoha_qdma_set_irqmask(irq_bank, index, mask, 0);
  }
  
@@ -40,7 +38,7 @@ index 8a8a6424c1dd..507ba046c719 100644
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1124,7 +1115,7 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1125,7 +1116,7 @@ static int airoha_qdma_init_hfwd_queues(
  			LMGR_INIT_START | LMGR_SRAM_MODE_MASK |
  			HW_FWD_DESC_NUM_MASK,
  			FIELD_PREP(HW_FWD_DESC_NUM_MASK, HW_DSCP_NUM) |
@@ -49,11 +47,9 @@ index 8a8a6424c1dd..507ba046c719 100644
  
  	return read_poll_timeout(airoha_qdma_rr, status,
  				 !(status & LMGR_INIT_START), USEC_PER_MSEC,
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 3e03ae9a5d0d..b815697302bf 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -597,6 +597,15 @@ u32 airoha_rmw(void __iomem *base, u32 offset, u32 mask, u32 val);
+@@ -597,6 +597,15 @@ u32 airoha_rmw(void __iomem *base, u32 o
  #define airoha_qdma_clear(qdma, offset, val)			\
  	airoha_rmw((qdma)->regs, (offset), (val), 0)
  
@@ -69,11 +65,9 @@ index 3e03ae9a5d0d..b815697302bf 100644
  bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
  			      struct airoha_gdm_port *port);
  
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 2d273937f19c..12d32c92717a 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -251,6 +251,12 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -251,6 +251,12 @@ static int airoha_ppe_foe_entry_prepare(
  		else
  			pse_port = 2; /* uplink relies on GDM2 loopback */
  		val |= FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT, pse_port);
@@ -86,6 +80,3 @@ index 2d273937f19c..12d32c92717a 100644
  	}
  
  	if (is_multicast_ether_addr(data->eth.h_dest))
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/075-v6.16-net-airoha-Fix-an-error-handling-path-in-airoha_allo.patch
+++ b/target/linux/airoha/patches-6.6/075-v6.16-net-airoha-Fix-an-error-handling-path-in-airoha_allo.patch
@@ -21,11 +21,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 10 +++++++++-
  1 file changed, 9 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 1e9ab65218ff..c169b8b411b4 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2541,7 +2541,15 @@ static int airoha_alloc_gdm_port(struct airoha_eth *eth,
+@@ -2881,7 +2881,15 @@ static int airoha_alloc_gdm_port(struct
  	if (err)
  		return err;
  
@@ -42,6 +40,3 @@ index 1e9ab65218ff..c169b8b411b4 100644
  }
  
  static int airoha_probe(struct platform_device *pdev)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/076-01-v6.16-net-airoha-Initialize-PPE-UPDMEM-source-mac-table.patch
+++ b/target/linux/airoha/patches-6.6/076-01-v6.16-net-airoha-Initialize-PPE-UPDMEM-source-mac-table.patch
@@ -24,11 +24,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_regs.h | 10 +++++++++
  4 files changed, 38 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index d1d3b854361e..a7ec609d64de 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -84,6 +84,8 @@ static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
+@@ -84,6 +84,8 @@ static void airoha_set_macaddr(struct ai
  	val = (addr[3] << 16) | (addr[4] << 8) | addr[5];
  	airoha_fe_wr(eth, REG_FE_MAC_LMIN(reg), val);
  	airoha_fe_wr(eth, REG_FE_MAC_LMAX(reg), val);
@@ -37,11 +35,9 @@ index d1d3b854361e..a7ec609d64de 100644
  }
  
  static void airoha_set_gdm_port_fwd_cfg(struct airoha_eth *eth, u32 addr,
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index b815697302bf..a970b789cf23 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -614,6 +614,7 @@ void airoha_ppe_check_skb(struct airoha_ppe *ppe, struct sk_buff *skb,
+@@ -614,6 +614,7 @@ void airoha_ppe_check_skb(struct airoha_
  int airoha_ppe_setup_tc_block_cb(struct net_device *dev, void *type_data);
  int airoha_ppe_init(struct airoha_eth *eth);
  void airoha_ppe_deinit(struct airoha_eth *eth);
@@ -49,11 +45,9 @@ index b815697302bf..a970b789cf23 100644
  struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
  						  u32 hash);
  void airoha_ppe_foe_entry_get_stats(struct airoha_ppe *ppe, u32 hash,
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 12d32c92717a..a783f16980e6 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -223,6 +223,7 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -223,6 +223,7 @@ static int airoha_ppe_foe_entry_prepare(
  	int dsa_port = airoha_get_dsa_port(&dev);
  	struct airoha_foe_mac_info_common *l2;
  	u32 qdata, ports_pad, val;
@@ -61,7 +55,7 @@ index 12d32c92717a..a783f16980e6 100644
  
  	memset(hwe, 0, sizeof(*hwe));
  
-@@ -257,6 +258,8 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -257,6 +258,8 @@ static int airoha_ppe_foe_entry_prepare(
  		 */
  		if (airhoa_is_lan_gdm_port(port))
  			val |= AIROHA_FOE_IB2_FAST_PATH;
@@ -70,7 +64,7 @@ index 12d32c92717a..a783f16980e6 100644
  	}
  
  	if (is_multicast_ether_addr(data->eth.h_dest))
-@@ -291,7 +294,7 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -291,7 +294,7 @@ static int airoha_ppe_foe_entry_prepare(
  		hwe->ipv4.l2.src_mac_lo =
  			get_unaligned_be16(data->eth.h_source + 4);
  	} else {
@@ -79,7 +73,7 @@ index 12d32c92717a..a783f16980e6 100644
  	}
  
  	if (data->vlan.num) {
-@@ -1238,6 +1241,27 @@ void airoha_ppe_check_skb(struct airoha_ppe *ppe, struct sk_buff *skb,
+@@ -1238,6 +1241,27 @@ void airoha_ppe_check_skb(struct airoha_
  	airoha_ppe_foe_insert_entry(ppe, skb, hash);
  }
  
@@ -107,8 +101,6 @@ index 12d32c92717a..a783f16980e6 100644
  int airoha_ppe_init(struct airoha_eth *eth)
  {
  	struct airoha_ppe *ppe;
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index d931530fc96f..04187eb40ec6 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
 @@ -313,6 +313,16 @@
@@ -128,6 +120,3 @@ index d931530fc96f..04187eb40ec6 100644
  #define REG_FE_GDM_TX_OK_PKT_CNT_H(_n)		(GDM_BASE(_n) + 0x280)
  #define REG_FE_GDM_TX_OK_BYTE_CNT_H(_n)		(GDM_BASE(_n) + 0x284)
  #define REG_FE_GDM_TX_ETH_PKT_CNT_H(_n)		(GDM_BASE(_n) + 0x288)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/076-02-v6.16-net-airoha-Fix-IPv6-hw-acceleration-in-bridge-mode.patch
+++ b/target/linux/airoha/patches-6.6/076-02-v6.16-net-airoha-Fix-IPv6-hw-acceleration-in-bridge-mode.patch
@@ -22,11 +22,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_ppe.c | 23 ++++++++++++-----------
  1 file changed, 12 insertions(+), 11 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index a783f16980e6..557779093a79 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -639,7 +639,6 @@ airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
+@@ -639,7 +639,6 @@ airoha_ppe_foe_commit_subflow_entry(stru
  	u32 mask = AIROHA_FOE_IB1_BIND_PACKET_TYPE | AIROHA_FOE_IB1_BIND_UDP;
  	struct airoha_foe_entry *hwe_p, hwe;
  	struct airoha_flow_table_entry *f;
@@ -34,7 +32,7 @@ index a783f16980e6..557779093a79 100644
  	int type;
  
  	hwe_p = airoha_ppe_foe_get_entry(ppe, hash);
-@@ -656,18 +655,20 @@ airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
+@@ -656,18 +655,20 @@ airoha_ppe_foe_commit_subflow_entry(stru
  
  	memcpy(&hwe, hwe_p, sizeof(*hwe_p));
  	hwe.ib1 = (hwe.ib1 & mask) | (e->data.ib1 & ~mask);
@@ -48,8 +46,6 @@ index a783f16980e6..557779093a79 100644
 -	else if (type >= PPE_PKT_TYPE_IPV6_ROUTE_3T &&
 -		 l2->common.etype == ETH_P_IP)
 -		l2->common.etype = ETH_P_IPV6;
--
--	hwe.bridge.ib2 = e->data.bridge.ib2;
 +	if (type >= PPE_PKT_TYPE_IPV6_ROUTE_3T) {
 +		memcpy(&hwe.ipv6.l2, &e->data.bridge.l2, sizeof(hwe.ipv6.l2));
 +		hwe.ipv6.ib2 = e->data.bridge.ib2;
@@ -61,10 +57,8 @@ index a783f16980e6..557779093a79 100644
 +			memcpy(&hwe.ipv4.new_tuple, &hwe.ipv4.orig_tuple,
 +			       sizeof(hwe.ipv4.new_tuple));
 +	}
-+
+ 
+-	hwe.bridge.ib2 = e->data.bridge.ib2;
  	hwe.bridge.data = e->data.bridge.data;
  	airoha_ppe_foe_commit_entry(ppe, &hwe, hash);
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/076-03-v6.16-net-airoha-Fix-smac_id-configuration-in-bridge-mode.patch
+++ b/target/linux/airoha/patches-6.6/076-03-v6.16-net-airoha-Fix-smac_id-configuration-in-bridge-mode.patch
@@ -16,11 +16,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_ppe.c | 5 +++++
  1 file changed, 5 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 557779093a79..9067d2fc7706 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -660,6 +660,11 @@ airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
+@@ -660,6 +660,11 @@ airoha_ppe_foe_commit_subflow_entry(stru
  	if (type >= PPE_PKT_TYPE_IPV6_ROUTE_3T) {
  		memcpy(&hwe.ipv6.l2, &e->data.bridge.l2, sizeof(hwe.ipv6.l2));
  		hwe.ipv6.ib2 = e->data.bridge.ib2;
@@ -32,6 +30,3 @@ index 557779093a79..9067d2fc7706 100644
  	} else {
  		memcpy(&hwe.bridge.l2, &e->data.bridge.l2,
  		       sizeof(hwe.bridge.l2));
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/077-v6.17-net-airoha-Add-PPPoE-offload-support.patch
+++ b/target/linux/airoha/patches-6.6/077-v6.17-net-airoha-Add-PPPoE-offload-support.patch
@@ -12,11 +12,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 31 ++++++++++++++++++------
  1 file changed, 23 insertions(+), 8 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 9067d2fc7706..50d816344b1f 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -232,6 +232,7 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -232,6 +232,7 @@ static int airoha_ppe_foe_entry_prepare(
  	      FIELD_PREP(AIROHA_FOE_IB1_BIND_UDP, l4proto == IPPROTO_UDP) |
  	      FIELD_PREP(AIROHA_FOE_IB1_BIND_VLAN_LAYER, data->vlan.num) |
  	      FIELD_PREP(AIROHA_FOE_IB1_BIND_VPM, data->vlan.num) |
@@ -24,7 +22,7 @@ index 9067d2fc7706..50d816344b1f 100644
  	      AIROHA_FOE_IB1_BIND_TTL;
  	hwe->ib1 = val;
  
-@@ -281,33 +282,42 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -281,33 +282,42 @@ static int airoha_ppe_foe_entry_prepare(
  		hwe->ipv6.data = qdata;
  		hwe->ipv6.ib2 = val;
  		l2 = &hwe->ipv6.l2;
@@ -75,7 +73,7 @@ index 9067d2fc7706..50d816344b1f 100644
  	}
  
  	return 0;
-@@ -957,6 +967,11 @@ static int airoha_ppe_flow_offload_replace(struct airoha_gdm_port *port,
+@@ -957,6 +967,11 @@ static int airoha_ppe_flow_offload_repla
  		case FLOW_ACTION_VLAN_POP:
  			break;
  		case FLOW_ACTION_PPPOE_PUSH:
@@ -87,6 +85,3 @@ index 9067d2fc7706..50d816344b1f 100644
  			break;
  		default:
  			return -EOPNOTSUPP;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/078-v6.16-net-airoha-Enable-RX-queues-16-31.patch
+++ b/target/linux/airoha/patches-6.6/078-v6.16-net-airoha-Enable-RX-queues-16-31.patch
@@ -13,8 +13,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_regs.h | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 04187eb40ec6..150c85995cc1 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
 @@ -614,8 +614,9 @@
@@ -28,6 +26,3 @@ index 04187eb40ec6..150c85995cc1 100644
  
  #define INT_RX2_MASK(_n)				\
  	((RX_NO_CPU_DSCP_HIGH_INT_MASK & (_n)) |	\
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/079-v6.16-net-airoha-Always-check-return-value-from-airoha_ppe.patch
+++ b/target/linux/airoha/patches-6.6/079-v6.16-net-airoha-Always-check-return-value-from-airoha_ppe.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 9067d2fc7706..0e217acfc5ef 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -809,8 +809,10 @@ airoha_ppe_foe_flow_l2_entry_update(struct airoha_ppe *ppe,
+@@ -819,8 +819,10 @@ airoha_ppe_foe_flow_l2_entry_update(stru
  		int idle;
  
  		hwe = airoha_ppe_foe_get_entry(ppe, iter->hash);
@@ -32,6 +30,3 @@ index 9067d2fc7706..0e217acfc5ef 100644
  		state = FIELD_GET(AIROHA_FOE_IB1_BIND_STATE, ib1);
  		if (state != AIROHA_FOE_STATE_BIND) {
  			iter->hash = 0xffff;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/080-01-v6.16-net-airoha-Compute-number-of-descriptors-according-t.patch
+++ b/target/linux/airoha/patches-6.6/080-01-v6.16-net-airoha-Compute-number-of-descriptors-according-t.patch
@@ -17,11 +17,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 21 ++++++++++++---------
  1 file changed, 12 insertions(+), 9 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index a7ec609d64de..1b7fd7ee0cbf 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1065,19 +1065,13 @@ static void airoha_qdma_cleanup_tx_queue(struct airoha_queue *q)
+@@ -1066,19 +1066,13 @@ static void airoha_qdma_cleanup_tx_queue
  
  static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
  {
@@ -42,7 +40,7 @@ index a7ec609d64de..1b7fd7ee0cbf 100644
  	name = devm_kasprintf(eth->dev, GFP_KERNEL, "qdma%d-buf", id);
  	if (!name)
  		return -ENOMEM;
-@@ -1099,8 +1093,12 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1100,8 +1094,12 @@ static int airoha_qdma_init_hfwd_queues(
  		rmem = of_reserved_mem_lookup(np);
  		of_node_put(np);
  		dma_addr = rmem->base;
@@ -56,7 +54,7 @@ index a7ec609d64de..1b7fd7ee0cbf 100644
  		if (!dmam_alloc_coherent(eth->dev, size, &dma_addr,
  					 GFP_KERNEL))
  			return -ENOMEM;
-@@ -1108,6 +1106,11 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1109,6 +1107,11 @@ static int airoha_qdma_init_hfwd_queues(
  
  	airoha_qdma_wr(qdma, REG_FWD_BUF_BASE, dma_addr);
  
@@ -68,7 +66,7 @@ index a7ec609d64de..1b7fd7ee0cbf 100644
  	airoha_qdma_rmw(qdma, REG_HW_FWD_DSCP_CFG,
  			HW_FWD_DSCP_PAYLOAD_SIZE_MASK,
  			FIELD_PREP(HW_FWD_DSCP_PAYLOAD_SIZE_MASK, 0));
-@@ -1116,7 +1119,7 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1117,7 +1120,7 @@ static int airoha_qdma_init_hfwd_queues(
  	airoha_qdma_rmw(qdma, REG_LMGR_INIT_CFG,
  			LMGR_INIT_START | LMGR_SRAM_MODE_MASK |
  			HW_FWD_DESC_NUM_MASK,
@@ -77,6 +75,3 @@ index a7ec609d64de..1b7fd7ee0cbf 100644
  			LMGR_INIT_START | LMGR_SRAM_MODE_MASK);
  
  	return read_poll_timeout(airoha_qdma_rr, status,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/080-02-v6.16-net-airoha-Differentiate-hwfd-buffer-size-for-QDMA0-.patch
+++ b/target/linux/airoha/patches-6.6/080-02-v6.16-net-airoha-Differentiate-hwfd-buffer-size-for-QDMA0-.patch
@@ -19,11 +19,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 10 ++++++----
  1 file changed, 6 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 1b7fd7ee0cbf..06dea3a13e77 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1068,14 +1068,15 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1069,14 +1069,15 @@ static int airoha_qdma_init_hfwd_queues(
  	int size, index, num_desc = HW_DSCP_NUM;
  	struct airoha_eth *eth = qdma->eth;
  	int id = qdma - &eth->qdma[0];
@@ -40,7 +38,7 @@ index 1b7fd7ee0cbf..06dea3a13e77 100644
  	index = of_property_match_string(eth->dev->of_node,
  					 "memory-region-names", name);
  	if (index >= 0) {
-@@ -1096,9 +1097,9 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1097,9 +1098,9 @@ static int airoha_qdma_init_hfwd_queues(
  		/* Compute the number of hw descriptors according to the
  		 * reserved memory size and the payload buffer size
  		 */
@@ -52,7 +50,7 @@ index 1b7fd7ee0cbf..06dea3a13e77 100644
  		if (!dmam_alloc_coherent(eth->dev, size, &dma_addr,
  					 GFP_KERNEL))
  			return -ENOMEM;
-@@ -1111,9 +1112,10 @@ static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
+@@ -1112,9 +1113,10 @@ static int airoha_qdma_init_hfwd_queues(
  		return -ENOMEM;
  
  	airoha_qdma_wr(qdma, REG_FWD_DSCP_BASE, dma_addr);
@@ -64,6 +62,3 @@ index 1b7fd7ee0cbf..06dea3a13e77 100644
  	airoha_qdma_rmw(qdma, REG_FWD_DSCP_LOW_THR, FWD_DSCP_LOW_THR_MASK,
  			FIELD_PREP(FWD_DSCP_LOW_THR_MASK, 128));
  	airoha_qdma_rmw(qdma, REG_LMGR_INIT_CFG,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/081-v6.17-net-airoha-Fix-PPE-table-access-in-airoha_ppe_debugf.patch
+++ b/target/linux/airoha/patches-6.6/081-v6.17-net-airoha-Fix-PPE-table-access-in-airoha_ppe_debugf.patch
@@ -19,11 +19,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 26 ++++++++++++++++++------
  1 file changed, 20 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index c354d536bc66..47411d2cbd28 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -508,9 +508,11 @@ static void airoha_ppe_foe_flow_stats_update(struct airoha_ppe *ppe,
+@@ -508,9 +508,11 @@ static void airoha_ppe_foe_flow_stats_up
  		FIELD_PREP(AIROHA_FOE_IB2_NBQ, nbq);
  }
  
@@ -37,7 +35,7 @@ index c354d536bc66..47411d2cbd28 100644
  	if (hash < PPE_SRAM_NUM_ENTRIES) {
  		u32 *hwe = ppe->foe + hash * sizeof(struct airoha_foe_entry);
  		struct airoha_eth *eth = ppe->eth;
-@@ -537,6 +539,18 @@ struct airoha_foe_entry *airoha_ppe_foe_get_entry(struct airoha_ppe *ppe,
+@@ -537,6 +539,18 @@ struct airoha_foe_entry *airoha_ppe_foe_
  	return ppe->foe + hash * sizeof(struct airoha_foe_entry);
  }
  
@@ -56,7 +54,7 @@ index c354d536bc66..47411d2cbd28 100644
  static bool airoha_ppe_foe_compare_entry(struct airoha_flow_table_entry *e,
  					 struct airoha_foe_entry *hwe)
  {
-@@ -651,7 +665,7 @@ airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
+@@ -651,7 +665,7 @@ airoha_ppe_foe_commit_subflow_entry(stru
  	struct airoha_flow_table_entry *f;
  	int type;
  
@@ -65,7 +63,7 @@ index c354d536bc66..47411d2cbd28 100644
  	if (!hwe_p)
  		return -EINVAL;
  
-@@ -703,7 +717,7 @@ static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe,
+@@ -703,7 +717,7 @@ static void airoha_ppe_foe_insert_entry(
  
  	spin_lock_bh(&ppe_lock);
  
@@ -74,7 +72,7 @@ index c354d536bc66..47411d2cbd28 100644
  	if (!hwe)
  		goto unlock;
  
-@@ -818,7 +832,7 @@ airoha_ppe_foe_flow_l2_entry_update(struct airoha_ppe *ppe,
+@@ -818,7 +832,7 @@ airoha_ppe_foe_flow_l2_entry_update(stru
  		u32 ib1, state;
  		int idle;
  
@@ -83,7 +81,7 @@ index c354d536bc66..47411d2cbd28 100644
  		if (!hwe)
  			continue;
  
-@@ -855,7 +869,7 @@ static void airoha_ppe_foe_flow_entry_update(struct airoha_ppe *ppe,
+@@ -855,7 +869,7 @@ static void airoha_ppe_foe_flow_entry_up
  	if (e->hash == 0xffff)
  		goto unlock;
  
@@ -92,6 +90,3 @@ index c354d536bc66..47411d2cbd28 100644
  	if (!hwe_p)
  		goto unlock;
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/082-v6.17-net-airoha-ppe-Do-not-invalid-PPE-entries-in-case-of.patch
+++ b/target/linux/airoha/patches-6.6/082-v6.17-net-airoha-ppe-Do-not-invalid-PPE-entries-in-case-of.patch
@@ -26,11 +26,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_ppe.c | 4 +---
  1 file changed, 1 insertion(+), 3 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 47411d2cbd28..88694b08afa1 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -736,10 +736,8 @@ static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe,
+@@ -736,10 +736,8 @@ static void airoha_ppe_foe_insert_entry(
  			continue;
  		}
  
@@ -42,6 +40,3 @@ index 47411d2cbd28..88694b08afa1 100644
  
  		airoha_ppe_foe_commit_entry(ppe, &e->data, hash);
  		commit_done = true;
--- 
-2.50.0
-

--- a/target/linux/airoha/patches-6.6/083-01-v6.13-resource-Add-resource-set-range-and-size-helpers.patch
+++ b/target/linux/airoha/patches-6.6/083-01-v6.13-resource-Add-resource-set-range-and-size-helpers.patch
@@ -30,11 +30,9 @@ Reviewed-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>
  include/linux/ioport.h | 32 ++++++++++++++++++++++++++++++++
  1 file changed, 32 insertions(+)
 
-diff --git a/include/linux/ioport.h b/include/linux/ioport.h
-index 6e9fb667a1c5..5385349f0b8a 100644
 --- a/include/linux/ioport.h
 +++ b/include/linux/ioport.h
-@@ -249,6 +249,38 @@ struct resource *lookup_resource(struct resource *root, resource_size_t start);
+@@ -216,6 +216,38 @@ struct resource *lookup_resource(struct
  int adjust_resource(struct resource *res, resource_size_t start,
  		    resource_size_t size);
  resource_size_t resource_alignment(struct resource *res);
@@ -73,6 +71,3 @@ index 6e9fb667a1c5..5385349f0b8a 100644
  static inline resource_size_t resource_size(const struct resource *res)
  {
  	return res->end - res->start + 1;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/083-02-v6.16-of-reserved_mem-Add-functions-to-parse-memory-region.patch
+++ b/target/linux/airoha/patches-6.6/083-02-v6.16-of-reserved_mem-Add-functions-to-parse-memory-region.patch
@@ -19,8 +19,6 @@ Signed-off-by: Rob Herring (Arm) <robh@kernel.org>
  include/linux/of_reserved_mem.h | 26 +++++++++++
  2 files changed, 106 insertions(+)
 
-diff --git a/drivers/of/of_reserved_mem.c b/drivers/of/of_reserved_mem.c
-index ee2e31522d7e..77016c0cc296 100644
 --- a/drivers/of/of_reserved_mem.c
 +++ b/drivers/of/of_reserved_mem.c
 @@ -12,6 +12,7 @@
@@ -31,7 +29,7 @@ index ee2e31522d7e..77016c0cc296 100644
  #include <linux/of.h>
  #include <linux/of_fdt.h>
  #include <linux/of_platform.h>
-@@ -740,3 +741,82 @@ struct reserved_mem *of_reserved_mem_lookup(struct device_node *np)
+@@ -514,3 +515,82 @@ struct reserved_mem *of_reserved_mem_loo
  	return NULL;
  }
  EXPORT_SYMBOL_GPL(of_reserved_mem_lookup);
@@ -114,8 +112,6 @@ index ee2e31522d7e..77016c0cc296 100644
 +	return of_count_phandle_with_args(np, "memory-region", NULL);
 +}
 +EXPORT_SYMBOL_GPL(of_reserved_mem_region_count);
-diff --git a/include/linux/of_reserved_mem.h b/include/linux/of_reserved_mem.h
-index e338282da652..f573423359f4 100644
 --- a/include/linux/of_reserved_mem.h
 +++ b/include/linux/of_reserved_mem.h
 @@ -7,6 +7,7 @@
@@ -126,7 +122,7 @@ index e338282da652..f573423359f4 100644
  
  struct reserved_mem {
  	const char			*name;
-@@ -39,6 +40,12 @@ int of_reserved_mem_device_init_by_name(struct device *dev,
+@@ -40,6 +41,12 @@ int of_reserved_mem_device_init_by_name(
  void of_reserved_mem_device_release(struct device *dev);
  
  struct reserved_mem *of_reserved_mem_lookup(struct device_node *np);
@@ -139,7 +135,7 @@ index e338282da652..f573423359f4 100644
  #else
  
  #define RESERVEDMEM_OF_DECLARE(name, compat, init)			\
-@@ -63,6 +70,25 @@ static inline struct reserved_mem *of_reserved_mem_lookup(struct device_node *np
+@@ -64,6 +71,25 @@ static inline struct reserved_mem *of_re
  {
  	return NULL;
  }
@@ -165,6 +161,3 @@ index e338282da652..f573423359f4 100644
  #endif
  
  /**
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/084-01-v6.18-net-airoha-npu-Add-NPU-wlan-memory-initialization-co.patch
+++ b/target/linux/airoha/patches-6.6/084-01-v6.18-net-airoha-npu-Add-NPU-wlan-memory-initialization-co.patch
@@ -18,8 +18,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.h | 38 +++++++++++
  2 files changed, 120 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index a802f95df99d..731e0119d988 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
 @@ -124,6 +124,13 @@ struct ppe_mbox_data {
@@ -36,7 +34,7 @@ index a802f95df99d..731e0119d988 100644
  static int airoha_npu_send_msg(struct airoha_npu *npu, int func_id,
  			       void *p, int size)
  {
-@@ -390,6 +397,80 @@ static int airoha_npu_stats_setup(struct airoha_npu *npu,
+@@ -390,6 +397,80 @@ out:
  	return err;
  }
  
@@ -117,7 +115,7 @@ index a802f95df99d..731e0119d988 100644
  struct airoha_npu *airoha_npu_get(struct device *dev, dma_addr_t *stats_addr)
  {
  	struct platform_device *pdev;
-@@ -493,6 +574,7 @@ static int airoha_npu_probe(struct platform_device *pdev)
+@@ -493,6 +574,7 @@ static int airoha_npu_probe(struct platf
  	npu->ops.ppe_deinit = airoha_npu_ppe_deinit;
  	npu->ops.ppe_flush_sram_entries = airoha_npu_ppe_flush_sram_entries;
  	npu->ops.ppe_foe_commit_entry = airoha_npu_foe_commit_entry;
@@ -125,8 +123,6 @@ index a802f95df99d..731e0119d988 100644
  
  	npu->regmap = devm_regmap_init_mmio(dev, base, &regmap_config);
  	if (IS_ERR(npu->regmap))
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.h b/drivers/net/ethernet/airoha/airoha_npu.h
-index 98ec3be74ce4..0cb5356b00e9 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.h
 +++ b/drivers/net/ethernet/airoha/airoha_npu.h
 @@ -6,6 +6,43 @@
@@ -181,6 +177,3 @@ index 98ec3be74ce4..0cb5356b00e9 100644
  	} ops;
  };
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/084-02-v6.18-net-airoha-npu-Add-wlan_-send-get-_msg-NPU-callbacks.patch
+++ b/target/linux/airoha/patches-6.6/084-02-v6.18-net-airoha-npu-Add-wlan_-send-get-_msg-NPU-callbacks.patch
@@ -17,8 +17,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.h | 22 ++++++++++
  2 files changed, 74 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 731e0119d988..2a337f00386f 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
 @@ -42,6 +42,22 @@
@@ -44,7 +42,7 @@ index 731e0119d988..2a337f00386f 100644
  #define NPU_TIMER_BASE_ADDR		0x310100
  #define REG_WDT_TIMER_CTRL(_n)		(NPU_TIMER_BASE_ADDR + ((_n) * 0x100))
  #define WDT_EN_MASK			BIT(25)
-@@ -420,6 +436,30 @@ static int airoha_npu_wlan_msg_send(struct airoha_npu *npu, int ifindex,
+@@ -420,6 +436,30 @@ static int airoha_npu_wlan_msg_send(stru
  	return err;
  }
  
@@ -75,7 +73,7 @@ index 731e0119d988..2a337f00386f 100644
  static int
  airoha_npu_wlan_set_reserved_memory(struct airoha_npu *npu,
  				    int ifindex, const char *name,
-@@ -471,6 +511,15 @@ static int airoha_npu_wlan_init_memory(struct airoha_npu *npu)
+@@ -471,6 +511,15 @@ static int airoha_npu_wlan_init_memory(s
  					GFP_KERNEL);
  }
  
@@ -91,7 +89,7 @@ index 731e0119d988..2a337f00386f 100644
  struct airoha_npu *airoha_npu_get(struct device *dev, dma_addr_t *stats_addr)
  {
  	struct platform_device *pdev;
-@@ -575,6 +624,9 @@ static int airoha_npu_probe(struct platform_device *pdev)
+@@ -575,6 +624,9 @@ static int airoha_npu_probe(struct platf
  	npu->ops.ppe_flush_sram_entries = airoha_npu_ppe_flush_sram_entries;
  	npu->ops.ppe_foe_commit_entry = airoha_npu_foe_commit_entry;
  	npu->ops.wlan_init_reserved_memory = airoha_npu_wlan_init_memory;
@@ -101,8 +99,6 @@ index 731e0119d988..2a337f00386f 100644
  
  	npu->regmap = devm_regmap_init_mmio(dev, base, &regmap_config);
  	if (IS_ERR(npu->regmap))
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.h b/drivers/net/ethernet/airoha/airoha_npu.h
-index 0cb5356b00e9..7b9ff370c879 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.h
 +++ b/drivers/net/ethernet/airoha/airoha_npu.h
 @@ -43,6 +43,20 @@ enum airoha_npu_wlan_set_cmd {
@@ -141,6 +137,3 @@ index 0cb5356b00e9..7b9ff370c879 100644
  	} ops;
  };
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/084-03-v6.18-net-airoha-npu-Add-wlan-irq-management-callbacks.patch
+++ b/target/linux/airoha/patches-6.6/084-03-v6.18-net-airoha-npu-Add-wlan-irq-management-callbacks.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.h |  4 ++++
  2 files changed, 31 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 2a337f00386f..5d1355126d16 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
-@@ -520,6 +520,29 @@ static u32 airoha_npu_wlan_queue_addr_get(struct airoha_npu *npu, int qid,
+@@ -520,6 +520,29 @@ static u32 airoha_npu_wlan_queue_addr_ge
  	return REG_RX_BASE(qid);
  }
  
@@ -50,7 +48,7 @@ index 2a337f00386f..5d1355126d16 100644
  struct airoha_npu *airoha_npu_get(struct device *dev, dma_addr_t *stats_addr)
  {
  	struct platform_device *pdev;
-@@ -627,6 +650,10 @@ static int airoha_npu_probe(struct platform_device *pdev)
+@@ -627,6 +650,10 @@ static int airoha_npu_probe(struct platf
  	npu->ops.wlan_send_msg = airoha_npu_wlan_msg_send;
  	npu->ops.wlan_get_msg = airoha_npu_wlan_msg_get;
  	npu->ops.wlan_get_queue_addr = airoha_npu_wlan_queue_addr_get;
@@ -61,8 +59,6 @@ index 2a337f00386f..5d1355126d16 100644
  
  	npu->regmap = devm_regmap_init_mmio(dev, base, &regmap_config);
  	if (IS_ERR(npu->regmap))
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.h b/drivers/net/ethernet/airoha/airoha_npu.h
-index 7b9ff370c879..84c83753c2bd 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.h
 +++ b/drivers/net/ethernet/airoha/airoha_npu.h
 @@ -89,6 +89,10 @@ struct airoha_npu {
@@ -76,6 +72,3 @@ index 7b9ff370c879..84c83753c2bd 100644
  	} ops;
  };
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/084-04-v6.18-net-airoha-npu-Read-NPU-wlan-interrupt-lines-from-th.patch
+++ b/target/linux/airoha/patches-6.6/084-04-v6.18-net-airoha-npu-Read-NPU-wlan-interrupt-lines-from-th.patch
@@ -19,11 +19,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.h | 3 +++
  2 files changed, 12 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 5d1355126d16..e0448e1225b8 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
-@@ -690,6 +690,15 @@ static int airoha_npu_probe(struct platform_device *pdev)
+@@ -696,6 +696,15 @@ static int airoha_npu_probe(struct platf
  		INIT_WORK(&core->wdt_work, airoha_npu_wdt_work);
  	}
  
@@ -39,8 +37,6 @@ index 5d1355126d16..e0448e1225b8 100644
  	err = dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
  	if (err)
  		return err;
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.h b/drivers/net/ethernet/airoha/airoha_npu.h
-index 84c83753c2bd..a448c74208a9 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.h
 +++ b/drivers/net/ethernet/airoha/airoha_npu.h
 @@ -5,6 +5,7 @@
@@ -60,6 +56,3 @@ index 84c83753c2bd..a448c74208a9 100644
  	struct airoha_foe_stats __iomem *stats;
  
  	struct {
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/084-05-v6.18-net-airoha-npu-Enable-core-3-for-WiFi-offloading.patch
+++ b/target/linux/airoha/patches-6.6/084-05-v6.18-net-airoha-npu-Enable-core-3-for-WiFi-offloading.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_npu.c | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index e0448e1225b8..66a8a992dbf2 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
-@@ -720,8 +720,7 @@ static int airoha_npu_probe(struct platform_device *pdev)
+@@ -726,8 +726,7 @@ static int airoha_npu_probe(struct platf
  	usleep_range(1000, 2000);
  
  	/* enable NPU cores */
@@ -28,6 +26,3 @@ index e0448e1225b8..66a8a992dbf2 100644
  	regmap_write(npu->regmap, REG_CR_BOOT_TRIGGER, 0x1);
  	msleep(100);
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/084-06-v6.18-net-airoha-Add-airoha_offload.h-header.patch
+++ b/target/linux/airoha/patches-6.6/084-06-v6.18-net-airoha-Add-airoha_offload.h-header.patch
@@ -18,8 +18,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  delete mode 100644 drivers/net/ethernet/airoha/airoha_npu.h
  create mode 100644 include/linux/soc/airoha/airoha_offload.h
 
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 66a8a992dbf2..1a6b191ae0b0 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
 @@ -11,9 +11,9 @@
@@ -33,9 +31,6 @@ index 66a8a992dbf2..1a6b191ae0b0 100644
  
  #define NPU_EN7581_FIRMWARE_DATA		"airoha/en7581_npu_data.bin"
  #define NPU_EN7581_FIRMWARE_RV32		"airoha/en7581_npu_rv32.bin"
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.h b/drivers/net/ethernet/airoha/airoha_npu.h
-deleted file mode 100644
-index a448c74208a9..000000000000
 --- a/drivers/net/ethernet/airoha/airoha_npu.h
 +++ /dev/null
 @@ -1,103 +0,0 @@
@@ -142,8 +137,6 @@ index a448c74208a9..000000000000
 -
 -struct airoha_npu *airoha_npu_get(struct device *dev, dma_addr_t *stats_addr);
 -void airoha_npu_put(struct airoha_npu *npu);
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 47411d2cbd28..82163392332c 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
 @@ -7,10 +7,10 @@
@@ -158,9 +151,6 @@ index 47411d2cbd28..82163392332c 100644
  #include "airoha_regs.h"
  #include "airoha_eth.h"
  
-diff --git a/include/linux/soc/airoha/airoha_offload.h b/include/linux/soc/airoha/airoha_offload.h
-new file mode 100644
-index 000000000000..117c63c2448d
 --- /dev/null
 +++ b/include/linux/soc/airoha/airoha_offload.h
 @@ -0,0 +1,260 @@
@@ -424,6 +414,3 @@ index 000000000000..117c63c2448d
 +#endif
 +
 +#endif /* AIROHA_OFFLOAD_H */
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/085-v6.18-net-airoha-Add-wlan-flowtable-TX-offload.patch
+++ b/target/linux/airoha/patches-6.6/085-v6.18-net-airoha-Add-wlan-flowtable-TX-offload.patch
@@ -15,8 +15,6 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/ethernet/airoha/airoha_ppe.c | 103 ++++++++++++++++-------
  2 files changed, 85 insertions(+), 29 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index a970b789cf23..9f721e2b972f 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -252,6 +252,10 @@ enum {
@@ -44,11 +42,9 @@ index a970b789cf23..9f721e2b972f 100644
  /* RX queue to IRQ mapping: BIT(q) in IRQ(n) */
  #define RX_IRQ0_BANK_PIN_MASK			0x839f
  #define RX_IRQ1_BANK_PIN_MASK			0x7fe00000
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 82163392332c..2bf1c584ba7b 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -190,6 +190,31 @@ static int airoha_ppe_flow_mangle_ipv4(const struct flow_action_entry *act,
+@@ -190,6 +190,31 @@ static int airoha_ppe_flow_mangle_ipv4(c
  	return 0;
  }
  
@@ -80,7 +76,7 @@ index 82163392332c..2bf1c584ba7b 100644
  static int airoha_get_dsa_port(struct net_device **dev)
  {
  #if IS_ENABLED(CONFIG_NET_DSA)
-@@ -220,9 +245,9 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -220,9 +245,9 @@ static int airoha_ppe_foe_entry_prepare(
  					struct airoha_flow_data *data,
  					int l4proto)
  {
@@ -92,7 +88,7 @@ index 82163392332c..2bf1c584ba7b 100644
  	u8 smac_id = 0xf;
  
  	memset(hwe, 0, sizeof(*hwe));
-@@ -236,31 +261,47 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -236,31 +261,47 @@ static int airoha_ppe_foe_entry_prepare(
  	      AIROHA_FOE_IB1_BIND_TTL;
  	hwe->ib1 = val;
  
@@ -108,7 +104,8 @@ index 82163392332c..2bf1c584ba7b 100644
 -
 -		if (!airoha_is_valid_gdm_port(eth, port))
 -			return -EINVAL;
--
++		struct airoha_wdma_info info = {};
+ 
 -		if (dsa_port >= 0)
 -			pse_port = port->id == 4 ? FE_PSE_PORT_GDM4 : port->id;
 -		else
@@ -120,10 +117,6 @@ index 82163392332c..2bf1c584ba7b 100644
 -		 */
 -		if (airhoa_is_lan_gdm_port(port))
 -			val |= AIROHA_FOE_IB2_FAST_PATH;
--
--		smac_id = port->id;
-+		struct airoha_wdma_info info = {};
-+
 +		if (!airoha_ppe_get_wdma_info(dev, data->eth.h_dest, &info)) {
 +			val |= FIELD_PREP(AIROHA_FOE_IB2_NBQ, info.idx) |
 +			       FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT,
@@ -158,13 +151,14 @@ index 82163392332c..2bf1c584ba7b 100644
 +			if (dsa_port >= 0)
 +				val |= FIELD_PREP(AIROHA_FOE_IB2_NBQ,
 +						  dsa_port);
-+
+ 
+-		smac_id = port->id;
 +			smac_id = port->id;
 +		}
  	}
  
  	if (is_multicast_ether_addr(data->eth.h_dest))
-@@ -272,7 +313,6 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -272,7 +313,6 @@ static int airoha_ppe_foe_entry_prepare(
  	if (type == PPE_PKT_TYPE_IPV6_ROUTE_3T)
  		hwe->ipv6.ports = ports_pad;
  
@@ -172,7 +166,7 @@ index 82163392332c..2bf1c584ba7b 100644
  	if (type == PPE_PKT_TYPE_BRIDGE) {
  		airoha_ppe_foe_set_bridge_addrs(&hwe->bridge, &data->eth);
  		hwe->bridge.data = qdata;
-@@ -313,7 +353,9 @@ static int airoha_ppe_foe_entry_prepare(struct airoha_eth *eth,
+@@ -313,7 +353,9 @@ static int airoha_ppe_foe_entry_prepare(
  			l2->vlan2 = data->vlan.hdr[1].id;
  	}
  
@@ -183,7 +177,7 @@ index 82163392332c..2bf1c584ba7b 100644
  		l2->etype = BIT(dsa_port);
  		l2->etype |= !data->vlan.num ? BIT(15) : 0;
  	} else if (data->pppoe.num) {
-@@ -490,6 +532,10 @@ static void airoha_ppe_foe_flow_stats_update(struct airoha_ppe *ppe,
+@@ -490,6 +532,10 @@ static void airoha_ppe_foe_flow_stats_up
  		meter = &hwe->ipv4.l2.meter;
  	}
  
@@ -194,7 +188,7 @@ index 82163392332c..2bf1c584ba7b 100644
  	airoha_ppe_foe_flow_stat_entry_reset(ppe, npu, index);
  
  	val = FIELD_GET(AIROHA_FOE_CHANNEL | AIROHA_FOE_QID, *data);
-@@ -500,7 +546,6 @@ static void airoha_ppe_foe_flow_stats_update(struct airoha_ppe *ppe,
+@@ -500,7 +546,6 @@ static void airoha_ppe_foe_flow_stats_up
  		      AIROHA_FOE_IB2_PSE_QOS | AIROHA_FOE_IB2_FAST_PATH);
  	*meter |= FIELD_PREP(AIROHA_FOE_TUNNEL_MTU, val);
  
@@ -202,6 +196,3 @@ index 82163392332c..2bf1c584ba7b 100644
  	nbq = pse_port == 1 ? 6 : 5;
  	*ib2 &= ~(AIROHA_FOE_IB2_NBQ | AIROHA_FOE_IB2_PSE_PORT |
  		  AIROHA_FOE_IB2_PSE_QOS);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/086-01-v6.18-net-airoha-Rely-on-airoha_eth-struct-in-airoha_ppe_f.patch
+++ b/target/linux/airoha/patches-6.6/086-01-v6.18-net-airoha-Rely-on-airoha_eth-struct-in-airoha_ppe_f.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_ppe.c | 20 ++++++++------------
  1 file changed, 8 insertions(+), 12 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 0d5cd3a13a3e..36b45e98279a 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -935,11 +935,10 @@ static int airoha_ppe_entry_idle_time(struct airoha_ppe *ppe,
+@@ -935,11 +935,10 @@ static int airoha_ppe_entry_idle_time(st
  	return airoha_ppe_get_entry_idle_time(ppe, e->data.ib1);
  }
  
@@ -33,7 +31,7 @@ index 0d5cd3a13a3e..36b45e98279a 100644
  	struct airoha_flow_table_entry *e;
  	struct airoha_flow_data data = {};
  	struct net_device *odev = NULL;
-@@ -1136,10 +1135,9 @@ static int airoha_ppe_flow_offload_replace(struct airoha_gdm_port *port,
+@@ -1136,10 +1135,9 @@ free_entry:
  	return err;
  }
  
@@ -45,7 +43,7 @@ index 0d5cd3a13a3e..36b45e98279a 100644
  	struct airoha_flow_table_entry *e;
  
  	e = rhashtable_lookup(&eth->flow_table, &f->cookie,
-@@ -1182,10 +1180,9 @@ void airoha_ppe_foe_entry_get_stats(struct airoha_ppe *ppe, u32 hash,
+@@ -1182,10 +1180,9 @@ void airoha_ppe_foe_entry_get_stats(stru
  	rcu_read_unlock();
  }
  
@@ -57,7 +55,7 @@ index 0d5cd3a13a3e..36b45e98279a 100644
  	struct airoha_flow_table_entry *e;
  	u32 idle;
  
-@@ -1209,16 +1206,16 @@ static int airoha_ppe_flow_offload_stats(struct airoha_gdm_port *port,
+@@ -1209,16 +1206,16 @@ static int airoha_ppe_flow_offload_stats
  	return 0;
  }
  
@@ -78,7 +76,7 @@ index 0d5cd3a13a3e..36b45e98279a 100644
  	default:
  		break;
  	}
-@@ -1288,7 +1285,6 @@ static int airoha_ppe_offload_setup(struct airoha_eth *eth)
+@@ -1288,7 +1285,6 @@ error_npu_put:
  int airoha_ppe_setup_tc_block_cb(struct net_device *dev, void *type_data)
  {
  	struct airoha_gdm_port *port = netdev_priv(dev);
@@ -86,7 +84,7 @@ index 0d5cd3a13a3e..36b45e98279a 100644
  	struct airoha_eth *eth = port->qdma->eth;
  	int err = 0;
  
-@@ -1297,7 +1293,7 @@ int airoha_ppe_setup_tc_block_cb(struct net_device *dev, void *type_data)
+@@ -1297,7 +1293,7 @@ int airoha_ppe_setup_tc_block_cb(struct
  	if (!eth->npu)
  		err = airoha_ppe_offload_setup(eth);
  	if (!err)
@@ -95,6 +93,3 @@ index 0d5cd3a13a3e..36b45e98279a 100644
  
  	mutex_unlock(&flow_offload_mutex);
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/086-02-v6.18-net-airoha-Add-airoha_ppe_dev-struct-definition.patch
+++ b/target/linux/airoha/patches-6.6/086-02-v6.18-net-airoha-Add-airoha_ppe_dev-struct-definition.patch
@@ -22,11 +22,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  include/linux/soc/airoha/airoha_offload.h | 35 ++++++++++++
  5 files changed, 104 insertions(+), 7 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index e6b802e3d844..5a04f90dd3de 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2599,13 +2599,15 @@ static int airoha_dev_setup_tc_block_cb(enum tc_setup_type type,
+@@ -2602,13 +2602,15 @@ static int airoha_dev_setup_tc_block_cb(
  					void *type_data, void *cb_priv)
  {
  	struct net_device *dev = cb_priv;
@@ -43,8 +41,6 @@ index e6b802e3d844..5a04f90dd3de 100644
  	case TC_SETUP_CLSMATCHALL:
  		return airoha_dev_tc_matchall(dev, type_data);
  	default:
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 9f721e2b972f..9060b1d2814e 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -13,6 +13,7 @@
@@ -63,7 +59,7 @@ index 9f721e2b972f..9060b1d2814e 100644
  	struct airoha_eth *eth;
  
  	void *foe;
-@@ -622,7 +624,7 @@ bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+@@ -622,7 +624,7 @@ bool airoha_is_valid_gdm_port(struct air
  
  void airoha_ppe_check_skb(struct airoha_ppe *ppe, struct sk_buff *skb,
  			  u16 hash);
@@ -72,8 +68,6 @@ index 9f721e2b972f..9060b1d2814e 100644
  int airoha_ppe_init(struct airoha_eth *eth);
  void airoha_ppe_deinit(struct airoha_eth *eth);
  void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port);
-diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
-index 1a6b191ae0b0..e1d131d6115c 100644
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
 @@ -11,7 +11,6 @@
@@ -84,8 +78,6 @@ index 1a6b191ae0b0..e1d131d6115c 100644
  
  #include "airoha_eth.h"
  
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 36b45e98279a..03d9b1f24bb3 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
 @@ -6,8 +6,9 @@
@@ -99,7 +91,7 @@ index 36b45e98279a..03d9b1f24bb3 100644
  #include <net/ipv6.h>
  #include <net/pkt_cls.h>
  
-@@ -1282,10 +1283,10 @@ static int airoha_ppe_offload_setup(struct airoha_eth *eth)
+@@ -1282,10 +1283,10 @@ error_npu_put:
  	return err;
  }
  
@@ -113,7 +105,7 @@ index 36b45e98279a..03d9b1f24bb3 100644
  	int err = 0;
  
  	mutex_lock(&flow_offload_mutex);
-@@ -1338,6 +1339,61 @@ void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port)
+@@ -1338,6 +1339,61 @@ void airoha_ppe_init_upd_mem(struct airo
  		     PPE_UPDMEM_WR_MASK | PPE_UPDMEM_REQ_MASK);
  }
  
@@ -175,7 +167,7 @@ index 36b45e98279a..03d9b1f24bb3 100644
  int airoha_ppe_init(struct airoha_eth *eth)
  {
  	struct airoha_ppe *ppe;
-@@ -1347,6 +1403,9 @@ int airoha_ppe_init(struct airoha_eth *eth)
+@@ -1347,6 +1403,9 @@ int airoha_ppe_init(struct airoha_eth *e
  	if (!ppe)
  		return -ENOMEM;
  
@@ -185,8 +177,6 @@ index 36b45e98279a..03d9b1f24bb3 100644
  	foe_size = PPE_NUM_ENTRIES * sizeof(struct airoha_foe_entry);
  	ppe->foe = dmam_alloc_coherent(eth->dev, foe_size, &ppe->foe_dma,
  				       GFP_KERNEL);
-diff --git a/include/linux/soc/airoha/airoha_offload.h b/include/linux/soc/airoha/airoha_offload.h
-index 117c63c2448d..4b4b8b9e426d 100644
 --- a/include/linux/soc/airoha/airoha_offload.h
 +++ b/include/linux/soc/airoha/airoha_offload.h
 @@ -9,6 +9,41 @@
@@ -231,6 +221,3 @@ index 117c63c2448d..4b4b8b9e426d 100644
  #define NPU_NUM_CORES		8
  #define NPU_NUM_IRQ		6
  #define NPU_RX0_DESC_NUM	512
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/086-03-v6.18-net-airoha-Introduce-check_skb-callback-in-ppe_dev-o.patch
+++ b/target/linux/airoha/patches-6.6/086-03-v6.18-net-airoha-Introduce-check_skb-callback-in-ppe_dev-o.patch
@@ -18,11 +18,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  include/linux/soc/airoha/airoha_offload.h | 20 ++++++++++++++++++
  4 files changed, 38 insertions(+), 18 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 5a04f90dd3de..81ea01a652b9 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -698,7 +698,8 @@ static int airoha_qdma_rx_process(struct airoha_queue *q, int budget)
+@@ -703,7 +703,8 @@ static int airoha_qdma_rx_process(struct
  
  		reason = FIELD_GET(AIROHA_RXD4_PPE_CPU_REASON, msg1);
  		if (reason == PPE_CPU_REASON_HIT_UNBIND_RATE_REACHED)
@@ -32,22 +30,20 @@ index 5a04f90dd3de..81ea01a652b9 100644
  
  		done++;
  		napi_gro_receive(&q->napi, q->skb);
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 9060b1d2814e..77fd13d466dc 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -229,10 +229,6 @@ struct airoha_hw_stats {
- 	u64 rx_len[7];
+@@ -230,10 +230,6 @@ struct airoha_hw_stats {
  };
  
--enum {
+ enum {
 -	PPE_CPU_REASON_HIT_UNBIND_RATE_REACHED = 0x0f,
 -};
 -
- enum {
+-enum {
  	AIROHA_FOE_STATE_INVALID,
  	AIROHA_FOE_STATE_UNBIND,
-@@ -622,8 +618,8 @@ static inline bool airhoa_is_lan_gdm_port(struct airoha_gdm_port *port)
+ 	AIROHA_FOE_STATE_BIND,
+@@ -622,8 +618,8 @@ static inline bool airhoa_is_lan_gdm_por
  bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
  			      struct airoha_gdm_port *port);
  
@@ -58,11 +54,9 @@ index 9060b1d2814e..77fd13d466dc 100644
  int airoha_ppe_setup_tc_block_cb(struct airoha_ppe_dev *dev, void *type_data);
  int airoha_ppe_init(struct airoha_eth *eth);
  void airoha_ppe_deinit(struct airoha_eth *eth);
-diff --git a/drivers/net/ethernet/airoha/airoha_ppe.c b/drivers/net/ethernet/airoha/airoha_ppe.c
-index 03d9b1f24bb3..78473527ff50 100644
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -616,7 +616,7 @@ static bool airoha_ppe_foe_compare_entry(struct airoha_flow_table_entry *e,
+@@ -616,7 +616,7 @@ static bool airoha_ppe_foe_compare_entry
  
  static int airoha_ppe_foe_commit_entry(struct airoha_ppe *ppe,
  				       struct airoha_foe_entry *e,
@@ -71,7 +65,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  {
  	struct airoha_foe_entry *hwe = ppe->foe + hash * sizeof(*hwe);
  	u32 ts = airoha_ppe_get_timestamp(ppe);
-@@ -639,7 +639,8 @@ static int airoha_ppe_foe_commit_entry(struct airoha_ppe *ppe,
+@@ -639,7 +639,8 @@ static int airoha_ppe_foe_commit_entry(s
  		goto unlock;
  	}
  
@@ -81,7 +75,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  
  	if (hash < PPE_SRAM_NUM_ENTRIES) {
  		dma_addr_t addr = ppe->foe_dma + hash * sizeof(*hwe);
-@@ -665,7 +666,7 @@ static void airoha_ppe_foe_remove_flow(struct airoha_ppe *ppe,
+@@ -665,7 +666,7 @@ static void airoha_ppe_foe_remove_flow(s
  		e->data.ib1 &= ~AIROHA_FOE_IB1_BIND_STATE;
  		e->data.ib1 |= FIELD_PREP(AIROHA_FOE_IB1_BIND_STATE,
  					  AIROHA_FOE_STATE_INVALID);
@@ -90,7 +84,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  		e->hash = 0xffff;
  	}
  	if (e->type == FLOW_TYPE_L2_SUBFLOW) {
-@@ -704,7 +705,7 @@ static void airoha_ppe_foe_flow_remove_entry(struct airoha_ppe *ppe,
+@@ -704,7 +705,7 @@ static void airoha_ppe_foe_flow_remove_e
  static int
  airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
  				    struct airoha_flow_table_entry *e,
@@ -99,7 +93,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  {
  	u32 mask = AIROHA_FOE_IB1_BIND_PACKET_TYPE | AIROHA_FOE_IB1_BIND_UDP;
  	struct airoha_foe_entry *hwe_p, hwe;
-@@ -745,14 +746,14 @@ airoha_ppe_foe_commit_subflow_entry(struct airoha_ppe *ppe,
+@@ -745,14 +746,14 @@ airoha_ppe_foe_commit_subflow_entry(stru
  	}
  
  	hwe.bridge.data = e->data.bridge.data;
@@ -116,7 +110,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  {
  	struct airoha_flow_table_entry *e;
  	struct airoha_foe_bridge br = {};
-@@ -785,7 +786,7 @@ static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe,
+@@ -785,7 +786,7 @@ static void airoha_ppe_foe_insert_entry(
  		if (!airoha_ppe_foe_compare_entry(e, hwe))
  			continue;
  
@@ -125,7 +119,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  		commit_done = true;
  		e->hash = hash;
  	}
-@@ -797,7 +798,7 @@ static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe,
+@@ -797,7 +798,7 @@ static void airoha_ppe_foe_insert_entry(
  	e = rhashtable_lookup_fast(&ppe->l2_flows, &br,
  				   airoha_l2_flow_table_params);
  	if (e)
@@ -134,7 +128,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  unlock:
  	spin_unlock_bh(&ppe_lock);
  }
-@@ -1301,9 +1302,10 @@ int airoha_ppe_setup_tc_block_cb(struct airoha_ppe_dev *dev, void *type_data)
+@@ -1301,9 +1302,10 @@ int airoha_ppe_setup_tc_block_cb(struct
  	return err;
  }
  
@@ -147,7 +141,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  	u16 now, diff;
  
  	if (hash > PPE_HASH_MASK)
-@@ -1315,7 +1317,7 @@ void airoha_ppe_check_skb(struct airoha_ppe *ppe, struct sk_buff *skb,
+@@ -1315,7 +1317,7 @@ void airoha_ppe_check_skb(struct airoha_
  		return;
  
  	ppe->foe_check_time[hash] = now;
@@ -156,7 +150,7 @@ index 03d9b1f24bb3..78473527ff50 100644
  }
  
  void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port)
-@@ -1404,6 +1406,7 @@ int airoha_ppe_init(struct airoha_eth *eth)
+@@ -1404,6 +1406,7 @@ int airoha_ppe_init(struct airoha_eth *e
  		return -ENOMEM;
  
  	ppe->dev.ops.setup_tc_block_cb = airoha_ppe_setup_tc_block_cb;
@@ -164,8 +158,6 @@ index 03d9b1f24bb3..78473527ff50 100644
  	ppe->dev.priv = ppe;
  
  	foe_size = PPE_NUM_ENTRIES * sizeof(struct airoha_foe_entry);
-diff --git a/include/linux/soc/airoha/airoha_offload.h b/include/linux/soc/airoha/airoha_offload.h
-index 4b4b8b9e426d..1dc5b4e35ef9 100644
 --- a/include/linux/soc/airoha/airoha_offload.h
 +++ b/include/linux/soc/airoha/airoha_offload.h
 @@ -9,10 +9,17 @@
@@ -186,7 +178,7 @@ index 4b4b8b9e426d..1dc5b4e35ef9 100644
  	} ops;
  
  	void *priv;
-@@ -27,6 +34,13 @@ static inline int airoha_ppe_dev_setup_tc_block_cb(struct airoha_ppe_dev *dev,
+@@ -27,6 +34,13 @@ static inline int airoha_ppe_dev_setup_t
  {
  	return dev->ops.setup_tc_block_cb(dev, type_data);
  }
@@ -200,7 +192,7 @@ index 4b4b8b9e426d..1dc5b4e35ef9 100644
  #else
  static inline struct airoha_ppe_dev *airoha_ppe_get_dev(struct device *dev)
  {
-@@ -42,6 +56,12 @@ static inline int airoha_ppe_setup_tc_block_cb(struct airoha_ppe_dev *dev,
+@@ -42,6 +56,12 @@ static inline int airoha_ppe_setup_tc_bl
  {
  	return -EOPNOTSUPP;
  }
@@ -213,6 +205,3 @@ index 4b4b8b9e426d..1dc5b4e35ef9 100644
  #endif
  
  #define NPU_NUM_CORES		8
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/087-v6.17-pinctrl-airoha-Fix-return-value-in-pinconf-callbacks.patch
+++ b/target/linux/airoha/patches-6.6/087-v6.17-pinctrl-airoha-Fix-return-value-in-pinconf-callbacks.patch
@@ -15,11 +15,9 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index 5f1ec9e0de21..1b2f132d76f0 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -2696,7 +2696,7 @@ static int airoha_pinconf_get(struct pinctrl_dev *pctrl_dev,
+@@ -2696,7 +2696,7 @@ static int airoha_pinconf_get(struct pin
  		arg = 1;
  		break;
  	default:
@@ -28,7 +26,7 @@ index 5f1ec9e0de21..1b2f132d76f0 100644
  	}
  
  	*config = pinconf_to_config_packed(param, arg);
-@@ -2788,7 +2788,7 @@ static int airoha_pinconf_set(struct pinctrl_dev *pctrl_dev,
+@@ -2790,7 +2790,7 @@ static int airoha_pinconf_set(struct pin
  			break;
  		}
  		default:
@@ -37,7 +35,7 @@ index 5f1ec9e0de21..1b2f132d76f0 100644
  		}
  	}
  
-@@ -2805,10 +2805,10 @@ static int airoha_pinconf_group_get(struct pinctrl_dev *pctrl_dev,
+@@ -2807,10 +2807,10 @@ static int airoha_pinconf_group_get(stru
  		if (airoha_pinconf_get(pctrl_dev,
  				       airoha_pinctrl_groups[group].pins[i],
  				       config))
@@ -50,6 +48,3 @@ index 5f1ec9e0de21..1b2f132d76f0 100644
  
  		cur_config = *config;
  	}
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/088-01-v6.16-net-dsa-mt7530-generalize-read-port-stats-logic.patch
+++ b/target/linux/airoha/patches-6.6/088-01-v6.16-net-dsa-mt7530-generalize-read-port-stats-logic.patch
@@ -16,15 +16,12 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/dsa/mt7530.c | 26 ++++++++++++++++++--------
  1 file changed, 18 insertions(+), 8 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index d70399bce5b9..85a040853194 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -789,24 +789,34 @@ mt7530_get_strings(struct dsa_switch *ds, int port, u32 stringset,
- 		ethtool_puts(&data, mt7530_mib[i].name);
+@@ -789,23 +789,33 @@ mt7530_get_strings(struct dsa_switch *ds
  }
  
-+static void
+ static void
 +mt7530_read_port_stats(struct mt7530_priv *priv, int port,
 +		       u32 offset, u8 size, uint64_t *data)
 +{
@@ -39,7 +36,7 @@ index d70399bce5b9..85a040853194 100644
 +	}
 +}
 +
- static void
++static void
  mt7530_get_ethtool_stats(struct dsa_switch *ds, int port,
  			 uint64_t *data)
  {
@@ -63,6 +60,3 @@ index d70399bce5b9..85a040853194 100644
  	}
  }
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/088-02-v6.16-net-dsa-mt7530-move-pkt-size-and-rx-err-MIB-counter-.patch
+++ b/target/linux/airoha/patches-6.6/088-02-v6.16-net-dsa-mt7530-move-pkt-size-and-rx-err-MIB-counter-.patch
@@ -18,11 +18,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/dsa/mt7530.h | 17 ++++++++++
  2 files changed, 72 insertions(+), 16 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index 85a040853194..54a6ddc380e9 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -44,12 +44,6 @@ static const struct mt7530_mib_desc mt7530_mib[] = {
+@@ -43,12 +43,6 @@ static const struct mt7530_mib_desc mt75
  	MIB_DESC(1, 0x24, "TxLateCollision"),
  	MIB_DESC(1, 0x28, "TxExcessiveCollistion"),
  	MIB_DESC(1, 0x2c, "TxPause"),
@@ -35,7 +33,7 @@ index 85a040853194..54a6ddc380e9 100644
  	MIB_DESC(2, 0x48, "TxBytes"),
  	MIB_DESC(1, 0x60, "RxDrop"),
  	MIB_DESC(1, 0x64, "RxFiltering"),
-@@ -58,17 +52,7 @@ static const struct mt7530_mib_desc mt7530_mib[] = {
+@@ -57,17 +51,7 @@ static const struct mt7530_mib_desc mt75
  	MIB_DESC(1, 0x70, "RxBroadcast"),
  	MIB_DESC(1, 0x74, "RxAlignErr"),
  	MIB_DESC(1, 0x78, "RxCrcErr"),
@@ -53,7 +51,7 @@ index 85a040853194..54a6ddc380e9 100644
  	MIB_DESC(2, 0xa8, "RxBytes"),
  	MIB_DESC(1, 0xb0, "RxCtrlDrop"),
  	MIB_DESC(1, 0xb4, "RxIngressDrop"),
-@@ -829,6 +813,60 @@ mt7530_get_sset_count(struct dsa_switch *ds, int port, int sset)
+@@ -828,6 +812,60 @@ mt7530_get_sset_count(struct dsa_switch
  	return ARRAY_SIZE(mt7530_mib);
  }
  
@@ -114,7 +112,7 @@ index 85a040853194..54a6ddc380e9 100644
  static int
  mt7530_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
  {
-@@ -3115,6 +3153,7 @@ const struct dsa_switch_ops mt7530_switch_ops = {
+@@ -3180,6 +3218,7 @@ const struct dsa_switch_ops mt7530_switc
  	.get_strings		= mt7530_get_strings,
  	.get_ethtool_stats	= mt7530_get_ethtool_stats,
  	.get_sset_count		= mt7530_get_sset_count,
@@ -122,11 +120,9 @@ index 85a040853194..54a6ddc380e9 100644
  	.set_ageing_time	= mt7530_set_ageing_time,
  	.port_enable		= mt7530_port_enable,
  	.port_disable		= mt7530_port_disable,
-diff --git a/drivers/net/dsa/mt7530.h b/drivers/net/dsa/mt7530.h
-index c3ea403d7acf..9bc90d1678f7 100644
 --- a/drivers/net/dsa/mt7530.h
 +++ b/drivers/net/dsa/mt7530.h
-@@ -423,6 +423,23 @@ enum mt7530_vlan_port_acc_frm {
+@@ -411,6 +411,23 @@ enum mt7530_vlan_port_acc_frm {
  
  /* Register for MIB */
  #define MT7530_PORT_MIB_COUNTER(x)	(0x4000 + (x) * 0x100)
@@ -150,6 +146,3 @@ index c3ea403d7acf..9bc90d1678f7 100644
  #define MT7530_MIB_CCR			0x4fe0
  #define  CCR_MIB_ENABLE			BIT(31)
  #define  CCR_RX_OCT_CNT_GOOD		BIT(7)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/088-03-v6.16-net-dsa-mt7530-move-pause-MIB-counter-to-eth_ctrl-st.patch
+++ b/target/linux/airoha/patches-6.6/088-03-v6.16-net-dsa-mt7530-move-pause-MIB-counter-to-eth_ctrl-st.patch
@@ -18,11 +18,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/dsa/mt7530.h |  2 ++
  2 files changed, 15 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index 54a6ddc380e9..f183a604355e 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -43,7 +43,6 @@ static const struct mt7530_mib_desc mt7530_mib[] = {
+@@ -42,7 +42,6 @@ static const struct mt7530_mib_desc mt75
  	MIB_DESC(1, 0x20, "TxDeferred"),
  	MIB_DESC(1, 0x24, "TxLateCollision"),
  	MIB_DESC(1, 0x28, "TxExcessiveCollistion"),
@@ -30,7 +28,7 @@ index 54a6ddc380e9..f183a604355e 100644
  	MIB_DESC(2, 0x48, "TxBytes"),
  	MIB_DESC(1, 0x60, "RxDrop"),
  	MIB_DESC(1, 0x64, "RxFiltering"),
-@@ -52,7 +51,6 @@ static const struct mt7530_mib_desc mt7530_mib[] = {
+@@ -51,7 +50,6 @@ static const struct mt7530_mib_desc mt75
  	MIB_DESC(1, 0x70, "RxBroadcast"),
  	MIB_DESC(1, 0x74, "RxAlignErr"),
  	MIB_DESC(1, 0x78, "RxCrcErr"),
@@ -38,7 +36,7 @@ index 54a6ddc380e9..f183a604355e 100644
  	MIB_DESC(2, 0xa8, "RxBytes"),
  	MIB_DESC(1, 0xb0, "RxCtrlDrop"),
  	MIB_DESC(1, 0xb4, "RxIngressDrop"),
-@@ -867,6 +865,18 @@ static void mt7530_get_rmon_stats(struct dsa_switch *ds, int port,
+@@ -866,6 +864,18 @@ static void mt7530_get_rmon_stats(struct
  	*ranges = mt7530_rmon_ranges;
  }
  
@@ -57,7 +55,7 @@ index 54a6ddc380e9..f183a604355e 100644
  static int
  mt7530_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
  {
-@@ -3154,6 +3164,7 @@ const struct dsa_switch_ops mt7530_switch_ops = {
+@@ -3219,6 +3229,7 @@ const struct dsa_switch_ops mt7530_switc
  	.get_ethtool_stats	= mt7530_get_ethtool_stats,
  	.get_sset_count		= mt7530_get_sset_count,
  	.get_rmon_stats		= mt7530_get_rmon_stats,
@@ -65,11 +63,9 @@ index 54a6ddc380e9..f183a604355e 100644
  	.set_ageing_time	= mt7530_set_ageing_time,
  	.port_enable		= mt7530_port_enable,
  	.port_disable		= mt7530_port_disable,
-diff --git a/drivers/net/dsa/mt7530.h b/drivers/net/dsa/mt7530.h
-index 9bc90d1678f7..a651ad29b750 100644
 --- a/drivers/net/dsa/mt7530.h
 +++ b/drivers/net/dsa/mt7530.h
-@@ -424,6 +424,7 @@ enum mt7530_vlan_port_acc_frm {
+@@ -412,6 +412,7 @@ enum mt7530_vlan_port_acc_frm {
  /* Register for MIB */
  #define MT7530_PORT_MIB_COUNTER(x)	(0x4000 + (x) * 0x100)
  /* Each define is an offset of MT7530_PORT_MIB_COUNTER */
@@ -77,7 +73,7 @@ index 9bc90d1678f7..a651ad29b750 100644
  #define   MT7530_PORT_MIB_TX_PKT_SZ_64	0x30
  #define   MT7530_PORT_MIB_TX_PKT_SZ_65_TO_127 0x34
  #define   MT7530_PORT_MIB_TX_PKT_SZ_128_TO_255 0x38
-@@ -434,6 +435,7 @@ enum mt7530_vlan_port_acc_frm {
+@@ -422,6 +423,7 @@ enum mt7530_vlan_port_acc_frm {
  #define   MT7530_PORT_MIB_RX_FRAG_ERR	0x80
  #define   MT7530_PORT_MIB_RX_OVER_SZ_ERR 0x84
  #define   MT7530_PORT_MIB_RX_JABBER_ERR	0x88
@@ -85,6 +81,3 @@ index 9bc90d1678f7..a651ad29b750 100644
  #define   MT7530_PORT_MIB_RX_PKT_SZ_64	0x90
  #define   MT7530_PORT_MIB_RX_PKT_SZ_65_TO_127 0x94
  #define   MT7530_PORT_MIB_RX_PKT_SZ_128_TO_255 0x98
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/088-04-v6.16-net-dsa-mt7530-move-pkt-stats-and-err-MIB-counter-to.patch
+++ b/target/linux/airoha/patches-6.6/088-04-v6.16-net-dsa-mt7530-move-pkt-stats-and-err-MIB-counter-to.patch
@@ -18,11 +18,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/dsa/mt7530.h | 14 ++++++++
  2 files changed, 70 insertions(+), 14 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index f183a604355e..2202c657930e 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -34,24 +34,10 @@ static struct mt753x_pcs *pcs_to_mt753x_pcs(struct phylink_pcs *pcs)
+@@ -33,24 +33,10 @@ static struct mt753x_pcs *pcs_to_mt753x_
  static const struct mt7530_mib_desc mt7530_mib[] = {
  	MIB_DESC(1, 0x00, "TxDrop"),
  	MIB_DESC(1, 0x04, "TxCrcErr"),
@@ -47,7 +45,7 @@ index f183a604355e..2202c657930e 100644
  	MIB_DESC(1, 0xb0, "RxCtrlDrop"),
  	MIB_DESC(1, 0xb4, "RxIngressDrop"),
  	MIB_DESC(1, 0xb8, "RxArlDrop"),
-@@ -811,6 +797,61 @@ mt7530_get_sset_count(struct dsa_switch *ds, int port, int sset)
+@@ -810,6 +796,61 @@ mt7530_get_sset_count(struct dsa_switch
  	return ARRAY_SIZE(mt7530_mib);
  }
  
@@ -109,7 +107,7 @@ index f183a604355e..2202c657930e 100644
  static const struct ethtool_rmon_hist_range mt7530_rmon_ranges[] = {
  	{ 0, 64 },
  	{ 65, 127 },
-@@ -3163,6 +3204,7 @@ const struct dsa_switch_ops mt7530_switch_ops = {
+@@ -3228,6 +3269,7 @@ const struct dsa_switch_ops mt7530_switc
  	.get_strings		= mt7530_get_strings,
  	.get_ethtool_stats	= mt7530_get_ethtool_stats,
  	.get_sset_count		= mt7530_get_sset_count,
@@ -117,11 +115,9 @@ index f183a604355e..2202c657930e 100644
  	.get_rmon_stats		= mt7530_get_rmon_stats,
  	.get_eth_ctrl_stats	= mt7530_get_eth_ctrl_stats,
  	.set_ageing_time	= mt7530_set_ageing_time,
-diff --git a/drivers/net/dsa/mt7530.h b/drivers/net/dsa/mt7530.h
-index a651ad29b750..0cc999fa1380 100644
 --- a/drivers/net/dsa/mt7530.h
 +++ b/drivers/net/dsa/mt7530.h
-@@ -424,6 +424,14 @@ enum mt7530_vlan_port_acc_frm {
+@@ -412,6 +412,14 @@ enum mt7530_vlan_port_acc_frm {
  /* Register for MIB */
  #define MT7530_PORT_MIB_COUNTER(x)	(0x4000 + (x) * 0x100)
  /* Each define is an offset of MT7530_PORT_MIB_COUNTER */
@@ -136,7 +132,7 @@ index a651ad29b750..0cc999fa1380 100644
  #define   MT7530_PORT_MIB_TX_PAUSE	0x2c
  #define   MT7530_PORT_MIB_TX_PKT_SZ_64	0x30
  #define   MT7530_PORT_MIB_TX_PKT_SZ_65_TO_127 0x34
-@@ -431,6 +439,11 @@ enum mt7530_vlan_port_acc_frm {
+@@ -419,6 +427,11 @@ enum mt7530_vlan_port_acc_frm {
  #define   MT7530_PORT_MIB_TX_PKT_SZ_256_TO_511 0x3c
  #define   MT7530_PORT_MIB_TX_PKT_SZ_512_TO_1023 0x40
  #define   MT7530_PORT_MIB_TX_PKT_SZ_1024_TO_MAX 0x44
@@ -148,7 +144,7 @@ index a651ad29b750..0cc999fa1380 100644
  #define   MT7530_PORT_MIB_RX_UNDER_SIZE_ERR 0x7c
  #define   MT7530_PORT_MIB_RX_FRAG_ERR	0x80
  #define   MT7530_PORT_MIB_RX_OVER_SZ_ERR 0x84
-@@ -442,6 +455,7 @@ enum mt7530_vlan_port_acc_frm {
+@@ -430,6 +443,7 @@ enum mt7530_vlan_port_acc_frm {
  #define   MT7530_PORT_MIB_RX_PKT_SZ_256_TO_511 0x9c
  #define   MT7530_PORT_MIB_RX_PKT_SZ_512_TO_1023 0xa0
  #define   MT7530_PORT_MIB_RX_PKT_SZ_1024_TO_MAX 0xa4
@@ -156,6 +152,3 @@ index a651ad29b750..0cc999fa1380 100644
  #define MT7530_MIB_CCR			0x4fe0
  #define  CCR_MIB_ENABLE			BIT(31)
  #define  CCR_RX_OCT_CNT_GOOD		BIT(7)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/088-05-v6.16-net-dsa-mt7530-move-remaining-MIB-counter-to-define.patch
+++ b/target/linux/airoha/patches-6.6/088-05-v6.16-net-dsa-mt7530-move-remaining-MIB-counter-to-define.patch
@@ -14,11 +14,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/dsa/mt7530.h |  9 +++++++++
  2 files changed, 18 insertions(+), 9 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index 2202c657930e..fdceefb2083c 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -32,15 +32,15 @@ static struct mt753x_pcs *pcs_to_mt753x_pcs(struct phylink_pcs *pcs)
+@@ -31,15 +31,15 @@ static struct mt753x_pcs *pcs_to_mt753x_
  
  /* String, offset, and register size in bytes if different from 4 bytes */
  static const struct mt7530_mib_desc mt7530_mib[] = {
@@ -43,11 +41,9 @@ index 2202c657930e..fdceefb2083c 100644
  };
  
  static void
-diff --git a/drivers/net/dsa/mt7530.h b/drivers/net/dsa/mt7530.h
-index 0cc999fa1380..d4b838a055ad 100644
 --- a/drivers/net/dsa/mt7530.h
 +++ b/drivers/net/dsa/mt7530.h
-@@ -424,9 +424,12 @@ enum mt7530_vlan_port_acc_frm {
+@@ -412,9 +412,12 @@ enum mt7530_vlan_port_acc_frm {
  /* Register for MIB */
  #define MT7530_PORT_MIB_COUNTER(x)	(0x4000 + (x) * 0x100)
  /* Each define is an offset of MT7530_PORT_MIB_COUNTER */
@@ -60,7 +56,7 @@ index 0cc999fa1380..d4b838a055ad 100644
  #define   MT7530_PORT_MIB_TX_SINGLE_COLLISION 0x18
  #define   MT7530_PORT_MIB_TX_MULTIPLE_COLLISION 0x1c
  #define   MT7530_PORT_MIB_TX_DEFERRED	0x20
-@@ -440,10 +443,13 @@ enum mt7530_vlan_port_acc_frm {
+@@ -428,10 +431,13 @@ enum mt7530_vlan_port_acc_frm {
  #define   MT7530_PORT_MIB_TX_PKT_SZ_512_TO_1023 0x40
  #define   MT7530_PORT_MIB_TX_PKT_SZ_1024_TO_MAX 0x44
  #define   MT7530_PORT_MIB_TX_BYTES	0x48 /* 64 bytes */
@@ -74,7 +70,7 @@ index 0cc999fa1380..d4b838a055ad 100644
  #define   MT7530_PORT_MIB_RX_UNDER_SIZE_ERR 0x7c
  #define   MT7530_PORT_MIB_RX_FRAG_ERR	0x80
  #define   MT7530_PORT_MIB_RX_OVER_SZ_ERR 0x84
-@@ -456,6 +462,9 @@ enum mt7530_vlan_port_acc_frm {
+@@ -444,6 +450,9 @@ enum mt7530_vlan_port_acc_frm {
  #define   MT7530_PORT_MIB_RX_PKT_SZ_512_TO_1023 0xa0
  #define   MT7530_PORT_MIB_RX_PKT_SZ_1024_TO_MAX 0xa4
  #define   MT7530_PORT_MIB_RX_BYTES	0xa8 /* 64 bytes */
@@ -84,6 +80,3 @@ index 0cc999fa1380..d4b838a055ad 100644
  #define MT7530_MIB_CCR			0x4fe0
  #define  CCR_MIB_ENABLE			BIT(31)
  #define  CCR_RX_OCT_CNT_GOOD		BIT(7)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/088-06-v6.16-net-dsa-mt7530-implement-.get_stats64.patch
+++ b/target/linux/airoha/patches-6.6/088-06-v6.16-net-dsa-mt7530-implement-.get_stats64.patch
@@ -20,11 +20,9 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  drivers/net/dsa/mt7530.c | 46 ++++++++++++++++++++++++++++++++++++++++
  1 file changed, 46 insertions(+)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index fdceefb2083c..0a33ca1dd7ca 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -906,6 +906,51 @@ static void mt7530_get_rmon_stats(struct dsa_switch *ds, int port,
+@@ -905,6 +905,51 @@ static void mt7530_get_rmon_stats(struct
  	*ranges = mt7530_rmon_ranges;
  }
  
@@ -76,7 +74,7 @@ index fdceefb2083c..0a33ca1dd7ca 100644
  static void mt7530_get_eth_ctrl_stats(struct dsa_switch *ds, int port,
  				      struct ethtool_eth_ctrl_stats *ctrl_stats)
  {
-@@ -3207,6 +3252,7 @@ const struct dsa_switch_ops mt7530_switch_ops = {
+@@ -3272,6 +3317,7 @@ const struct dsa_switch_ops mt7530_switc
  	.get_eth_mac_stats	= mt7530_get_eth_mac_stats,
  	.get_rmon_stats		= mt7530_get_rmon_stats,
  	.get_eth_ctrl_stats	= mt7530_get_eth_ctrl_stats,
@@ -84,6 +82,3 @@ index fdceefb2083c..0a33ca1dd7ca 100644
  	.set_ageing_time	= mt7530_set_ageing_time,
  	.port_enable		= mt7530_port_enable,
  	.port_disable		= mt7530_port_disable,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/089-v6.14-net-airoha-Fix-channel-configuration-for-ETS-Qdisc.patch
+++ b/target/linux/airoha/patches-6.6/089-v6.14-net-airoha-Fix-channel-configuration-for-ETS-Qdisc.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index b9f1c42f0a40..a30c417d66f2 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2840,11 +2840,14 @@ static int airoha_qdma_get_tx_ets_stats(struct airoha_gdm_port *port,
+@@ -2184,11 +2184,14 @@ static int airoha_qdma_get_tx_ets_stats(
  static int airoha_tc_setup_qdisc_ets(struct airoha_gdm_port *port,
  				     struct tc_ets_qopt_offload *opt)
  {
@@ -36,6 +34,3 @@ index b9f1c42f0a40..a30c417d66f2 100644
  	switch (opt->command) {
  	case TC_ETS_REPLACE:
  		return airoha_qdma_set_tx_ets_sched(port, channel, opt);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/090-v6.17-net-mdio-Add-MDIO-bus-controller-for-Airoha-AN7583.patch
+++ b/target/linux/airoha/patches-6.6/090-v6.17-net-mdio-Add-MDIO-bus-controller-for-Airoha-AN7583.patch
@@ -35,13 +35,11 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  3 files changed, 284 insertions(+)
  create mode 100644 drivers/net/mdio/mdio-airoha.c
 
-diff --git a/drivers/net/mdio/Kconfig b/drivers/net/mdio/Kconfig
-index 7db40aaa079d..e1e32b687068 100644
 --- a/drivers/net/mdio/Kconfig
 +++ b/drivers/net/mdio/Kconfig
-@@ -27,6 +27,13 @@ config ACPI_MDIO
- 	help
- 	  ACPI MDIO bus (Ethernet PHY) accessors
+@@ -46,6 +46,13 @@ if MDIO_BUS
+ config MDIO_DEVRES
+ 	tristate
  
 +config MDIO_AIROHA
 +	tristate "Airoha AN7583 MDIO bus controller"
@@ -53,8 +51,6 @@ index 7db40aaa079d..e1e32b687068 100644
  config MDIO_SUN4I
  	tristate "Allwinner sun4i MDIO interface support"
  	depends on ARCH_SUNXI || COMPILE_TEST
-diff --git a/drivers/net/mdio/Makefile b/drivers/net/mdio/Makefile
-index c23778e73890..fbec636700e7 100644
 --- a/drivers/net/mdio/Makefile
 +++ b/drivers/net/mdio/Makefile
 @@ -5,6 +5,7 @@ obj-$(CONFIG_ACPI_MDIO)		+= acpi_mdio.o
@@ -65,9 +61,6 @@ index c23778e73890..fbec636700e7 100644
  obj-$(CONFIG_MDIO_ASPEED)		+= mdio-aspeed.o
  obj-$(CONFIG_MDIO_BCM_IPROC)		+= mdio-bcm-iproc.o
  obj-$(CONFIG_MDIO_BCM_UNIMAC)		+= mdio-bcm-unimac.o
-diff --git a/drivers/net/mdio/mdio-airoha.c b/drivers/net/mdio/mdio-airoha.c
-new file mode 100644
-index 000000000000..1dc9939c8d7d
 --- /dev/null
 +++ b/drivers/net/mdio/mdio-airoha.c
 @@ -0,0 +1,276 @@
@@ -347,6 +340,3 @@ index 000000000000..1dc9939c8d7d
 +MODULE_DESCRIPTION("Airoha AN7583 MDIO interface driver");
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_LICENSE("GPL");
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/091-01-v6.18-pinctrl-airoha-fix-wrong-PHY-LED-mux-value-for-LED1-.patch
+++ b/target/linux/airoha/patches-6.6/091-01-v6.18-pinctrl-airoha-fix-wrong-PHY-LED-mux-value-for-LED1-.patch
@@ -20,11 +20,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 16 ++++++++--------
  1 file changed, 8 insertions(+), 8 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index 5d84a778683d..f7f8fd2f35fc 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -1752,8 +1752,8 @@ static const struct airoha_pinctrl_func_group phy1_led1_func_group[] = {
+@@ -1746,8 +1746,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -35,7 +33,7 @@ index 5d84a778683d..f7f8fd2f35fc 100644
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
-@@ -1816,8 +1816,8 @@ static const struct airoha_pinctrl_func_group phy2_led1_func_group[] = {
+@@ -1810,8 +1810,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -46,7 +44,7 @@ index 5d84a778683d..f7f8fd2f35fc 100644
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
-@@ -1880,8 +1880,8 @@ static const struct airoha_pinctrl_func_group phy3_led1_func_group[] = {
+@@ -1874,8 +1874,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -57,7 +55,7 @@ index 5d84a778683d..f7f8fd2f35fc 100644
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
-@@ -1944,8 +1944,8 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1938,8 +1938,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -68,6 +66,3 @@ index 5d84a778683d..f7f8fd2f35fc 100644
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/091-02-v6.18-pinctrl-airoha-fix-wrong-MDIO-function-bitmaks.patch
+++ b/target/linux/airoha/patches-6.6/091-02-v6.18-pinctrl-airoha-fix-wrong-MDIO-function-bitmaks.patch
@@ -21,11 +21,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 15 +++++++++------
  1 file changed, 9 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index f7f8fd2f35fc..d89da9581c55 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -108,6 +108,9 @@
+@@ -102,6 +102,9 @@
  #define JTAG_UDI_EN_MASK			BIT(4)
  #define JTAG_DFD_EN_MASK			BIT(3)
  
@@ -35,17 +33,16 @@ index f7f8fd2f35fc..d89da9581c55 100644
  /* LED MAP */
  #define REG_LAN_LED0_MAPPING			0x027c
  #define REG_LAN_LED1_MAPPING			0x0280
-@@ -718,17 +721,17 @@ static const struct airoha_pinctrl_func_group mdio_func_group[] = {
- 	{
+@@ -713,16 +716,16 @@ static const struct airoha_pinctrl_func_
  		.name = "mdio",
  		.regmap[0] = {
--			AIROHA_FUNC_MUX,
+ 			AIROHA_FUNC_MUX,
 -			REG_GPIO_PON_MODE,
 -			GPIO_SGMII_MDIO_MODE_MASK,
 -			GPIO_SGMII_MDIO_MODE_MASK
 -		},
 -		.regmap[1] = {
- 			AIROHA_FUNC_MUX,
+-			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
  			GPIO_MDC_IO_MASTER_MODE_MODE,
  			GPIO_MDC_IO_MASTER_MODE_MODE
@@ -59,6 +56,3 @@ index f7f8fd2f35fc..d89da9581c55 100644
  		.regmap_size = 2,
  	},
  };
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/108-pwm-airoha-Add-support-for-EN7581-SoC.patch
+++ b/target/linux/airoha/patches-6.6/108-pwm-airoha-Add-support-for-EN7581-SoC.patch
@@ -19,13 +19,11 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  3 files changed, 618 insertions(+)
  create mode 100644 drivers/pwm/pwm-airoha.c
 
-diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index c866ed388da9..4aa7d94cd680 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
-@@ -54,6 +54,16 @@ config PWM_ADP5585
- 	  This option enables support for the PWM function found in the Analog
- 	  Devices ADP5585.
+@@ -51,6 +51,16 @@ config PWM_AB8500
+ 	  To compile this driver as a module, choose M here: the module
+ 	  will be called pwm-ab8500.
  
 +config PWM_AIROHA
 +	tristate "Airoha PWM support"
@@ -40,8 +38,6 @@ index c866ed388da9..4aa7d94cd680 100644
  config PWM_APPLE
  	tristate "Apple SoC PWM support"
  	depends on ARCH_APPLE || COMPILE_TEST
-diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index 5c782af8f49b..cd3e6de2e44a 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -2,6 +2,7 @@
@@ -52,9 +48,6 @@ index 5c782af8f49b..cd3e6de2e44a 100644
  obj-$(CONFIG_PWM_APPLE)		+= pwm-apple.o
  obj-$(CONFIG_PWM_ATMEL)		+= pwm-atmel.o
  obj-$(CONFIG_PWM_ATMEL_HLCDC_PWM)	+= pwm-atmel-hlcdc.o
-diff --git a/drivers/pwm/pwm-airoha.c b/drivers/pwm/pwm-airoha.c
-new file mode 100644
-index 000000000000..e16d3962b9df
 --- /dev/null
 +++ b/drivers/pwm/pwm-airoha.c
 @@ -0,0 +1,619 @@
@@ -677,6 +670,3 @@ index 000000000000..e16d3962b9df
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_DESCRIPTION("Airoha EN7581 PWM driver");
 +MODULE_LICENSE("GPL");
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/116-02-net-airoha-deassert-XSI-line-on-hw-init.patch
+++ b/target/linux/airoha/patches-6.6/116-02-net-airoha-deassert-XSI-line-on-hw-init.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1295,6 +1295,10 @@ static int airoha_hw_init(struct platfor
+@@ -1402,6 +1402,10 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/116-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
+++ b/target/linux/airoha/patches-6.6/116-03-net-airoha-add-reference-for-SPORT-GDM4-in-qdma_get_.patch
@@ -16,7 +16,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -594,8 +594,11 @@ static int airoha_qdma_get_gdm_port(stru
+@@ -605,8 +605,11 @@ static int airoha_qdma_get_gdm_port(stru
  
  	sport = FIELD_GET(QDMA_ETH_RXMSG_SPORT_MASK, msg1);
  	switch (sport) {

--- a/target/linux/airoha/patches-6.6/116-05-net-airoha-drop-redundant-GDM3-4-define.patch
+++ b/target/linux/airoha/patches-6.6/116-05-net-airoha-drop-redundant-GDM3-4-define.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -515,8 +515,8 @@ static int airoha_fe_init(struct airoha_
+@@ -507,8 +507,8 @@ static int airoha_fe_init(struct airoha_
  		      FIELD_PREP(IP_ASSEMBLE_PORT_MASK, 0) |
  		      FIELD_PREP(IP_ASSEMBLE_NBQ_MASK, 22));
  
@@ -36,7 +36,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  #define GDM_DROP_CRC_ERR		BIT(23)
  #define GDM_IP4_CKSUM			BIT(22)
  #define GDM_TCP_CKSUM			BIT(21)
-@@ -338,13 +339,6 @@
+@@ -349,13 +350,6 @@
  #define MBI_RX_AGE_SEL_MASK		GENMASK(26, 25)
  #define MBI_TX_AGE_SEL_MASK		GENMASK(18, 17)
  

--- a/target/linux/airoha/patches-6.6/116-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
+++ b/target/linux/airoha/patches-6.6/116-06-net-airoha-add-initial-fixup-for-GDM3-4-port-support.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -515,8 +515,10 @@ static int airoha_fe_init(struct airoha_
+@@ -507,8 +507,10 @@ static int airoha_fe_init(struct airoha_
  		      FIELD_PREP(IP_ASSEMBLE_PORT_MASK, 0) |
  		      FIELD_PREP(IP_ASSEMBLE_NBQ_MASK, 22));
  
@@ -28,7 +28,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	airoha_fe_crsn_qsel_init(eth);
  
-@@ -1537,7 +1539,8 @@ static int airoha_dev_open(struct net_de
+@@ -1644,7 +1646,8 @@ static int airoha_dev_open(struct net_de
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.6/116-07-airoha-ethernet-drop-xsi-mac-reset.patch
+++ b/target/linux/airoha/patches-6.6/116-07-airoha-ethernet-drop-xsi-mac-reset.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2551,11 +2551,10 @@ static int airoha_probe(struct platform_
+@@ -2949,11 +2949,10 @@ static int airoha_probe(struct platform_
  		return err;
  	}
  
@@ -33,8 +33,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  						    eth->xsi_rsts);
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -19,7 +19,7 @@
- #define AIROHA_MAX_NUM_QDMA		2
+@@ -21,7 +21,7 @@
+ #define AIROHA_MAX_NUM_IRQ_BANKS	4
  #define AIROHA_MAX_DSA_PORTS		7
  #define AIROHA_MAX_NUM_RSTS		3
 -#define AIROHA_MAX_NUM_XSI_RSTS		5

--- a/target/linux/airoha/patches-6.6/116-08-net-phylink-add-.pcs_link_down-PCS-OP.patch
+++ b/target/linux/airoha/patches-6.6/116-08-net-phylink-add-.pcs_link_down-PCS-OP.patch
@@ -20,11 +20,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  include/linux/phylink.h   | 2 ++
  2 files changed, 10 insertions(+)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 214b62fba991..e5588d710b2a 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1073,6 +1073,12 @@ static void phylink_pcs_link_up(struct phylink_pcs *pcs, unsigned int neg_mode,
+@@ -1106,6 +1106,12 @@ static void phylink_pcs_link_up(struct p
  		pcs->ops->pcs_link_up(pcs, neg_mode, interface, speed, duplex);
  }
  
@@ -37,7 +35,7 @@ index 214b62fba991..e5588d710b2a 100644
  static void phylink_pcs_poll_stop(struct phylink *pl)
  {
  	if (pl->cfg_link_an_mode == MLO_AN_INBAND)
-@@ -1694,6 +1700,8 @@ static void phylink_link_down(struct phylink *pl)
+@@ -1437,6 +1443,8 @@ static void phylink_link_down(struct phy
  
  	if (ndev)
  		netif_carrier_off(ndev);
@@ -46,11 +44,9 @@ index 214b62fba991..e5588d710b2a 100644
  	pl->mac_ops->mac_link_down(pl->config, pl->cur_link_an_mode,
  				   pl->cur_interface);
  	phylink_info(pl, "Link is Down\n");
-diff --git a/include/linux/phylink.h b/include/linux/phylink.h
-index 898b00451bbf..43733743c125 100644
 --- a/include/linux/phylink.h
 +++ b/include/linux/phylink.h
-@@ -477,6 +477,7 @@ struct phylink_pcs {
+@@ -507,6 +507,7 @@ struct phylink_pcs {
   * @pcs_an_restart: restart 802.3z BaseX autonegotiation.
   * @pcs_link_up: program the PCS for the resolved link configuration
   *               (where necessary).
@@ -58,7 +54,7 @@ index 898b00451bbf..43733743c125 100644
   */
  struct phylink_pcs_ops {
  	int (*pcs_validate)(struct phylink_pcs *pcs, unsigned long *supported,
-@@ -500,6 +501,7 @@ struct phylink_pcs_ops {
+@@ -526,6 +527,7 @@ struct phylink_pcs_ops {
  	void (*pcs_an_restart)(struct phylink_pcs *pcs);
  	void (*pcs_link_up)(struct phylink_pcs *pcs, unsigned int neg_mode,
  			    phy_interface_t interface, int speed, int duplex);
@@ -66,6 +62,3 @@ index 898b00451bbf..43733743c125 100644
  };
  
  #if 0 /* For kernel-doc purposes only. */
--- 
-2.50.0
-

--- a/target/linux/airoha/patches-6.6/116-09-net-pcs-airoha-add-PCS-driver-for-Airoha-SoC.patch
+++ b/target/linux/airoha/patches-6.6/116-09-net-pcs-airoha-add-PCS-driver-for-Airoha-SoC.patch
@@ -29,30 +29,23 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  create mode 100644 drivers/net/pcs/airoha/pcs-an7581.c
  create mode 100644 include/linux/pcs/pcs-airoha.h
 
-diff --git a/drivers/net/pcs/Kconfig b/drivers/net/pcs/Kconfig
-index f6aa437473de..56c74bdd483d 100644
 --- a/drivers/net/pcs/Kconfig
 +++ b/drivers/net/pcs/Kconfig
-@@ -33,4 +33,6 @@ config PCS_RZN1_MIIC
+@@ -44,4 +44,6 @@ config PCS_RZN1_MIIC
  	  on RZ/N1 SoCs. This PCS converts MII to RMII/RGMII or can be set in
  	  pass-through mode for MII.
  
 +source "drivers/net/pcs/airoha/Kconfig"
 +
  endmenu
-diff --git a/drivers/net/pcs/Makefile b/drivers/net/pcs/Makefile
-index 4f7920618b90..c4df65abefa6 100644
 --- a/drivers/net/pcs/Makefile
 +++ b/drivers/net/pcs/Makefile
-@@ -8,3 +8,5 @@ obj-$(CONFIG_PCS_XPCS)		+= pcs_xpcs.o
+@@ -8,3 +8,5 @@ obj-$(CONFIG_PCS_LYNX)		+= pcs-lynx.o
  obj-$(CONFIG_PCS_MTK_LYNXI)	+= pcs-mtk-lynxi.o
  obj-$(CONFIG_PCS_RZN1_MIIC)	+= pcs-rzn1-miic.o
  obj-$(CONFIG_PCS_MTK_USXGMII)	+= pcs-mtk-usxgmii.o
 +
 +obj-$(CONFIG_PCS_AIROHA)	+= airoha/
-diff --git a/drivers/net/pcs/airoha/Kconfig b/drivers/net/pcs/airoha/Kconfig
-new file mode 100644
-index 000000000000..ba88cca278b1
 --- /dev/null
 +++ b/drivers/net/pcs/airoha/Kconfig
 @@ -0,0 +1,11 @@
@@ -67,9 +60,6 @@ index 000000000000..ba88cca278b1
 +	help
 +	  This module provides helper to phylink for managing the Airoha
 +	  AN7581 PCS for SoC Ethernet and PON SERDES.
-diff --git a/drivers/net/pcs/airoha/Makefile b/drivers/net/pcs/airoha/Makefile
-new file mode 100644
-index 000000000000..25cb8f090c21
 --- /dev/null
 +++ b/drivers/net/pcs/airoha/Makefile
 @@ -0,0 +1,7 @@
@@ -80,9 +70,6 @@ index 000000000000..25cb8f090c21
 +ifdef CONFIG_PCS_AIROHA_AN7581
 +pcs-airoha-objs			+= pcs-an7581.o
 +endif
-diff --git a/drivers/net/pcs/airoha/pcs-airoha-common.c b/drivers/net/pcs/airoha/pcs-airoha-common.c
-new file mode 100644
-index 000000000000..f61e291bc325
 --- /dev/null
 +++ b/drivers/net/pcs/airoha/pcs-airoha-common.c
 @@ -0,0 +1,1052 @@
@@ -1138,9 +1125,6 @@ index 000000000000..f61e291bc325
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("Airoha PCS driver");
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
-diff --git a/drivers/net/pcs/airoha/pcs-airoha.h b/drivers/net/pcs/airoha/pcs-airoha.h
-new file mode 100644
-index 000000000000..93ddec60d6dd
 --- /dev/null
 +++ b/drivers/net/pcs/airoha/pcs-airoha.h
 @@ -0,0 +1,822 @@
@@ -1966,9 +1950,6 @@ index 000000000000..93ddec60d6dd
 +	return 0;
 +}
 +#endif
-diff --git a/drivers/net/pcs/airoha/pcs-an7581.c b/drivers/net/pcs/airoha/pcs-an7581.c
-new file mode 100644
-index 000000000000..4e817639ed1d
 --- /dev/null
 +++ b/drivers/net/pcs/airoha/pcs-an7581.c
 @@ -0,0 +1,1419 @@
@@ -3391,9 +3372,6 @@ index 000000000000..4e817639ed1d
 +	 */
 +	return -EINVAL;
 +}
-diff --git a/include/linux/pcs/pcs-airoha.h b/include/linux/pcs/pcs-airoha.h
-new file mode 100644
-index 000000000000..9b17134f7290
 --- /dev/null
 +++ b/include/linux/pcs/pcs-airoha.h
 @@ -0,0 +1,9 @@
@@ -3406,6 +3384,3 @@ index 000000000000..9b17134f7290
 +void airoha_pcs_destroy(struct phylink_pcs *pcs);
 +
 +#endif /* __LINUX_PCS_AIROHA_H */
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/116-10-net-airoha-add-phylink-support-for-GDM1.patch
+++ b/target/linux/airoha/patches-6.6/116-10-net-airoha-add-phylink-support-for-GDM1.patch
@@ -16,11 +16,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/ethernet/airoha/airoha_eth.h |   3 +
  2 files changed, 101 insertions(+), 12 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 81ea01a652b9..de1d167f123a 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1626,6 +1626,8 @@ static int airoha_dev_open(struct net_device *dev)
+@@ -1641,6 +1641,8 @@ static int airoha_dev_open(struct net_de
  	struct airoha_gdm_port *port = netdev_priv(dev);
  	struct airoha_qdma *qdma = port->qdma;
  
@@ -29,7 +27,7 @@ index 81ea01a652b9..de1d167f123a 100644
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
  	if (err)
-@@ -1678,6 +1680,8 @@ static int airoha_dev_stop(struct net_device *dev)
+@@ -1694,6 +1696,8 @@ static int airoha_dev_stop(struct net_de
  		}
  	}
  
@@ -38,7 +36,7 @@ index 81ea01a652b9..de1d167f123a 100644
  	return 0;
  }
  
-@@ -2766,6 +2770,17 @@ static const struct ethtool_ops airoha_ethtool_ops = {
+@@ -2782,6 +2786,17 @@ static const struct ethtool_ops airoha_e
  	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
  };
  
@@ -56,7 +54,7 @@ index 81ea01a652b9..de1d167f123a 100644
  static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
  {
  	int i;
-@@ -2810,6 +2825,57 @@ bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
+@@ -2826,6 +2841,57 @@ bool airoha_is_valid_gdm_port(struct air
  	return false;
  }
  
@@ -114,7 +112,7 @@ index 81ea01a652b9..de1d167f123a 100644
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np, int index)
  {
-@@ -2884,19 +2950,30 @@ static int airoha_alloc_gdm_port(struct airoha_eth *eth,
+@@ -2900,19 +2966,30 @@ static int airoha_alloc_gdm_port(struct
  	port->id = id;
  	eth->ports[p] = port;
  
@@ -155,7 +153,7 @@ index 81ea01a652b9..de1d167f123a 100644
  }
  
  static int airoha_probe(struct platform_device *pdev)
-@@ -2977,6 +3054,10 @@ static int airoha_probe(struct platform_device *pdev)
+@@ -2992,6 +3069,10 @@ static int airoha_probe(struct platform_
  		}
  	}
  
@@ -166,7 +164,7 @@ index 81ea01a652b9..de1d167f123a 100644
  	return 0;
  
  error_napi_stop:
-@@ -2990,10 +3071,14 @@ static int airoha_probe(struct platform_device *pdev)
+@@ -3004,10 +3085,14 @@ error_hw_cleanup:
  	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
  		struct airoha_gdm_port *port = eth->ports[i];
  
@@ -183,7 +181,7 @@ index 81ea01a652b9..de1d167f123a 100644
  	}
  	free_netdev(eth->napi_dev);
  	platform_set_drvdata(pdev, NULL);
-@@ -3019,6 +3104,7 @@ static void airoha_remove(struct platform_device *pdev)
+@@ -3033,6 +3118,7 @@ static void airoha_remove(struct platfor
  
  		airoha_dev_stop(port->dev);
  		unregister_netdev(port->dev);
@@ -191,8 +189,6 @@ index 81ea01a652b9..de1d167f123a 100644
  		airoha_metadata_dst_free(port);
  	}
  	free_netdev(eth->napi_dev);
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 77fd13d466dc..3141168d8ae3 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -528,6 +528,9 @@ struct airoha_gdm_port {
@@ -205,6 +201,3 @@ index 77fd13d466dc..3141168d8ae3 100644
  	struct airoha_hw_stats stats;
  
  	DECLARE_BITMAP(qos_sq_bmap, AIROHA_NUM_QOS_CHANNELS);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/116-11-net-airoha-add-phylink-support-for-GDM2-4.patch
+++ b/target/linux/airoha/patches-6.6/116-11-net-airoha-add-phylink-support-for-GDM2-4.patch
@@ -13,8 +13,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/ethernet/airoha/airoha_regs.h | 12 +++
  3 files changed, 99 insertions(+), 5 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index de1d167f123a..528caf7f37e9 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
 @@ -8,6 +8,7 @@
@@ -25,7 +23,7 @@ index de1d167f123a..528caf7f37e9 100644
  #include <linux/u64_stats_sync.h>
  #include <net/dst_metadata.h>
  #include <net/page_pool/helpers.h>
-@@ -71,6 +72,11 @@ static void airoha_qdma_irq_disable(struct airoha_irq_bank *irq_bank,
+@@ -71,6 +72,11 @@ static void airoha_qdma_irq_disable(stru
  	airoha_qdma_set_irqmask(irq_bank, index, mask, 0);
  }
  
@@ -37,7 +35,7 @@ index de1d167f123a..528caf7f37e9 100644
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1626,6 +1632,15 @@ static int airoha_dev_open(struct net_device *dev)
+@@ -1641,6 +1647,15 @@ static int airoha_dev_open(struct net_de
  	struct airoha_gdm_port *port = netdev_priv(dev);
  	struct airoha_qdma *qdma = port->qdma;
  
@@ -53,7 +51,7 @@ index de1d167f123a..528caf7f37e9 100644
  	phylink_start(port->phylink);
  
  	netif_tx_start_all_queues(dev);
-@@ -1681,6 +1696,8 @@ static int airoha_dev_stop(struct net_device *dev)
+@@ -1697,6 +1712,8 @@ static int airoha_dev_stop(struct net_de
  	}
  
  	phylink_stop(port->phylink);
@@ -62,7 +60,7 @@ index de1d167f123a..528caf7f37e9 100644
  
  	return 0;
  }
-@@ -2773,7 +2790,13 @@ static const struct ethtool_ops airoha_ethtool_ops = {
+@@ -2789,7 +2806,13 @@ static const struct ethtool_ops airoha_e
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
@@ -77,7 +75,7 @@ index de1d167f123a..528caf7f37e9 100644
  }
  
  static void airoha_mac_config(struct phylink_config *config, unsigned int mode,
-@@ -2829,6 +2852,38 @@ static void airoha_mac_link_up(struct phylink_config *config, struct phy_device
+@@ -2845,6 +2868,38 @@ static void airoha_mac_link_up(struct ph
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
  {
@@ -116,14 +114,16 @@ index de1d167f123a..528caf7f37e9 100644
  }
  
  static void airoha_mac_link_down(struct phylink_config *config, unsigned int mode,
-@@ -2859,11 +2914,33 @@ static int airoha_setup_phylink(struct net_device *dev)
+@@ -2875,11 +2930,33 @@ static int airoha_setup_phylink(struct n
  
  	port->phylink_config.dev = &dev->dev;
  	port->phylink_config.type = PHYLINK_NETDEV;
 -	port->phylink_config.mac_capabilities = MAC_ASYM_PAUSE | MAC_SYM_PAUSE |
 -						MAC_10000FD;
 +	port->phylink_config.mac_capabilities = MAC_ASYM_PAUSE | MAC_SYM_PAUSE;
-+
+ 
+-	__set_bit(PHY_INTERFACE_MODE_INTERNAL,
+-		  port->phylink_config.supported_interfaces);
 +	if (airhoa_is_phy_external(port)) {
 +		port->phylink_config.mac_capabilities |= MAC_10 | MAC_100 |
 +							MAC_1000 | MAC_2500FD |
@@ -145,16 +145,14 @@ index de1d167f123a..528caf7f37e9 100644
 +			return PTR_ERR(port->pcs);
 +	} else {
 +		port->phylink_config.mac_capabilities |= MAC_10000FD;
- 
--	__set_bit(PHY_INTERFACE_MODE_INTERNAL,
--		  port->phylink_config.supported_interfaces);
++
 +		__set_bit(PHY_INTERFACE_MODE_INTERNAL,
 +			  port->phylink_config.supported_interfaces);
 +	}
  
  	phylink = phylink_create(&port->phylink_config,
  				 of_fwnode_handle(np),
-@@ -3077,6 +3154,8 @@ static int airoha_probe(struct platform_device *pdev)
+@@ -3091,6 +3168,8 @@ error_hw_cleanup:
  		if (port->dev->reg_state == NETREG_REGISTERED) {
  			unregister_netdev(port->dev);
  			phylink_destroy(port->phylink);
@@ -163,7 +161,7 @@ index de1d167f123a..528caf7f37e9 100644
  		}
  		airoha_metadata_dst_free(port);
  	}
-@@ -3105,6 +3184,8 @@ static void airoha_remove(struct platform_device *pdev)
+@@ -3119,6 +3198,8 @@ static void airoha_remove(struct platfor
  		airoha_dev_stop(port->dev);
  		unregister_netdev(port->dev);
  		phylink_destroy(port->phylink);
@@ -172,8 +170,6 @@ index de1d167f123a..528caf7f37e9 100644
  		airoha_metadata_dst_free(port);
  	}
  	free_netdev(eth->napi_dev);
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.h b/drivers/net/ethernet/airoha/airoha_eth.h
-index 3141168d8ae3..919d22bea72f 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
 @@ -530,6 +530,7 @@ struct airoha_gdm_port {
@@ -184,11 +180,9 @@ index 3141168d8ae3..919d22bea72f 100644
  
  	struct airoha_hw_stats stats;
  
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 150c85995cc1..27feb83ee8e9 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
-@@ -367,6 +367,18 @@
+@@ -361,6 +361,18 @@
  #define IP_FRAGMENT_PORT_MASK		GENMASK(8, 5)
  #define IP_FRAGMENT_NBQ_MASK		GENMASK(4, 0)
  
@@ -207,6 +201,3 @@ index 150c85995cc1..27feb83ee8e9 100644
  #define REG_MC_VLAN_EN			0x2100
  #define MC_VLAN_EN_MASK			BIT(0)
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/120-02-pinctrl-mediatek-airoha-generalize-pins-group-functi.patch
+++ b/target/linux/airoha/patches-6.6/120-02-pinctrl-mediatek-airoha-generalize-pins-group-functi.patch
@@ -16,8 +16,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 569 ++++++++++++----------
  1 file changed, 319 insertions(+), 250 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index 8ef7f88477aa..8af9109db992 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
 @@ -30,14 +30,14 @@
@@ -41,7 +39,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	}
  
  #define PINCTRL_CONF_DESC(p, offset, mask)				\
-@@ -359,16 +359,46 @@ struct airoha_pinctrl_gpiochip {
+@@ -356,16 +356,46 @@ struct airoha_pinctrl_gpiochip {
  	u32 irq_type[AIROHA_NUM_PINS];
  };
  
@@ -89,7 +87,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	PINCTRL_PIN(0, "uart1_txd"),
  	PINCTRL_PIN(1, "uart1_rxd"),
  	PINCTRL_PIN(2, "i2c_scl"),
-@@ -429,172 +459,172 @@ static struct pinctrl_pin_desc airoha_pinctrl_pins[] = {
+@@ -426,172 +456,172 @@ static struct pinctrl_pin_desc airoha_pi
  	PINCTRL_PIN(63, "pcie_reset2"),
  };
  
@@ -428,7 +426,7 @@ index 8ef7f88477aa..8af9109db992 100644
  };
  
  static const char *const pon_groups[] = { "pon" };
-@@ -1957,33 +1987,33 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1954,33 +1984,33 @@ static const struct airoha_pinctrl_func_
  	},
  };
  
@@ -487,7 +485,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_PU, UART1_TXD_PU_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_PU, UART1_RXD_PU_MASK),
  	PINCTRL_CONF_DESC(2, REG_I2C_SDA_PU, I2C_SDA_PU_MASK),
-@@ -2044,7 +2074,7 @@ static const struct airoha_pinctrl_conf airoha_pinctrl_pullup_conf[] = {
+@@ -2041,7 +2071,7 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_PU, PCIE2_RESET_PU_MASK),
  };
  
@@ -496,7 +494,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_PD, UART1_TXD_PD_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_PD, UART1_RXD_PD_MASK),
  	PINCTRL_CONF_DESC(2, REG_I2C_SDA_PD, I2C_SDA_PD_MASK),
-@@ -2105,7 +2135,7 @@ static const struct airoha_pinctrl_conf airoha_pinctrl_pulldown_conf[] = {
+@@ -2102,7 +2132,7 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_PD, PCIE2_RESET_PD_MASK),
  };
  
@@ -505,7 +503,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_E2, UART1_TXD_E2_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_E2, UART1_RXD_E2_MASK),
  	PINCTRL_CONF_DESC(2, REG_I2C_SDA_E2, I2C_SDA_E2_MASK),
-@@ -2166,7 +2196,7 @@ static const struct airoha_pinctrl_conf airoha_pinctrl_drive_e2_conf[] = {
+@@ -2163,7 +2193,7 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_E2, PCIE2_RESET_E2_MASK),
  };
  
@@ -514,7 +512,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_E4, UART1_TXD_E4_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_E4, UART1_RXD_E4_MASK),
  	PINCTRL_CONF_DESC(2, REG_I2C_SDA_E4, I2C_SDA_E4_MASK),
-@@ -2227,7 +2257,7 @@ static const struct airoha_pinctrl_conf airoha_pinctrl_drive_e4_conf[] = {
+@@ -2224,7 +2254,7 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_E4, PCIE2_RESET_E4_MASK),
  };
  
@@ -523,7 +521,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	PINCTRL_CONF_DESC(61, REG_PCIE_RESET_OD, PCIE0_RESET_OD_MASK),
  	PINCTRL_CONF_DESC(62, REG_PCIE_RESET_OD, PCIE1_RESET_OD_MASK),
  	PINCTRL_CONF_DESC(63, REG_PCIE_RESET_OD, PCIE2_RESET_OD_MASK),
-@@ -2548,12 +2578,17 @@ airoha_pinctrl_get_conf_reg(const struct airoha_pinctrl_conf *conf,
+@@ -2551,12 +2581,17 @@ airoha_pinctrl_get_conf_reg(const struct
  }
  
  static int airoha_pinctrl_get_conf(struct airoha_pinctrl *pinctrl,
@@ -544,7 +542,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	if (!reg)
  		return -EINVAL;
  
-@@ -2566,12 +2601,17 @@ static int airoha_pinctrl_get_conf(struct airoha_pinctrl *pinctrl,
+@@ -2569,12 +2604,17 @@ static int airoha_pinctrl_get_conf(struc
  }
  
  static int airoha_pinctrl_set_conf(struct airoha_pinctrl *pinctrl,
@@ -565,7 +563,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	if (!reg)
  		return -EINVAL;
  
-@@ -2584,44 +2624,34 @@ static int airoha_pinctrl_set_conf(struct airoha_pinctrl *pinctrl,
+@@ -2587,44 +2627,34 @@ static int airoha_pinctrl_set_conf(struc
  }
  
  #define airoha_pinctrl_get_pullup_conf(pinctrl, pin, val)			\
@@ -620,7 +618,7 @@ index 8ef7f88477aa..8af9109db992 100644
  				(pin), (val))
  
  static int airoha_pinconf_get_direction(struct pinctrl_dev *pctrl_dev, u32 p)
-@@ -2798,12 +2828,13 @@ static int airoha_pinconf_set(struct pinctrl_dev *pctrl_dev,
+@@ -2803,12 +2833,13 @@ static int airoha_pinconf_set(struct pin
  static int airoha_pinconf_group_get(struct pinctrl_dev *pctrl_dev,
  				    unsigned int group, unsigned long *config)
  {
@@ -634,9 +632,9 @@ index 8ef7f88477aa..8af9109db992 100644
 -				       airoha_pinctrl_groups[group].pins[i],
 +				       pinctrl->grps[group].pins[i],
  				       config))
- 			return -EOPNOTSUPP;
+ 			return -ENOTSUPP;
  
-@@ -2820,13 +2851,14 @@ static int airoha_pinconf_group_set(struct pinctrl_dev *pctrl_dev,
+@@ -2825,13 +2856,14 @@ static int airoha_pinconf_group_set(stru
  				    unsigned int group, unsigned long *configs,
  				    unsigned int num_configs)
  {
@@ -653,7 +651,7 @@ index 8ef7f88477aa..8af9109db992 100644
  					 configs, num_configs);
  		if (err)
  			return err;
-@@ -2852,23 +2884,16 @@ static const struct pinctrl_ops airoha_pctlops = {
+@@ -2857,23 +2889,16 @@ static const struct pinctrl_ops airoha_p
  	.dt_free_map = pinconf_generic_dt_free_map,
  };
  
@@ -680,7 +678,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	pinctrl = devm_kzalloc(dev, sizeof(*pinctrl), GFP_KERNEL);
  	if (!pinctrl)
  		return -ENOMEM;
-@@ -2883,14 +2908,23 @@ static int airoha_pinctrl_probe(struct platform_device *pdev)
+@@ -2888,14 +2913,23 @@ static int airoha_pinctrl_probe(struct p
  
  	pinctrl->chip_scu = map;
  
@@ -707,7 +705,7 @@ index 8ef7f88477aa..8af9109db992 100644
  
  		err = pinctrl_generic_add_group(pinctrl->ctrl, grp->name,
  						(int *)grp->pins, grp->npins,
-@@ -2903,10 +2937,10 @@ static int airoha_pinctrl_probe(struct platform_device *pdev)
+@@ -2908,10 +2942,10 @@ static int airoha_pinctrl_probe(struct p
  	}
  
  	/* build functions */
@@ -720,7 +718,7 @@ index 8ef7f88477aa..8af9109db992 100644
  		err = pinmux_generic_add_function(pinctrl->ctrl,
  						  func->desc.name,
  						  func->desc.group_names,
-@@ -2919,6 +2953,10 @@ static int airoha_pinctrl_probe(struct platform_device *pdev)
+@@ -2924,6 +2958,10 @@ static int airoha_pinctrl_probe(struct p
  		}
  	}
  
@@ -731,7 +729,7 @@ index 8ef7f88477aa..8af9109db992 100644
  	err = pinctrl_enable(pinctrl->ctrl);
  	if (err)
  		return err;
-@@ -2927,8 +2965,39 @@ static int airoha_pinctrl_probe(struct platform_device *pdev)
+@@ -2932,8 +2970,39 @@ static int airoha_pinctrl_probe(struct p
  	return airoha_pinctrl_add_gpiochip(pinctrl, pdev);
  }
  
@@ -772,6 +770,3 @@ index 8ef7f88477aa..8af9109db992 100644
  	{ /* sentinel */ }
  };
  MODULE_DEVICE_TABLE(of, airoha_pinctrl_of_match);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/120-03-pinctrl-airoha-convert-PHY-LED-GPIO-to-macro.patch
+++ b/target/linux/airoha/patches-6.6/120-03-pinctrl-airoha-convert-PHY-LED-GPIO-to-macro.patch
@@ -13,11 +13,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 570 ++++------------------
  1 file changed, 82 insertions(+), 488 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index e00a90067462..a1620d7e59a4 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -1475,516 +1475,110 @@ static const struct airoha_pinctrl_func_group pwm_func_group[] = {
+@@ -1472,516 +1472,110 @@ static const struct airoha_pinctrl_func_
  	},
  };
  
@@ -616,6 +614,3 @@ index e00a90067462..a1620d7e59a4 100644
  };
  
  static const struct airoha_pinctrl_func en7581_pinctrl_funcs[] = {
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/120-04-pinctrl-airoha-convert-PWM-GPIO-to-macro.patch
+++ b/target/linux/airoha/patches-6.6/120-04-pinctrl-airoha-convert-PWM-GPIO-to-macro.patch
@@ -14,11 +14,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 465 ++++------------------
  1 file changed, 68 insertions(+), 397 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index a1620d7e59a4..b5e1d722d904 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -1075,404 +1075,75 @@ static const struct airoha_pinctrl_func_group pcie_reset_func_group[] = {
+@@ -1072,404 +1072,75 @@ static const struct airoha_pinctrl_func_
  };
  
  /* PWM */
@@ -491,6 +489,3 @@ index a1620d7e59a4..b5e1d722d904 100644
  };
  
  #define AIROHA_PINCTRL_PHY_LED(gpio, mux_val, map_mask, map_val)	\
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/120-05-pinctrl-airoha-add-support-for-Airoha-AN7583-PINs.patch
+++ b/target/linux/airoha/patches-6.6/120-05-pinctrl-airoha-add-support-for-Airoha-AN7583-PINs.patch
@@ -13,11 +13,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 733 ++++++++++++++++++++++
  1 file changed, 733 insertions(+)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index 8c8d5b598f4f..0960649d5d66 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -75,6 +75,7 @@
+@@ -69,6 +69,7 @@
  #define GPIO_PCM_SPI_CS3_MODE_MASK		BIT(20)
  #define GPIO_PCM_SPI_CS2_MODE_P156_MASK		BIT(19)
  #define GPIO_PCM_SPI_CS2_MODE_P128_MASK		BIT(18)
@@ -25,7 +23,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define GPIO_PCM_SPI_CS1_MODE_MASK		BIT(17)
  #define GPIO_PCM_SPI_MODE_MASK			BIT(16)
  #define GPIO_PCM2_MODE_MASK			BIT(13)
-@@ -129,6 +130,8 @@
+@@ -126,6 +127,8 @@
  
  /* CONF */
  #define REG_I2C_SDA_E2				0x001c
@@ -34,7 +32,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define SPI_MISO_E2_MASK			BIT(14)
  #define SPI_MOSI_E2_MASK			BIT(13)
  #define SPI_CLK_E2_MASK				BIT(12)
-@@ -136,12 +139,16 @@
+@@ -133,12 +136,16 @@
  #define PCIE2_RESET_E2_MASK			BIT(10)
  #define PCIE1_RESET_E2_MASK			BIT(9)
  #define PCIE0_RESET_E2_MASK			BIT(8)
@@ -51,7 +49,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define SPI_MISO_E4_MASK			BIT(14)
  #define SPI_MOSI_E4_MASK			BIT(13)
  #define SPI_CLK_E4_MASK				BIT(12)
-@@ -149,6 +156,8 @@
+@@ -146,6 +153,8 @@
  #define PCIE2_RESET_E4_MASK			BIT(10)
  #define PCIE1_RESET_E4_MASK			BIT(9)
  #define PCIE0_RESET_E4_MASK			BIT(8)
@@ -60,7 +58,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define UART1_RXD_E4_MASK			BIT(3)
  #define UART1_TXD_E4_MASK			BIT(2)
  #define I2C_SCL_E4_MASK				BIT(1)
-@@ -160,6 +169,8 @@
+@@ -157,6 +166,8 @@
  #define REG_GPIO_H_E4				0x0030
  
  #define REG_I2C_SDA_PU				0x0044
@@ -69,7 +67,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define SPI_MISO_PU_MASK			BIT(14)
  #define SPI_MOSI_PU_MASK			BIT(13)
  #define SPI_CLK_PU_MASK				BIT(12)
-@@ -167,12 +178,16 @@
+@@ -164,12 +175,16 @@
  #define PCIE2_RESET_PU_MASK			BIT(10)
  #define PCIE1_RESET_PU_MASK			BIT(9)
  #define PCIE0_RESET_PU_MASK			BIT(8)
@@ -86,7 +84,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define SPI_MISO_PD_MASK			BIT(14)
  #define SPI_MOSI_PD_MASK			BIT(13)
  #define SPI_CLK_PD_MASK				BIT(12)
-@@ -180,6 +195,8 @@
+@@ -177,6 +192,8 @@
  #define PCIE2_RESET_PD_MASK			BIT(10)
  #define PCIE1_RESET_PD_MASK			BIT(9)
  #define PCIE0_RESET_PD_MASK			BIT(8)
@@ -95,7 +93,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  #define UART1_RXD_PD_MASK			BIT(3)
  #define UART1_TXD_PD_MASK			BIT(2)
  #define I2C_SCL_PD_MASK				BIT(1)
-@@ -627,10 +644,223 @@ static const struct pingroup en7581_pinctrl_groups[] = {
+@@ -624,10 +641,223 @@ static const struct pingroup en7581_pinc
  	PINCTRL_PIN_GROUP("pcie_reset2", en7581_pcie_reset2),
  };
  
@@ -319,7 +317,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const char *const uart_groups[] = { "uart2", "uart2_cts_rts", "hsuart",
  					   "hsuart_cts_rts", "uart4",
  					   "uart5" };
-@@ -643,11 +873,16 @@ static const char *const pcm_spi_groups[] = { "pcm_spi", "pcm_spi_int",
+@@ -640,11 +870,16 @@ static const char *const pcm_spi_groups[
  					      "pcm_spi_cs2_p156",
  					      "pcm_spi_cs2_p128",
  					      "pcm_spi_cs3", "pcm_spi_cs4" };
@@ -336,7 +334,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const char *const pwm_groups[] = { "gpio0", "gpio1",
  					  "gpio2", "gpio3",
  					  "gpio4", "gpio5",
-@@ -686,6 +921,22 @@ static const char *const phy3_led1_groups[] = { "gpio43", "gpio44",
+@@ -683,6 +918,22 @@ static const char *const phy3_led1_group
  						"gpio45", "gpio46" };
  static const char *const phy4_led1_groups[] = { "gpio43", "gpio44",
  						"gpio45", "gpio46" };
@@ -359,7 +357,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  
  static const struct airoha_pinctrl_func_group pon_func_group[] = {
  	{
-@@ -763,6 +1014,25 @@ static const struct airoha_pinctrl_func_group mdio_func_group[] = {
+@@ -760,6 +1011,25 @@ static const struct airoha_pinctrl_func_
  	},
  };
  
@@ -385,7 +383,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_func_group uart_func_group[] = {
  	{
  		.name = "uart2",
-@@ -1004,6 +1274,73 @@ static const struct airoha_pinctrl_func_group pcm_spi_func_group[] = {
+@@ -1001,6 +1271,73 @@ static const struct airoha_pinctrl_func_
  	},
  };
  
@@ -459,7 +457,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_func_group i2s_func_group[] = {
  	{
  		.name = "i2s",
-@@ -1074,6 +1411,28 @@ static const struct airoha_pinctrl_func_group pcie_reset_func_group[] = {
+@@ -1071,6 +1408,28 @@ static const struct airoha_pinctrl_func_
  	},
  };
  
@@ -488,7 +486,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  /* PWM */
  #define AIROHA_PINCTRL_PWM(gpio, mux_val)		\
  	{						\
-@@ -1252,6 +1611,94 @@ static const struct airoha_pinctrl_func_group phy4_led1_func_group[] = {
+@@ -1249,6 +1608,94 @@ static const struct airoha_pinctrl_func_
  			       LAN3_LED_MAPPING_MASK, LAN3_PHY_LED_MAP(2)),
  };
  
@@ -583,7 +581,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_func en7581_pinctrl_funcs[] = {
  	PINCTRL_FUNC_DESC("pon", pon),
  	PINCTRL_FUNC_DESC("tod_1pps", tod_1pps),
-@@ -1278,6 +1725,31 @@ static const struct airoha_pinctrl_func en7581_pinctrl_funcs[] = {
+@@ -1275,6 +1722,31 @@ static const struct airoha_pinctrl_func
  	PINCTRL_FUNC_DESC("phy4_led1", phy4_led1),
  };
  
@@ -615,7 +613,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_conf en7581_pinctrl_pullup_conf[] = {
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_PU, UART1_TXD_PU_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_PU, UART1_RXD_PU_MASK),
-@@ -1339,6 +1811,62 @@ static const struct airoha_pinctrl_conf en7581_pinctrl_pullup_conf[] = {
+@@ -1336,6 +1808,62 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_PU, PCIE2_RESET_PU_MASK),
  };
  
@@ -678,7 +676,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_conf en7581_pinctrl_pulldown_conf[] = {
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_PD, UART1_TXD_PD_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_PD, UART1_RXD_PD_MASK),
-@@ -1400,6 +1928,62 @@ static const struct airoha_pinctrl_conf en7581_pinctrl_pulldown_conf[] = {
+@@ -1397,6 +1925,62 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_PD, PCIE2_RESET_PD_MASK),
  };
  
@@ -741,7 +739,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_conf en7581_pinctrl_drive_e2_conf[] = {
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_E2, UART1_TXD_E2_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_E2, UART1_RXD_E2_MASK),
-@@ -1461,6 +2045,62 @@ static const struct airoha_pinctrl_conf en7581_pinctrl_drive_e2_conf[] = {
+@@ -1458,6 +2042,62 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_E2, PCIE2_RESET_E2_MASK),
  };
  
@@ -804,7 +802,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static const struct airoha_pinctrl_conf en7581_pinctrl_drive_e4_conf[] = {
  	PINCTRL_CONF_DESC(0, REG_I2C_SDA_E4, UART1_TXD_E4_MASK),
  	PINCTRL_CONF_DESC(1, REG_I2C_SDA_E4, UART1_RXD_E4_MASK),
-@@ -1522,12 +2162,73 @@ static const struct airoha_pinctrl_conf en7581_pinctrl_drive_e4_conf[] = {
+@@ -1519,12 +2159,73 @@ static const struct airoha_pinctrl_conf
  	PINCTRL_CONF_DESC(63, REG_I2C_SDA_E4, PCIE2_RESET_E4_MASK),
  };
  
@@ -878,7 +876,7 @@ index 8c8d5b598f4f..0960649d5d66 100644
  static int airoha_convert_pin_to_reg_offset(struct pinctrl_dev *pctrl_dev,
  					    struct pinctrl_gpio_range *range,
  					    int pin)
-@@ -2261,8 +2962,40 @@ static const struct airoha_pinctrl_match_data en7581_pinctrl_match_data = {
+@@ -2266,8 +2967,40 @@ static const struct airoha_pinctrl_match
  	},
  };
  
@@ -919,6 +917,3 @@ index 8c8d5b598f4f..0960649d5d66 100644
  	{ /* sentinel */ }
  };
  MODULE_DEVICE_TABLE(of, airoha_pinctrl_of_match);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/122-01-i2c-mt7621-rework-cmd-wait-OPs-to-support-atomic-afe.patch
+++ b/target/linux/airoha/patches-6.6/122-01-i2c-mt7621-rework-cmd-wait-OPs-to-support-atomic-afe.patch
@@ -14,8 +14,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/i2c/busses/i2c-mt7621.c | 59 ++++++++++++++++++++++-----------
  1 file changed, 40 insertions(+), 19 deletions(-)
 
-diff --git a/drivers/i2c/busses/i2c-mt7621.c b/drivers/i2c/busses/i2c-mt7621.c
-index 2103f21f9ddd..8de3c4c9f352 100644
 --- a/drivers/i2c/busses/i2c-mt7621.c
 +++ b/drivers/i2c/busses/i2c-mt7621.c
 @@ -67,14 +67,19 @@ struct mtk_i2c {
@@ -42,7 +40,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  	if (ret)
  		dev_dbg(i2c->dev, "idle err(%d)\n", ret);
  
-@@ -117,27 +122,28 @@ static int mtk_i2c_check_ack(struct mtk_i2c *i2c, u32 expected)
+@@ -117,27 +122,28 @@ static int mtk_i2c_check_ack(struct mtk_
  	return ((ack & ack_expected) == ack_expected) ? 0 : -ENXIO;
  }
  
@@ -79,7 +77,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  {
  	struct mtk_i2c *i2c;
  	struct i2c_msg *pmsg;
-@@ -152,12 +158,12 @@ static int mtk_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -152,12 +158,12 @@ static int mtk_i2c_xfer(struct i2c_adapt
  		pmsg = &msgs[i];
  
  		/* wait hardware idle */
@@ -94,7 +92,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  		if (ret)
  			goto err_timeout;
  
-@@ -169,14 +175,16 @@ static int mtk_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -169,14 +175,16 @@ static int mtk_i2c_xfer(struct i2c_adapt
  			if (pmsg->flags & I2C_M_RD)
  				addr |= 1;
  			iowrite32(addr, i2c->base + REG_SM0D0_REG);
@@ -113,7 +111,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  			if (ret)
  				goto err_timeout;
  		}
-@@ -202,7 +210,7 @@ static int mtk_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -202,7 +210,7 @@ static int mtk_i2c_xfer(struct i2c_adapt
  				cmd = SM0CTL1_WRITE;
  			}
  
@@ -122,7 +120,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  			if (ret)
  				goto err_timeout;
  
-@@ -222,7 +230,7 @@ static int mtk_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -222,7 +230,7 @@ static int mtk_i2c_xfer(struct i2c_adapt
  		}
  	}
  
@@ -131,7 +129,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  	if (ret)
  		goto err_timeout;
  
-@@ -230,7 +238,7 @@ static int mtk_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -230,7 +238,7 @@ static int mtk_i2c_xfer(struct i2c_adapt
  	return i;
  
  err_ack:
@@ -140,7 +138,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  	if (ret)
  		goto err_timeout;
  	return -ENXIO;
-@@ -241,6 +249,18 @@ static int mtk_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg *msgs,
+@@ -241,6 +249,18 @@ err_timeout:
  	return ret;
  }
  
@@ -159,7 +157,7 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  static u32 mtk_i2c_func(struct i2c_adapter *a)
  {
  	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL | I2C_FUNC_PROTOCOL_MANGLING;
-@@ -248,6 +268,7 @@ static u32 mtk_i2c_func(struct i2c_adapter *a)
+@@ -248,6 +268,7 @@ static u32 mtk_i2c_func(struct i2c_adapt
  
  static const struct i2c_algorithm mtk_i2c_algo = {
  	.master_xfer = mtk_i2c_xfer,
@@ -167,6 +165,3 @@ index 2103f21f9ddd..8de3c4c9f352 100644
  	.functionality = mtk_i2c_func,
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/122-02-i2c-mt7621-clear-pending-interrupt-on-i2c-reset.patch
+++ b/target/linux/airoha/patches-6.6/122-02-i2c-mt7621-clear-pending-interrupt-on-i2c-reset.patch
@@ -11,11 +11,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/i2c/busses/i2c-mt7621.c | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/drivers/i2c/busses/i2c-mt7621.c b/drivers/i2c/busses/i2c-mt7621.c
-index 8de3c4c9f352..865958d497be 100644
 --- a/drivers/i2c/busses/i2c-mt7621.c
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -101,6 +101,8 @@ static void mtk_i2c_reset(struct mtk_i2c *i2c)
+@@ -101,6 +101,8 @@ static void mtk_i2c_reset(struct mtk_i2c
  	iowrite32(((i2c->clk_div << 16) & SM0CTL0_CLK_DIV_MASK) | SM0CTL0_EN |
  		  SM0CTL0_SCL_STRETCH, i2c->base + REG_SM0CTL0_REG);
  	iowrite32(0, i2c->base + REG_SM0CFG2_REG);
@@ -24,6 +22,3 @@ index 8de3c4c9f352..865958d497be 100644
  }
  
  static void mtk_i2c_dump_reg(struct mtk_i2c *i2c)
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/122-03-i2c-mt7621-limit-SCL_STRETCH-only-to-Mediatek-SoC.patch
+++ b/target/linux/airoha/patches-6.6/122-03-i2c-mt7621-limit-SCL_STRETCH-only-to-Mediatek-SoC.patch
@@ -14,11 +14,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/i2c/busses/i2c-mt7621.c | 10 ++++++++--
  1 file changed, 8 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/i2c/busses/i2c-mt7621.c b/drivers/i2c/busses/i2c-mt7621.c
-index 865958d497be..1fd876f34b52 100644
 --- a/drivers/i2c/busses/i2c-mt7621.c
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -88,6 +88,7 @@ static int mtk_i2c_wait_idle(struct mtk_i2c *i2c, bool atomic)
+@@ -88,6 +88,7 @@ static int mtk_i2c_wait_idle(struct mtk_
  
  static void mtk_i2c_reset(struct mtk_i2c *i2c)
  {
@@ -26,7 +24,7 @@ index 865958d497be..1fd876f34b52 100644
  	int ret;
  
  	ret = device_reset(i2c->adap.dev.parent);
-@@ -98,8 +99,12 @@ static void mtk_i2c_reset(struct mtk_i2c *i2c)
+@@ -98,8 +99,12 @@ static void mtk_i2c_reset(struct mtk_i2c
  	 * Don't set SM0CTL0_ODRAIN as its bit meaning is inverted. To
  	 * configure open-drain mode, this bit needs to be cleared.
  	 */
@@ -41,7 +39,7 @@ index 865958d497be..1fd876f34b52 100644
  	iowrite32(0, i2c->base + REG_SM0CFG2_REG);
  	/* Clear any pending interrupt */
  	iowrite32(1, i2c->base + REG_PINTEN_REG);
-@@ -276,6 +281,7 @@ static const struct i2c_algorithm mtk_i2c_algo = {
+@@ -276,6 +281,7 @@ static const struct i2c_algorithm mtk_i2
  
  static const struct of_device_id i2c_mtk_dt_ids[] = {
  	{ .compatible = "mediatek,mt7621-i2c" },
@@ -49,6 +47,3 @@ index 865958d497be..1fd876f34b52 100644
  	{ /* sentinel */ }
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/122-04-i2c-mt7621-make-parent-device-reset-optional.patch
+++ b/target/linux/airoha/patches-6.6/122-04-i2c-mt7621-make-parent-device-reset-optional.patch
@@ -11,11 +11,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/i2c/busses/i2c-mt7621.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/i2c/busses/i2c-mt7621.c b/drivers/i2c/busses/i2c-mt7621.c
-index 1fd876f34b52..b7da6b5e4fd9 100644
 --- a/drivers/i2c/busses/i2c-mt7621.c
 +++ b/drivers/i2c/busses/i2c-mt7621.c
-@@ -91,7 +91,7 @@ static void mtk_i2c_reset(struct mtk_i2c *i2c)
+@@ -91,7 +91,7 @@ static void mtk_i2c_reset(struct mtk_i2c
  	u32 reg;
  	int ret;
  
@@ -24,6 +22,3 @@ index 1fd876f34b52..b7da6b5e4fd9 100644
  	if (ret)
  		dev_err(i2c->dev, "I2C reset failed!\n");
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/123-01-ASoC-mediatek-move-some-header-to-global-include.patch
+++ b/target/linux/airoha/patches-6.6/123-01-ASoC-mediatek-move-some-header-to-global-include.patch
@@ -35,16 +35,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  rename {sound/soc/mediatek/common => include/sound/mediatek}/mtk-afe-fe-dai.h (100%)
  rename {sound/soc/mediatek/common => include/sound/mediatek}/mtk-afe-platform-driver.h (100%)
 
-diff --git a/sound/soc/mediatek/common/mtk-afe-fe-dai.h b/include/sound/mediatek/mtk-afe-fe-dai.h
-similarity index 100%
-rename from sound/soc/mediatek/common/mtk-afe-fe-dai.h
-rename to include/sound/mediatek/mtk-afe-fe-dai.h
-diff --git a/sound/soc/mediatek/common/mtk-afe-platform-driver.h b/include/sound/mediatek/mtk-afe-platform-driver.h
-similarity index 100%
-rename from sound/soc/mediatek/common/mtk-afe-platform-driver.h
-rename to include/sound/mediatek/mtk-afe-platform-driver.h
-diff --git a/sound/soc/mediatek/common/mtk-afe-fe-dai.c b/sound/soc/mediatek/common/mtk-afe-fe-dai.c
-index 3809068f5620..de58ee0afe27 100644
 --- a/sound/soc/mediatek/common/mtk-afe-fe-dai.c
 +++ b/sound/soc/mediatek/common/mtk-afe-fe-dai.c
 @@ -11,9 +11,9 @@
@@ -59,8 +49,6 @@ index 3809068f5620..de58ee0afe27 100644
  #include "mtk-base-afe.h"
  
  #define AFE_BASE_END_OFFSET 8
-diff --git a/sound/soc/mediatek/common/mtk-afe-platform-driver.c b/sound/soc/mediatek/common/mtk-afe-platform-driver.c
-index 6b6330583941..fc1681281ad5 100644
 --- a/sound/soc/mediatek/common/mtk-afe-platform-driver.c
 +++ b/sound/soc/mediatek/common/mtk-afe-platform-driver.c
 @@ -10,7 +10,7 @@
@@ -72,11 +60,9 @@ index 6b6330583941..fc1681281ad5 100644
  #include "mtk-base-afe.h"
  
  int mtk_afe_combine_sub_dai(struct mtk_base_afe *afe)
-diff --git a/sound/soc/mediatek/mt2701/mt2701-afe-pcm.c b/sound/soc/mediatek/mt2701/mt2701-afe-pcm.c
-index fcae38135d93..ce50eda77bd9 100644
 --- a/sound/soc/mediatek/mt2701/mt2701-afe-pcm.c
 +++ b/sound/soc/mediatek/mt2701/mt2701-afe-pcm.c
-@@ -16,8 +16,8 @@
+@@ -18,8 +18,8 @@
  
  #include "mt2701-afe-common.h"
  #include "mt2701-afe-clock-ctrl.h"
@@ -87,8 +73,6 @@ index fcae38135d93..ce50eda77bd9 100644
  
  static const struct snd_pcm_hardware mt2701_afe_hardware = {
  	.info = SNDRV_PCM_INFO_MMAP | SNDRV_PCM_INFO_INTERLEAVED
-diff --git a/sound/soc/mediatek/mt6797/mt6797-afe-pcm.c b/sound/soc/mediatek/mt6797/mt6797-afe-pcm.c
-index f62a32f2f2b6..dd8583df7d0a 100644
 --- a/sound/soc/mediatek/mt6797/mt6797-afe-pcm.c
 +++ b/sound/soc/mediatek/mt6797/mt6797-afe-pcm.c
 @@ -16,8 +16,8 @@
@@ -102,8 +86,6 @@ index f62a32f2f2b6..dd8583df7d0a 100644
  
  enum {
  	MTK_AFE_RATE_8K = 0,
-diff --git a/sound/soc/mediatek/mt7986/mt7986-afe-pcm.c b/sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
-index 7a6ad9116e55..640c3a7bff2d 100644
 --- a/sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
 +++ b/sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
 @@ -16,8 +16,8 @@
@@ -117,8 +99,6 @@ index 7a6ad9116e55..640c3a7bff2d 100644
  
  enum {
  	MTK_AFE_RATE_8K = 0,
-diff --git a/sound/soc/mediatek/mt8173/mt8173-afe-pcm.c b/sound/soc/mediatek/mt8173/mt8173-afe-pcm.c
-index 04ed0cfec174..6c58daa0a963 100644
 --- a/sound/soc/mediatek/mt8173/mt8173-afe-pcm.c
 +++ b/sound/soc/mediatek/mt8173/mt8173-afe-pcm.c
 @@ -18,8 +18,8 @@
@@ -132,8 +112,6 @@ index 04ed0cfec174..6c58daa0a963 100644
  
  /*****************************************************************************
   *                  R E G I S T E R       D E F I N I T I O N
-diff --git a/sound/soc/mediatek/mt8183/mt8183-afe-pcm.c b/sound/soc/mediatek/mt8183/mt8183-afe-pcm.c
-index e8884354995c..9e1fa40bcb56 100644
 --- a/sound/soc/mediatek/mt8183/mt8183-afe-pcm.c
 +++ b/sound/soc/mediatek/mt8183/mt8183-afe-pcm.c
 @@ -17,8 +17,8 @@
@@ -147,8 +125,6 @@ index e8884354995c..9e1fa40bcb56 100644
  
  enum {
  	MTK_AFE_RATE_8K = 0,
-diff --git a/sound/soc/mediatek/mt8183/mt8183-da7219-max98357.c b/sound/soc/mediatek/mt8183/mt8183-da7219-max98357.c
-index 3388e076ccc9..faba30a58e9e 100644
 --- a/sound/soc/mediatek/mt8183/mt8183-da7219-max98357.c
 +++ b/sound/soc/mediatek/mt8183/mt8183-da7219-max98357.c
 @@ -16,7 +16,7 @@
@@ -160,8 +136,6 @@ index 3388e076ccc9..faba30a58e9e 100644
  #include "mt8183-afe-common.h"
  
  #define DA7219_CODEC_DAI "da7219-hifi"
-diff --git a/sound/soc/mediatek/mt8183/mt8183-mt6358-ts3a227-max98357.c b/sound/soc/mediatek/mt8183/mt8183-mt6358-ts3a227-max98357.c
-index 497a9043be7b..5d6bcaaebd8f 100644
 --- a/sound/soc/mediatek/mt8183/mt8183-mt6358-ts3a227-max98357.c
 +++ b/sound/soc/mediatek/mt8183/mt8183-mt6358-ts3a227-max98357.c
 @@ -15,7 +15,7 @@
@@ -173,8 +147,6 @@ index 497a9043be7b..5d6bcaaebd8f 100644
  #include "mt8183-afe-common.h"
  
  #define RT1015_CODEC_DAI "rt1015-aif"
-diff --git a/sound/soc/mediatek/mt8186/mt8186-afe-pcm.c b/sound/soc/mediatek/mt8186/mt8186-afe-pcm.c
-index db7c93401bee..2ffb64d88c56 100644
 --- a/sound/soc/mediatek/mt8186/mt8186-afe-pcm.c
 +++ b/sound/soc/mediatek/mt8186/mt8186-afe-pcm.c
 @@ -14,8 +14,8 @@
@@ -188,8 +160,6 @@ index db7c93401bee..2ffb64d88c56 100644
  
  #include "mt8186-afe-common.h"
  #include "mt8186-afe-clk.h"
-diff --git a/sound/soc/mediatek/mt8186/mt8186-misc-control.c b/sound/soc/mediatek/mt8186/mt8186-misc-control.c
-index 2317de8c44c0..96ee69fdc8a6 100644
 --- a/sound/soc/mediatek/mt8186/mt8186-misc-control.c
 +++ b/sound/soc/mediatek/mt8186/mt8186-misc-control.c
 @@ -11,8 +11,8 @@
@@ -203,8 +173,6 @@ index 2317de8c44c0..96ee69fdc8a6 100644
  #include "mt8186-afe-common.h"
  
  static const char * const mt8186_sgen_mode_str[] = {
-diff --git a/sound/soc/mediatek/mt8186/mt8186-mt6366-common.c b/sound/soc/mediatek/mt8186/mt8186-mt6366-common.c
-index fa08eb0654d8..4155db56c59a 100644
 --- a/sound/soc/mediatek/mt8186/mt8186-mt6366-common.c
 +++ b/sound/soc/mediatek/mt8186/mt8186-mt6366-common.c
 @@ -9,7 +9,7 @@
@@ -216,8 +184,6 @@ index fa08eb0654d8..4155db56c59a 100644
  #include "mt8186-afe-common.h"
  #include "mt8186-mt6366-common.h"
  
-diff --git a/sound/soc/mediatek/mt8188/mt8188-afe-pcm.c b/sound/soc/mediatek/mt8188/mt8188-afe-pcm.c
-index ac4fdf8ba78f..30bb0cd34953 100644
 --- a/sound/soc/mediatek/mt8188/mt8188-afe-pcm.c
 +++ b/sound/soc/mediatek/mt8188/mt8188-afe-pcm.c
 @@ -24,8 +24,8 @@
@@ -231,8 +197,6 @@ index ac4fdf8ba78f..30bb0cd34953 100644
  
  #define MT8188_MEMIF_BUFFER_BYTES_ALIGN  (0x40)
  #define MT8188_MEMIF_DL7_MAX_PERIOD_SIZE (0x3fff)
-diff --git a/sound/soc/mediatek/mt8192/mt8192-afe-pcm.c b/sound/soc/mediatek/mt8192/mt8192-afe-pcm.c
-index fd6af74d7995..1498714ff6c0 100644
 --- a/sound/soc/mediatek/mt8192/mt8192-afe-pcm.c
 +++ b/sound/soc/mediatek/mt8192/mt8192-afe-pcm.c
 @@ -16,8 +16,8 @@
@@ -246,8 +210,6 @@ index fd6af74d7995..1498714ff6c0 100644
  
  #include "mt8192-afe-common.h"
  #include "mt8192-afe-clk.h"
-diff --git a/sound/soc/mediatek/mt8195/mt8195-afe-pcm.c b/sound/soc/mediatek/mt8195/mt8195-afe-pcm.c
-index 5d025ad72263..a18fdfd9049c 100644
 --- a/sound/soc/mediatek/mt8195/mt8195-afe-pcm.c
 +++ b/sound/soc/mediatek/mt8195/mt8195-afe-pcm.c
 @@ -20,8 +20,8 @@
@@ -261,8 +223,6 @@ index 5d025ad72263..a18fdfd9049c 100644
  
  #define MT8195_MEMIF_BUFFER_BYTES_ALIGN  (0x40)
  #define MT8195_MEMIF_DL7_MAX_PERIOD_SIZE (0x3fff)
-diff --git a/sound/soc/mediatek/mt8195/mt8195-mt6359.c b/sound/soc/mediatek/mt8195/mt8195-mt6359.c
-index e57391c213e7..9594689d935a 100644
 --- a/sound/soc/mediatek/mt8195/mt8195-mt6359.c
 +++ b/sound/soc/mediatek/mt8195/mt8195-mt6359.c
 @@ -19,7 +19,7 @@
@@ -273,7 +233,178 @@ index e57391c213e7..9594689d935a 100644
 +#include <sound/mediatek/mtk-afe-platform-driver.h>
  #include "../common/mtk-dsp-sof-common.h"
  #include "../common/mtk-soc-card.h"
- #include "../common/mtk-soundcard-driver.h"
--- 
-2.50.1
-
+ #include "mt8195-afe-clk.h"
+--- /dev/null
++++ b/include/sound/mediatek/mtk-afe-fe-dai.h
+@@ -0,0 +1,53 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mtk-afe-fe-dais.h  --  Mediatek afe fe dai operator definition
++ *
++ * Copyright (c) 2016 MediaTek Inc.
++ * Author: Garlic Tseng <garlic.tseng@mediatek.com>
++ */
++
++#ifndef _MTK_AFE_FE_DAI_H_
++#define _MTK_AFE_FE_DAI_H_
++
++struct snd_soc_dai_ops;
++struct mtk_base_afe;
++struct mtk_base_afe_memif;
++
++int mtk_afe_fe_startup(struct snd_pcm_substream *substream,
++		       struct snd_soc_dai *dai);
++void mtk_afe_fe_shutdown(struct snd_pcm_substream *substream,
++			 struct snd_soc_dai *dai);
++int mtk_afe_fe_hw_params(struct snd_pcm_substream *substream,
++			 struct snd_pcm_hw_params *params,
++			 struct snd_soc_dai *dai);
++int mtk_afe_fe_hw_free(struct snd_pcm_substream *substream,
++		       struct snd_soc_dai *dai);
++int mtk_afe_fe_prepare(struct snd_pcm_substream *substream,
++		       struct snd_soc_dai *dai);
++int mtk_afe_fe_trigger(struct snd_pcm_substream *substream, int cmd,
++		       struct snd_soc_dai *dai);
++
++extern const struct snd_soc_dai_ops mtk_afe_fe_ops;
++
++int mtk_dynamic_irq_acquire(struct mtk_base_afe *afe);
++int mtk_dynamic_irq_release(struct mtk_base_afe *afe, int irq_id);
++int mtk_afe_suspend(struct snd_soc_component *component);
++int mtk_afe_resume(struct snd_soc_component *component);
++
++int mtk_memif_set_enable(struct mtk_base_afe *afe, int id);
++int mtk_memif_set_disable(struct mtk_base_afe *afe, int id);
++int mtk_memif_set_addr(struct mtk_base_afe *afe, int id,
++		       unsigned char *dma_area,
++		       dma_addr_t dma_addr,
++		       size_t dma_bytes);
++int mtk_memif_set_channel(struct mtk_base_afe *afe,
++			  int id, unsigned int channel);
++int mtk_memif_set_rate(struct mtk_base_afe *afe,
++		       int id, unsigned int rate);
++int mtk_memif_set_rate_substream(struct snd_pcm_substream *substream,
++				 int id, unsigned int rate);
++int mtk_memif_set_format(struct mtk_base_afe *afe,
++			 int id, snd_pcm_format_t format);
++int mtk_memif_set_pbuf_size(struct mtk_base_afe *afe,
++			    int id, int pbuf_size);
++#endif
+--- /dev/null
++++ b/include/sound/mediatek/mtk-afe-platform-driver.h
+@@ -0,0 +1,28 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mtk-afe-platform-driver.h  --  Mediatek afe platform driver definition
++ *
++ * Copyright (c) 2016 MediaTek Inc.
++ * Author: Garlic Tseng <garlic.tseng@mediatek.com>
++ */
++
++#ifndef _MTK_AFE_PLATFORM_DRIVER_H_
++#define _MTK_AFE_PLATFORM_DRIVER_H_
++
++#define AFE_PCM_NAME "mtk-afe-pcm"
++extern const struct snd_soc_component_driver mtk_afe_pcm_platform;
++
++struct mtk_base_afe;
++struct snd_pcm;
++struct snd_soc_component;
++struct snd_soc_pcm_runtime;
++
++snd_pcm_uframes_t mtk_afe_pcm_pointer(struct snd_soc_component *component,
++				      struct snd_pcm_substream *substream);
++int mtk_afe_pcm_new(struct snd_soc_component *component,
++		    struct snd_soc_pcm_runtime *rtd);
++
++int mtk_afe_combine_sub_dai(struct mtk_base_afe *afe);
++int mtk_afe_add_sub_dai_control(struct snd_soc_component *component);
++#endif
++
+--- a/sound/soc/mediatek/common/mtk-afe-fe-dai.h
++++ /dev/null
+@@ -1,53 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/*
+- * mtk-afe-fe-dais.h  --  Mediatek afe fe dai operator definition
+- *
+- * Copyright (c) 2016 MediaTek Inc.
+- * Author: Garlic Tseng <garlic.tseng@mediatek.com>
+- */
+-
+-#ifndef _MTK_AFE_FE_DAI_H_
+-#define _MTK_AFE_FE_DAI_H_
+-
+-struct snd_soc_dai_ops;
+-struct mtk_base_afe;
+-struct mtk_base_afe_memif;
+-
+-int mtk_afe_fe_startup(struct snd_pcm_substream *substream,
+-		       struct snd_soc_dai *dai);
+-void mtk_afe_fe_shutdown(struct snd_pcm_substream *substream,
+-			 struct snd_soc_dai *dai);
+-int mtk_afe_fe_hw_params(struct snd_pcm_substream *substream,
+-			 struct snd_pcm_hw_params *params,
+-			 struct snd_soc_dai *dai);
+-int mtk_afe_fe_hw_free(struct snd_pcm_substream *substream,
+-		       struct snd_soc_dai *dai);
+-int mtk_afe_fe_prepare(struct snd_pcm_substream *substream,
+-		       struct snd_soc_dai *dai);
+-int mtk_afe_fe_trigger(struct snd_pcm_substream *substream, int cmd,
+-		       struct snd_soc_dai *dai);
+-
+-extern const struct snd_soc_dai_ops mtk_afe_fe_ops;
+-
+-int mtk_dynamic_irq_acquire(struct mtk_base_afe *afe);
+-int mtk_dynamic_irq_release(struct mtk_base_afe *afe, int irq_id);
+-int mtk_afe_suspend(struct snd_soc_component *component);
+-int mtk_afe_resume(struct snd_soc_component *component);
+-
+-int mtk_memif_set_enable(struct mtk_base_afe *afe, int id);
+-int mtk_memif_set_disable(struct mtk_base_afe *afe, int id);
+-int mtk_memif_set_addr(struct mtk_base_afe *afe, int id,
+-		       unsigned char *dma_area,
+-		       dma_addr_t dma_addr,
+-		       size_t dma_bytes);
+-int mtk_memif_set_channel(struct mtk_base_afe *afe,
+-			  int id, unsigned int channel);
+-int mtk_memif_set_rate(struct mtk_base_afe *afe,
+-		       int id, unsigned int rate);
+-int mtk_memif_set_rate_substream(struct snd_pcm_substream *substream,
+-				 int id, unsigned int rate);
+-int mtk_memif_set_format(struct mtk_base_afe *afe,
+-			 int id, snd_pcm_format_t format);
+-int mtk_memif_set_pbuf_size(struct mtk_base_afe *afe,
+-			    int id, int pbuf_size);
+-#endif
+--- a/sound/soc/mediatek/common/mtk-afe-platform-driver.h
++++ /dev/null
+@@ -1,28 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/*
+- * mtk-afe-platform-driver.h  --  Mediatek afe platform driver definition
+- *
+- * Copyright (c) 2016 MediaTek Inc.
+- * Author: Garlic Tseng <garlic.tseng@mediatek.com>
+- */
+-
+-#ifndef _MTK_AFE_PLATFORM_DRIVER_H_
+-#define _MTK_AFE_PLATFORM_DRIVER_H_
+-
+-#define AFE_PCM_NAME "mtk-afe-pcm"
+-extern const struct snd_soc_component_driver mtk_afe_pcm_platform;
+-
+-struct mtk_base_afe;
+-struct snd_pcm;
+-struct snd_soc_component;
+-struct snd_soc_pcm_runtime;
+-
+-snd_pcm_uframes_t mtk_afe_pcm_pointer(struct snd_soc_component *component,
+-				      struct snd_pcm_substream *substream);
+-int mtk_afe_pcm_new(struct snd_soc_component *component,
+-		    struct snd_soc_pcm_runtime *rtd);
+-
+-int mtk_afe_combine_sub_dai(struct mtk_base_afe *afe);
+-int mtk_afe_add_sub_dai_control(struct snd_soc_component *component);
+-#endif
+-

--- a/target/linux/airoha/patches-6.6/123-02-ASoC-airoha-Add-AFE-and-I2S-driver-for-Airoha-AN7581.patch
+++ b/target/linux/airoha/patches-6.6/123-02-ASoC-airoha-Add-AFE-and-I2S-driver-for-Airoha-AN7581.patch
@@ -28,11 +28,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  create mode 100644 sound/soc/airoha/an7581/an7581-i2s.c
  create mode 100644 sound/soc/airoha/an7581/an7581-reg.h
 
-diff --git a/sound/soc/Kconfig b/sound/soc/Kconfig
-index 1b983c7006f1..5ea1af792f2e 100644
 --- a/sound/soc/Kconfig
 +++ b/sound/soc/Kconfig
-@@ -103,6 +103,7 @@ config SND_SOC_USB
+@@ -78,6 +78,7 @@ config SND_SOC_ACPI
  
  # All the supported SoCs
  source "sound/soc/adi/Kconfig"
@@ -40,11 +38,9 @@ index 1b983c7006f1..5ea1af792f2e 100644
  source "sound/soc/amd/Kconfig"
  source "sound/soc/apple/Kconfig"
  source "sound/soc/atmel/Kconfig"
-diff --git a/sound/soc/Makefile b/sound/soc/Makefile
-index 462322c38aa4..a6a9f5e84bad 100644
 --- a/sound/soc/Makefile
 +++ b/sound/soc/Makefile
-@@ -46,6 +46,7 @@ obj-$(CONFIG_SND_SOC)	+= codecs/
+@@ -36,6 +36,7 @@ obj-$(CONFIG_SND_SOC)	+= codecs/
  obj-$(CONFIG_SND_SOC)	+= generic/
  obj-$(CONFIG_SND_SOC)	+= apple/
  obj-$(CONFIG_SND_SOC)	+= adi/
@@ -52,9 +48,6 @@ index 462322c38aa4..a6a9f5e84bad 100644
  obj-$(CONFIG_SND_SOC)	+= amd/
  obj-$(CONFIG_SND_SOC)	+= atmel/
  obj-$(CONFIG_SND_SOC)	+= au1x/
-diff --git a/sound/soc/airoha/Kconfig b/sound/soc/airoha/Kconfig
-new file mode 100644
-index 000000000000..7c271c164f1f
 --- /dev/null
 +++ b/sound/soc/airoha/Kconfig
 @@ -0,0 +1,19 @@
@@ -77,17 +70,11 @@ index 000000000000..7c271c164f1f
 +	  that can be used with other codecs.
 +	  Select Y if you have such device.
 +	  If unsure select "N".
-diff --git a/sound/soc/airoha/Makefile b/sound/soc/airoha/Makefile
-new file mode 100644
-index 000000000000..fef7fed384a9
 --- /dev/null
 +++ b/sound/soc/airoha/Makefile
 @@ -0,0 +1,2 @@
 +# SPDX-License-Identifier: GPL-2.0
 +obj-$(CONFIG_SND_SOC_AN7581) += an7581/
-diff --git a/sound/soc/airoha/an7581/Makefile b/sound/soc/airoha/an7581/Makefile
-new file mode 100644
-index 000000000000..8cec1a48dc89
 --- /dev/null
 +++ b/sound/soc/airoha/an7581/Makefile
 @@ -0,0 +1,8 @@
@@ -99,9 +86,6 @@ index 000000000000..8cec1a48dc89
 +
 +obj-$(CONFIG_SND_SOC_AN7581) += snd-soc-an7581-afe.o
 +obj-$(CONFIG_SND_SOC_AN7581_I2S) += an7581-i2s.o
-diff --git a/sound/soc/airoha/an7581/an7581-afe-common.h b/sound/soc/airoha/an7581/an7581-afe-common.h
-new file mode 100644
-index 000000000000..233f12e77d32
 --- /dev/null
 +++ b/sound/soc/airoha/an7581/an7581-afe-common.h
 @@ -0,0 +1,35 @@
@@ -140,9 +124,6 @@ index 000000000000..233f12e77d32
 +				       unsigned int rate);
 +
 +#endif
-diff --git a/sound/soc/airoha/an7581/an7581-afe-pcm.c b/sound/soc/airoha/an7581/an7581-afe-pcm.c
-new file mode 100644
-index 000000000000..9df236881b9b
 --- /dev/null
 +++ b/sound/soc/airoha/an7581/an7581-afe-pcm.c
 @@ -0,0 +1,455 @@
@@ -601,9 +582,6 @@ index 000000000000..9df236881b9b
 +
 +MODULE_DESCRIPTION("Airoha SoC AFE platform driver for ALSA AN7581");
 +MODULE_LICENSE("GPL");
-diff --git a/sound/soc/airoha/an7581/an7581-i2s.c b/sound/soc/airoha/an7581/an7581-i2s.c
-new file mode 100644
-index 000000000000..542caa107921
 --- /dev/null
 +++ b/sound/soc/airoha/an7581/an7581-i2s.c
 @@ -0,0 +1,133 @@
@@ -740,9 +718,6 @@ index 000000000000..542caa107921
 +
 +MODULE_DESCRIPTION("Airoha SoC I2S platform driver for ALSA AN7581");
 +MODULE_LICENSE("GPL");
-diff --git a/sound/soc/airoha/an7581/an7581-reg.h b/sound/soc/airoha/an7581/an7581-reg.h
-new file mode 100644
-index 000000000000..2b14a66afa68
 --- /dev/null
 +++ b/sound/soc/airoha/an7581/an7581-reg.h
 @@ -0,0 +1,29 @@
@@ -775,6 +750,3 @@ index 000000000000..2b14a66afa68
 +#define AFE_MAX_REGISTER		AFE_IRQ1_CON0
 +
 +#endif
--- 
-2.50.1
-

--- a/target/linux/airoha/patches-6.6/123-03-sound-airoha-add-support-for-AN7581-PCM-driver.patch
+++ b/target/linux/airoha/patches-6.6/123-03-sound-airoha-add-support-for-AN7581-PCM-driver.patch
@@ -18,8 +18,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  create mode 100644 sound/airoha/Makefile
  create mode 100644 sound/airoha/an7581-pcm.c
 
-diff --git a/sound/Kconfig b/sound/Kconfig
-index 8b40205394fe..7886c2460e86 100644
 --- a/sound/Kconfig
 +++ b/sound/Kconfig
 @@ -63,6 +63,8 @@ source "sound/ppc/Kconfig"
@@ -31,8 +29,6 @@ index 8b40205394fe..7886c2460e86 100644
  source "sound/aoa/Kconfig"
  
  source "sound/arm/Kconfig"
-diff --git a/sound/Makefile b/sound/Makefile
-index 5942311a4232..85008bb22b7e 100644
 --- a/sound/Makefile
 +++ b/sound/Makefile
 @@ -6,7 +6,7 @@ obj-$(CONFIG_SOUND) += soundcore.o
@@ -44,9 +40,6 @@ index 5942311a4232..85008bb22b7e 100644
  obj-$(CONFIG_SND_AOA) += aoa/
  
  # This one must be compilable even if sound is configured out
-diff --git a/sound/airoha/Kconfig b/sound/airoha/Kconfig
-new file mode 100644
-index 000000000000..fe226fedd1a4
 --- /dev/null
 +++ b/sound/airoha/Kconfig
 @@ -0,0 +1,9 @@
@@ -59,18 +52,12 @@ index 000000000000..fe226fedd1a4
 +	  that can be used with other codecs.
 +	  Select Y if you have such device.
 +	  If unsure select "N".
-diff --git a/sound/airoha/Makefile b/sound/airoha/Makefile
-new file mode 100644
-index 000000000000..039b8853d5a2
 --- /dev/null
 +++ b/sound/airoha/Makefile
 @@ -0,0 +1,3 @@
 +# SPDX-License-Identifier: GPL-2.0
 +
 +obj-$(CONFIG_SND_AN7581_PCM) += an7581-pcm.o
-diff --git a/sound/airoha/an7581-pcm.c b/sound/airoha/an7581-pcm.c
-new file mode 100644
-index 000000000000..1b6fc2a86776
 --- /dev/null
 +++ b/sound/airoha/an7581-pcm.c
 @@ -0,0 +1,637 @@
@@ -711,6 +698,3 @@ index 000000000000..1b6fc2a86776
 +
 +MODULE_DESCRIPTION("Airoha SoC PCM platform driver for ALSA AN7581");
 +MODULE_LICENSE("GPL");
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/124-01-net-phy-introduce-phy_id_compare_vendor-PHY-ID-helpe.patch
+++ b/target/linux/airoha/patches-6.6/124-01-net-phy-introduce-phy_id_compare_vendor-PHY-ID-helpe.patch
@@ -14,13 +14,11 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  include/linux/phy.h | 23 ++++++++++++++++++++---
  1 file changed, 20 insertions(+), 3 deletions(-)
 
-diff --git a/include/linux/phy.h b/include/linux/phy.h
-index 74c1bcf64b3c..173567b86617 100644
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
-@@ -1260,9 +1260,13 @@ struct phy_driver {
- #define to_phy_driver(d) container_of_const(to_mdio_common_driver(d),		\
- 				      struct phy_driver, mdiodrv)
+@@ -1186,9 +1186,13 @@ struct phy_driver {
+ #define PHY_ANY_ID "MATCH ANY PHY"
+ #define PHY_ANY_UID 0xffffffff
  
 -#define PHY_ID_MATCH_EXACT(id) .phy_id = (id), .phy_id_mask = GENMASK(31, 0)
 -#define PHY_ID_MATCH_MODEL(id) .phy_id = (id), .phy_id_mask = GENMASK(31, 4)
@@ -35,11 +33,10 @@ index 74c1bcf64b3c..173567b86617 100644
  
  /**
   * phy_id_compare - compare @id1 with @id2 taking account of @mask
-@@ -1278,6 +1282,19 @@ static inline bool phy_id_compare(u32 id1, u32 id2, u32 mask)
- 	return !((id1 ^ id2) & mask);
+@@ -1205,6 +1209,19 @@ static inline bool phy_id_compare(u32 id
  }
  
-+/**
+ /**
 + * phy_id_compare_vendor - compare @id with @vendor mask
 + * @id: PHY ID
 + * @vendor: PHY Vendor mask
@@ -52,9 +49,7 @@ index 74c1bcf64b3c..173567b86617 100644
 +	return phy_id_compare(id, vendor_mask, PHY_ID_MATCH_VENDOR_MASK);
 +}
 +
- /**
++/**
   * phydev_id_compare - compare @id with the PHY's Clause 22 ID
   * @phydev: the PHY device
--- 
-2.50.0
-
+  * @id: the PHY ID to be matched

--- a/target/linux/airoha/patches-6.6/124-02-net-phy-as21xxx-better-handle-PHY-HW-reset-on-soft-r.patch
+++ b/target/linux/airoha/patches-6.6/124-02-net-phy-as21xxx-better-handle-PHY-HW-reset-on-soft-r.patch
@@ -24,11 +24,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 7 ++++---
  1 file changed, 4 insertions(+), 3 deletions(-)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 92697f43087d..005277360656 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -884,11 +884,12 @@ static int as21xxx_match_phy_device(struct phy_device *phydev,
+@@ -884,11 +884,12 @@ static int as21xxx_match_phy_device(stru
  	u32 phy_id;
  	int ret;
  
@@ -44,6 +42,3 @@ index 92697f43087d..005277360656 100644
  	ret = phy_read_mmd(phydev, MDIO_MMD_PCS, MII_PHYSID1);
  	if (ret < 0)
  		return ret;
--- 
-2.50.0
-

--- a/target/linux/airoha/patches-6.6/220-04-dt-bindings-soc-Add-bindings-for-Airoha-SCU-Serdes-l.patch
+++ b/target/linux/airoha/patches-6.6/220-04-dt-bindings-soc-Add-bindings-for-Airoha-SCU-Serdes-l.patch
@@ -19,9 +19,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  1 file changed, 11 insertions(+)
  create mode 100644 include/dt-bindings/soc/airoha,scu-ssr.h
 
-diff --git a/include/dt-bindings/soc/airoha,scu-ssr.h b/include/dt-bindings/soc/airoha,scu-ssr.h
-new file mode 100644
-index 000000000000..915f3cde7c1a
 --- /dev/null
 +++ b/include/dt-bindings/soc/airoha,scu-ssr.h
 @@ -0,0 +1,11 @@
@@ -36,6 +33,3 @@ index 000000000000..915f3cde7c1a
 +#define AIROHA_SCU_SERDES_USB2		3
 +
 +#endif /* __DT_BINDINGS_AIROHA_SCU_SSR_H */
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/220-05-dt-bindings-phy-Add-documentation-for-Airoha-AN7581-.patch
+++ b/target/linux/airoha/patches-6.6/220-05-dt-bindings-phy-Add-documentation-for-Airoha-AN7581-.patch
@@ -23,9 +23,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  create mode 100644 Documentation/devicetree/bindings/phy/airoha,an7581-usb-phy.yaml
  create mode 100644 include/dt-bindings/phy/airoha,an7581-usb-phy.h
 
-diff --git a/Documentation/devicetree/bindings/phy/airoha,an7581-usb-phy.yaml b/Documentation/devicetree/bindings/phy/airoha,an7581-usb-phy.yaml
-new file mode 100644
-index 000000000000..39ceaded5d0e
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/phy/airoha,an7581-usb-phy.yaml
 @@ -0,0 +1,83 @@
@@ -112,13 +109,11 @@ index 000000000000..39ceaded5d0e
 +        #phy-cells = <1>;
 +    };
 +
-diff --git a/MAINTAINERS b/MAINTAINERS
-index 3eee238c2ea2..2468f4fea5b7 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -745,6 +745,13 @@ S:	Maintained
- F:	Documentation/devicetree/bindings/spi/airoha,en7581-snand.yaml
- F:	drivers/spi/spi-airoha-snfi.c
+@@ -647,6 +647,13 @@ S:	Supported
+ F:	fs/aio.c
+ F:	include/linux/*aio*.h
  
 +AIROHA USB PHY DRIVER
 +M:	Christian Marangi <ansuelsmth@gmail.com>
@@ -128,11 +123,8 @@ index 3eee238c2ea2..2468f4fea5b7 100644
 +F:	include/dt-bindings/phy/airoha,an7581-usb-phy.h
 +
  AIRSPY MEDIA DRIVER
+ M:	Antti Palosaari <crope@iki.fi>
  L:	linux-media@vger.kernel.org
- S:	Orphan
-diff --git a/include/dt-bindings/phy/airoha,an7581-usb-phy.h b/include/dt-bindings/phy/airoha,an7581-usb-phy.h
-new file mode 100644
-index 000000000000..efbb0ae75e3a
 --- /dev/null
 +++ b/include/dt-bindings/phy/airoha,an7581-usb-phy.h
 @@ -0,0 +1,11 @@
@@ -147,6 +139,3 @@ index 000000000000..efbb0ae75e3a
 +#define AIROHA_USB2_MONCLK_SEL3                 3
 +
 +#endif
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/220-06-phy-move-Airoha-PCIe-PHY-driver-to-dedicated-directo.patch
+++ b/target/linux/airoha/patches-6.6/220-06-phy-move-Airoha-PCIe-PHY-driver-to-dedicated-directo.patch
@@ -38,8 +38,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 #  AIROHA SPI SNFI DRIVER
 #  M:	Lorenzo Bianconi <lorenzo@kernel.org>
-diff --git a/drivers/phy/Kconfig b/drivers/phy/Kconfig
-index 8d58efe998ec..7f9f5b786643 100644
 --- a/drivers/phy/Kconfig
 +++ b/drivers/phy/Kconfig
 @@ -72,16 +72,7 @@ config PHY_CAN_TRANSCEIVER
@@ -60,11 +58,9 @@ index 8d58efe998ec..7f9f5b786643 100644
  source "drivers/phy/allwinner/Kconfig"
  source "drivers/phy/amlogic/Kconfig"
  source "drivers/phy/broadcom/Kconfig"
-diff --git a/drivers/phy/Makefile b/drivers/phy/Makefile
-index e281442acc75..9ab557db59e6 100644
 --- a/drivers/phy/Makefile
 +++ b/drivers/phy/Makefile
-@@ -10,8 +10,8 @@ obj-$(CONFIG_PHY_LPC18XX_USB_OTG)	+= phy-lpc18xx-usb-otg.o
+@@ -10,8 +10,8 @@ obj-$(CONFIG_PHY_LPC18XX_USB_OTG)	+= phy
  obj-$(CONFIG_PHY_XGENE)			+= phy-xgene.o
  obj-$(CONFIG_PHY_PISTACHIO_USB)		+= phy-pistachio-usb.o
  obj-$(CONFIG_USB_LGM_PHY)		+= phy-lgm-usb.o
@@ -75,9 +71,6 @@ index e281442acc75..9ab557db59e6 100644
  					   amlogic/	\
  					   broadcom/	\
  					   cadence/	\
-diff --git a/drivers/phy/airoha/Kconfig b/drivers/phy/airoha/Kconfig
-new file mode 100644
-index 000000000000..70b7eac4a2bf
 --- /dev/null
 +++ b/drivers/phy/airoha/Kconfig
 @@ -0,0 +1,13 @@
@@ -94,18 +87,12 @@ index 000000000000..70b7eac4a2bf
 +	  Say Y here to add support for Airoha PCIe PHY driver.
 +	  This driver create the basic PHY instance and provides initialize
 +	  callback for PCIe GEN3 port.
-diff --git a/drivers/phy/airoha/Makefile b/drivers/phy/airoha/Makefile
-new file mode 100644
-index 000000000000..3222f749546b
 --- /dev/null
 +++ b/drivers/phy/airoha/Makefile
 @@ -0,0 +1,3 @@
 +# SPDX-License-Identifier: GPL-2.0
 +
 +obj-$(CONFIG_PHY_AIROHA_PCIE)		+= phy-airoha-pcie.o
-diff --git a/drivers/phy/airoha/phy-airoha-pcie-regs.h b/drivers/phy/airoha/phy-airoha-pcie-regs.h
-new file mode 100644
-index 000000000000..b938a7b468fe
 --- /dev/null
 +++ b/drivers/phy/airoha/phy-airoha-pcie-regs.h
 @@ -0,0 +1,494 @@
@@ -603,9 +590,6 @@ index 000000000000..b938a7b468fe
 +#define REG_PCIE_PEXTP_DIG_LN_RX30_P1		0x0100
 +
 +#endif /* _PHY_AIROHA_PCIE_H */
-diff --git a/drivers/phy/airoha/phy-airoha-pcie.c b/drivers/phy/airoha/phy-airoha-pcie.c
-new file mode 100644
-index 000000000000..56e9ade8a9fd
 --- /dev/null
 +++ b/drivers/phy/airoha/phy-airoha-pcie.c
 @@ -0,0 +1,1290 @@
@@ -1899,6 +1883,3 @@ index 000000000000..56e9ade8a9fd
 +MODULE_DESCRIPTION("Airoha PCIe PHY driver");
 +MODULE_AUTHOR("Lorenzo Bianconi <lorenzo@kernel.org>");
 +MODULE_LICENSE("GPL");
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/220-07-phy-airoha-Add-support-for-Airoha-AN7581-USB-PHY.patch
+++ b/target/linux/airoha/patches-6.6/220-07-phy-airoha-Add-support-for-Airoha-AN7581-USB-PHY.patch
@@ -33,11 +33,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  4 files changed, 609 insertions(+)
  create mode 100644 drivers/phy/airoha/phy-airoha-usb.c
 
-diff --git a/MAINTAINERS b/MAINTAINERS
-index 3f930a613658..a7294bf67ae9 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -750,6 +750,7 @@ M:	Christian Marangi <ansuelsmth@gmail.com>
+@@ -652,6 +652,7 @@ M:	Christian Marangi <ansuelsmth@gmail.c
  L:	linux-arm-kernel@lists.infradead.org (moderated for non-subscribers)
  S:	Maintained
  F:	Documentation/devicetree/bindings/phy/airoha,an7581-usb-phy.yaml
@@ -45,8 +43,6 @@ index 3f930a613658..a7294bf67ae9 100644
  F:	include/dt-bindings/phy/airoha,an7581-usb-phy.h
  
  AIRSPY MEDIA DRIVER
-diff --git a/drivers/phy/airoha/Kconfig b/drivers/phy/airoha/Kconfig
-index 70b7eac4a2bf..0675d8f2f9d1 100644
 --- a/drivers/phy/airoha/Kconfig
 +++ b/drivers/phy/airoha/Kconfig
 @@ -11,3 +11,13 @@ config PHY_AIROHA_PCIE
@@ -63,8 +59,6 @@ index 70b7eac4a2bf..0675d8f2f9d1 100644
 +	  Say 'Y' here to add support for Airoha USB PHY driver.
 +	  This driver create the basic PHY instance and provides initialize
 +	  callback for USB port.
-diff --git a/drivers/phy/airoha/Makefile b/drivers/phy/airoha/Makefile
-index 3222f749546b..fd188d08c412 100644
 --- a/drivers/phy/airoha/Makefile
 +++ b/drivers/phy/airoha/Makefile
 @@ -1,3 +1,4 @@
@@ -72,9 +66,6 @@ index 3222f749546b..fd188d08c412 100644
  
  obj-$(CONFIG_PHY_AIROHA_PCIE)		+= phy-airoha-pcie.o
 +obj-$(CONFIG_PHY_AIROHA_USB)		+= phy-airoha-usb.o
-diff --git a/drivers/phy/airoha/phy-airoha-usb.c b/drivers/phy/airoha/phy-airoha-usb.c
-new file mode 100644
-index 000000000000..2d6d63e2de83
 --- /dev/null
 +++ b/drivers/phy/airoha/phy-airoha-usb.c
 @@ -0,0 +1,596 @@
@@ -674,6 +665,3 @@ index 000000000000..2d6d63e2de83
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("Airoha USB PHY driver");
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/220-08-usb-host-add-ARCH_AIROHA-in-XHCI-MTK-dependency.patch
+++ b/target/linux/airoha/patches-6.6/220-08-usb-host-add-ARCH_AIROHA-in-XHCI-MTK-dependency.patch
@@ -12,8 +12,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/usb/host/Kconfig | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/usb/host/Kconfig b/drivers/usb/host/Kconfig
-index d011d6c753ed..9d8626f36ca6 100644
 --- a/drivers/usb/host/Kconfig
 +++ b/drivers/usb/host/Kconfig
 @@ -71,7 +71,7 @@ config USB_XHCI_HISTB
@@ -25,6 +23,3 @@ index d011d6c753ed..9d8626f36ca6 100644
  	help
  	  Say 'Y' to enable the support for the xHCI host controller
  	  found in MediaTek SoCs.
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/220-10-PCI-mediatek-gen3-set-PHY-mode-for-Airoha-EN7581.patch
+++ b/target/linux/airoha/patches-6.6/220-10-PCI-mediatek-gen3-set-PHY-mode-for-Airoha-EN7581.patch
@@ -17,11 +17,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pci/controller/pcie-mediatek-gen3.c | 6 ++++++
  1 file changed, 6 insertions(+)
 
-diff --git a/drivers/pci/controller/pcie-mediatek-gen3.c b/drivers/pci/controller/pcie-mediatek-gen3.c
-index 9d52504acae4..6ccceafb438e 100644
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -973,6 +973,12 @@ static int mtk_pcie_en7581_power_up(struct mtk_gen3_pcie *pcie)
+@@ -932,6 +932,12 @@ static int mtk_pcie_en7581_power_up(stru
  	size = lower_32_bits(resource_size(entry->res));
  	regmap_write(pbus_regmap, args[1], GENMASK(31, __fls(size)));
  
@@ -34,6 +32,3 @@ index 9d52504acae4..6ccceafb438e 100644
  	/*
  	 * Unlike the other MediaTek Gen3 controllers, the Airoha EN7581
  	 * requires PHY initialization and power-on before PHY reset deassert.
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/221-nvmem-airoha-Add-support-for-SMC-eFUSE.patch
+++ b/target/linux/airoha/patches-6.6/221-nvmem-airoha-Add-support-for-SMC-eFUSE.patch
@@ -20,11 +20,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  3 files changed, 133 insertions(+)
  create mode 100644 drivers/nvmem/airoha-smc-efuses.c
 
-diff --git a/drivers/nvmem/Kconfig b/drivers/nvmem/Kconfig
-index 8671b7c974b9..5c44576d7457 100644
 --- a/drivers/nvmem/Kconfig
 +++ b/drivers/nvmem/Kconfig
-@@ -28,6 +28,19 @@ source "drivers/nvmem/layouts/Kconfig"
+@@ -29,6 +29,19 @@ source "drivers/nvmem/layouts/Kconfig"
  
  # Devices
  
@@ -44,8 +42,6 @@ index 8671b7c974b9..5c44576d7457 100644
  config NVMEM_APPLE_EFUSES
  	tristate "Apple eFuse support"
  	depends on ARCH_APPLE || COMPILE_TEST
-diff --git a/drivers/nvmem/Makefile b/drivers/nvmem/Makefile
-index 5b77bbb6488b..77c0264f7d39 100644
 --- a/drivers/nvmem/Makefile
 +++ b/drivers/nvmem/Makefile
 @@ -10,6 +10,8 @@ nvmem_layouts-y			:= layouts.o
@@ -57,9 +53,6 @@ index 5b77bbb6488b..77c0264f7d39 100644
  obj-$(CONFIG_NVMEM_APPLE_EFUSES)	+= nvmem-apple-efuses.o
  nvmem-apple-efuses-y 			:= apple-efuses.o
  obj-$(CONFIG_NVMEM_BCM_OCOTP)		+= nvmem-bcm-ocotp.o
-diff --git a/drivers/nvmem/airoha-smc-efuses.c b/drivers/nvmem/airoha-smc-efuses.c
-new file mode 100644
-index 000000000000..bb279d149519
 --- /dev/null
 +++ b/drivers/nvmem/airoha-smc-efuses.c
 @@ -0,0 +1,118 @@
@@ -181,6 +174,3 @@ index 000000000000..bb279d149519
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_DESCRIPTION("Driver for Airoha SMC eFUSEs");
 +MODULE_LICENSE("GPL");
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/303-01-net-phy-mediatek-export-__mtk_tr_write.patch
+++ b/target/linux/airoha/patches-6.6/303-01-net-phy-mediatek-export-__mtk_tr_write.patch
@@ -11,11 +11,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/mediatek/mtk.h         | 2 ++
  2 files changed, 5 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/net/phy/mediatek/mtk-phy-lib.c b/drivers/net/phy/mediatek/mtk-phy-lib.c
-index dfd0f4e439a2..78b998af5238 100644
 --- a/drivers/net/phy/mediatek/mtk-phy-lib.c
 +++ b/drivers/net/phy/mediatek/mtk-phy-lib.c
-@@ -36,8 +36,8 @@ static void __mtk_tr_read(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
+@@ -36,8 +36,8 @@ static void __mtk_tr_read(struct phy_dev
  		*tr_high, *tr_low);
  }
  
@@ -26,7 +24,7 @@ index dfd0f4e439a2..78b998af5238 100644
  {
  	__phy_write(phydev, 0x11, tr_data & 0xffff);
  	__phy_write(phydev, 0x12, tr_data >> 16);
-@@ -45,6 +45,7 @@ static void __mtk_tr_write(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
+@@ -45,6 +45,7 @@ static void __mtk_tr_write(struct phy_de
  		tr_data >> 16, tr_data & 0xffff);
  	__mtk_tr_access(phydev, false, ch_addr, node_addr, data_addr);
  }
@@ -34,8 +32,6 @@ index dfd0f4e439a2..78b998af5238 100644
  
  void __mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
  		     u8 data_addr, u32 mask, u32 set)
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index 320f76ffa81f..f172f7d671c9 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -72,6 +72,8 @@ struct mtk_socphy_priv {
@@ -47,6 +43,3 @@ index 320f76ffa81f..f172f7d671c9 100644
  void __mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
  		     u8 data_addr, u32 mask, u32 set);
  void mtk_tr_modify(struct phy_device *phydev, u8 ch_addr, u8 node_addr,
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/303-02-net-phy-mediatek-move-MTK-GE-SoC-registers-define-to.patch
+++ b/target/linux/airoha/patches-6.6/303-02-net-phy-mediatek-move-MTK-GE-SoC-registers-define-to.patch
@@ -20,13 +20,11 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  2 files changed, 372 insertions(+), 350 deletions(-)
  create mode 100644 drivers/net/phy/mediatek/mtk-ge-soc.h
 
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index cd09fbf92ef2..3b7c6f17985d 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
-@@ -11,322 +11,10 @@
+@@ -9,322 +9,10 @@
+ #include <linux/regmap.h>
  
- #include "../phylib.h"
  #include "mtk.h"
 +#include "mtk-ge-soc.h"
  
@@ -348,7 +346,7 @@ index cd09fbf92ef2..3b7c6f17985d 100644
  /* These macro privides efuse parsing for internal phy. */
  #define EFS_DA_TX_I2MPB_A(x)			(((x) >> 0) & GENMASK(5, 0))
  #define EFS_DA_TX_I2MPB_B(x)			(((x) >> 6) & GENMASK(5, 0))
-@@ -346,51 +34,16 @@
+@@ -344,51 +32,16 @@
  #define EFS_RG_BG_RASEL(x)			(((x) >> 4) & GENMASK(2, 0))
  #define EFS_RG_REXT_TRIM(x)			(((x) >> 7) & GENMASK(5, 0))
  
@@ -401,7 +399,7 @@ index cd09fbf92ef2..3b7c6f17985d 100644
  	phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CALIN,
  			 MTK_PHY_DA_CALIN_FLAG);
  
-@@ -409,7 +62,25 @@ static int cal_cycle(struct phy_device *phydev, int devad,
+@@ -407,7 +60,25 @@ static int cal_cycle(struct phy_device *
  	ret = phy_read_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_RG_AD_CAL_COMP);
  	if (ret < 0)
  		return ret;
@@ -428,9 +426,6 @@ index cd09fbf92ef2..3b7c6f17985d 100644
  	phydev_dbg(phydev, "cal_val: 0x%x, ret: %d\n", cal_val, ret);
  
  	return ret;
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.h b/drivers/net/phy/mediatek/mtk-ge-soc.h
-new file mode 100644
-index 000000000000..9aaa7e3caa41
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.h
 @@ -0,0 +1,351 @@
@@ -785,6 +780,3 @@ index 000000000000..9aaa7e3caa41
 +int mtk_cal_cycle_wait(struct phy_device *phydev);
 +
 +#endif /* _MTK_GE_SOC_H_ */
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/303-03-net-phy-mediatek-add-calibration-logic-for-AN7581.patch
+++ b/target/linux/airoha/patches-6.6/303-03-net-phy-mediatek-add-calibration-logic-for-AN7581.patch
@@ -31,8 +31,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  create mode 100644 drivers/net/phy/mediatek/airoha-phy-lib.c
  create mode 100644 drivers/net/phy/mediatek/an7581.c
 
-diff --git a/drivers/net/phy/mediatek/Makefile b/drivers/net/phy/mediatek/Makefile
-index ac57ecc799fc..7c5c8f8158e5 100644
 --- a/drivers/net/phy/mediatek/Makefile
 +++ b/drivers/net/phy/mediatek/Makefile
 @@ -2,3 +2,5 @@
@@ -41,9 +39,6 @@ index ac57ecc799fc..7c5c8f8158e5 100644
  obj-$(CONFIG_MEDIATEK_GE_SOC_PHY)	+= mtk-ge-soc.o
 +mtk-ge-soc-objs				+= mtk-ge-soc.o
 +mtk-ge-soc-objs				+= airoha-phy-lib.o an7581.o
-diff --git a/drivers/net/phy/mediatek/airoha-phy-lib.c b/drivers/net/phy/mediatek/airoha-phy-lib.c
-new file mode 100644
-index 000000000000..78783aac2d03
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/airoha-phy-lib.c
 @@ -0,0 +1,1115 @@
@@ -1162,9 +1157,6 @@ index 000000000000..78783aac2d03
 +
 +	return 0;
 +}
-diff --git a/drivers/net/phy/mediatek/an7581.c b/drivers/net/phy/mediatek/an7581.c
-new file mode 100644
-index 000000000000..5c40b1d175e2
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/an7581.c
 @@ -0,0 +1,341 @@
@@ -1509,11 +1501,9 @@ index 000000000000..5c40b1d175e2
 +
 +	return 0;
 +}
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index 3b7c6f17985d..da08ee90948d 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
-@@ -752,7 +752,6 @@ static int cal_sw(struct phy_device *phydev, enum CAL_ITEM cal_item,
+@@ -750,7 +750,6 @@ static int cal_sw(struct phy_device *phy
  	int ret;
  
  	for (pair_n = start_pair; pair_n <= end_pair; pair_n++) {
@@ -1521,7 +1511,7 @@ index 3b7c6f17985d..da08ee90948d 100644
  		switch (cal_item) {
  		case TX_VCM:
  			ret = tx_vcm_cal_sw(phydev, pair_n);
-@@ -1091,8 +1090,10 @@ static int mt7981_phy_probe(struct phy_device *phydev)
+@@ -1082,8 +1081,10 @@ static int mt7981_phy_probe(struct phy_d
  
  static int an7581_phy_probe(struct phy_device *phydev)
  {
@@ -1532,7 +1522,7 @@ index 3b7c6f17985d..da08ee90948d 100644
  
  	/* Toggle pinctrl to enable PHY LED */
  	pinctrl = devm_pinctrl_get_select(&phydev->mdio.dev, "gbe-led");
-@@ -1100,10 +1101,21 @@ static int an7581_phy_probe(struct phy_device *phydev)
+@@ -1091,10 +1092,21 @@ static int an7581_phy_probe(struct phy_d
  		dev_err(&phydev->mdio.bus->dev,
  			"Failed to setup PHY LED pinctrl\n");
  
@@ -1554,7 +1544,7 @@ index 3b7c6f17985d..da08ee90948d 100644
  	phydev->priv = priv;
  
  	return 0;
-@@ -1179,6 +1191,7 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1171,6 +1183,7 @@ static struct phy_driver mtk_socphy_driv
  	{
  		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581),
  		.name		= "Airoha AN7581 PHY",
@@ -1562,7 +1552,7 @@ index 3b7c6f17985d..da08ee90948d 100644
  		.probe		= an7581_phy_probe,
  		.led_blink_set	= mt798x_phy_led_blink_set,
  		.led_brightness_set = mt798x_phy_led_brightness_set,
-@@ -1186,6 +1199,8 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1178,6 +1191,8 @@ static struct phy_driver mtk_socphy_driv
  		.led_hw_control_set = mt798x_phy_led_hw_control_set,
  		.led_hw_control_get = mt798x_phy_led_hw_control_get,
  		.led_polarity_set = an7581_phy_led_polarity_set,
@@ -1571,8 +1561,6 @@ index 3b7c6f17985d..da08ee90948d 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7583),
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.h b/drivers/net/phy/mediatek/mtk-ge-soc.h
-index 9aaa7e3caa41..db8e96c83a99 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.h
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.h
 @@ -12,6 +12,7 @@
@@ -1676,6 +1664,3 @@ index 9aaa7e3caa41..db8e96c83a99 100644
 +int an7581_phy_config_init(struct phy_device *phydev);
 +
  #endif /* _MTK_GE_SOC_H_ */
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/401-02-net-dsa-mt7530-Add-AN7583-support.patch
+++ b/target/linux/airoha/patches-6.6/401-02-net-dsa-mt7530-Add-AN7583-support.patch
@@ -16,8 +16,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/dsa/mt7530.h      | 18 ++++++++++++++----
  3 files changed, 37 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/net/dsa/mt7530-mmio.c b/drivers/net/dsa/mt7530-mmio.c
-index 5f2db4317dd3..842d74268e77 100644
 --- a/drivers/net/dsa/mt7530-mmio.c
 +++ b/drivers/net/dsa/mt7530-mmio.c
 @@ -11,6 +11,7 @@
@@ -28,11 +26,9 @@ index 5f2db4317dd3..842d74268e77 100644
  	{ .compatible = "airoha,en7581-switch", .data = &mt753x_table[ID_EN7581], },
  	{ .compatible = "mediatek,mt7988-switch", .data = &mt753x_table[ID_MT7988], },
  	{ /* sentinel */ },
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index 7361380ffb5f..df213c37b4fe 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -1298,7 +1298,7 @@ mt753x_cpu_port_enable(struct dsa_switch *ds, int port)
+@@ -1297,7 +1297,7 @@ mt753x_cpu_port_enable(struct dsa_switch
  	 * is affine to the inbound user port.
  	 */
  	if (priv->id == ID_MT7531 || priv->id == ID_MT7988 ||
@@ -41,7 +37,7 @@ index 7361380ffb5f..df213c37b4fe 100644
  		mt7530_set(priv, MT7531_CFC, MT7531_CPU_PMAP(BIT(port)));
  
  	/* CPU port gets connected to all user ports of
-@@ -2612,7 +2612,7 @@ mt7531_setup_common(struct dsa_switch *ds)
+@@ -2733,7 +2733,7 @@ mt7531_setup_common(struct dsa_switch *d
  	mt7530_set(priv, MT753X_AGC, LOCAL_EN);
  
  	/* Enable Special Tag for rx frames */
@@ -50,7 +46,7 @@ index 7361380ffb5f..df213c37b4fe 100644
  		mt7530_write(priv, MT753X_CPORT_SPTAG_CFG,
  			     CPORT_SW2FE_STAG_EN | CPORT_FE2SW_STAG_EN);
  
-@@ -3236,6 +3236,16 @@ static int mt7988_setup(struct dsa_switch *ds)
+@@ -3301,6 +3301,16 @@ static int mt7988_setup(struct dsa_switc
  	reset_control_deassert(priv->rstc);
  	usleep_range(20, 50);
  
@@ -67,25 +63,23 @@ index 7361380ffb5f..df213c37b4fe 100644
  	/* Reset the switch PHYs */
  	mt7530_write(priv, MT7530_SYS_CTRL, SYS_CTRL_PHY_RST);
  
-@@ -3344,6 +3354,16 @@ const struct mt753x_info mt753x_table[] = {
- 		.phy_write_c45 = mt7531_ind_c45_phy_write,
- 		.mac_port_get_caps = en7581_mac_port_get_caps,
- 	},
-+	[ID_AN7583] = {
-+		.id = ID_AN7583,
-+		.pcs_ops = &mt7530_pcs_ops,
-+		.sw_setup = mt7988_setup,
-+		.phy_read_c22 = mt7531_ind_c22_phy_read,
+@@ -3401,6 +3411,16 @@ const struct mt753x_info mt753x_table[]
+ 		.pcs_ops = &mt7530_pcs_ops,
+ 		.sw_setup = mt7988_setup,
+ 		.phy_read_c22 = mt7531_ind_c22_phy_read,
 +		.phy_write_c22 = mt7531_ind_c22_phy_write,
 +		.phy_read_c45 = mt7531_ind_c45_phy_read,
 +		.phy_write_c45 = mt7531_ind_c45_phy_write,
 +		.mac_port_get_caps = en7581_mac_port_get_caps,
 +	},
- };
- EXPORT_SYMBOL_GPL(mt753x_table);
- 
-diff --git a/drivers/net/dsa/mt7530.h b/drivers/net/dsa/mt7530.h
-index d4b838a055ad..7e47cd9af256 100644
++	[ID_AN7583] = {
++		.id = ID_AN7583,
++		.pcs_ops = &mt7530_pcs_ops,
++		.sw_setup = mt7988_setup,
++		.phy_read_c22 = mt7531_ind_c22_phy_read,
+ 		.phy_write_c22 = mt7531_ind_c22_phy_write,
+ 		.phy_read_c45 = mt7531_ind_c45_phy_read,
+ 		.phy_write_c45 = mt7531_ind_c45_phy_write,
 --- a/drivers/net/dsa/mt7530.h
 +++ b/drivers/net/dsa/mt7530.h
 @@ -20,6 +20,7 @@ enum mt753x_id {
@@ -132,7 +126,7 @@ index d4b838a055ad..7e47cd9af256 100644
  					 MT7531_MIRROR_PORT_SET(val) : \
  					 MT7530_MIRROR_PORT_SET(val))
  
-@@ -673,6 +678,11 @@ enum mt7531_xtal_fsel {
+@@ -661,6 +666,11 @@ enum mt7531_xtal_fsel {
  #define  CPORT_SW2FE_STAG_EN		BIT(1)
  #define  CPORT_FE2SW_STAG_EN		BIT(0)
  
@@ -144,6 +138,3 @@ index d4b838a055ad..7e47cd9af256 100644
  /* Registers for LED GPIO control (MT7530 only)
   * All registers follow this pattern:
   * [ 2: 0]  port 0
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/402-01-thermal-airoha-convert-to-regmap-API.patch
+++ b/target/linux/airoha/patches-6.6/402-01-thermal-airoha-convert-to-regmap-API.patch
@@ -12,8 +12,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/thermal/airoha_thermal.c | 72 +++++++++++++++++++-------------
  1 file changed, 42 insertions(+), 30 deletions(-)
 
-diff --git a/drivers/thermal/airoha_thermal.c b/drivers/thermal/airoha_thermal.c
-index 9a7a702a17de..04bda890dbb1 100644
 --- a/drivers/thermal/airoha_thermal.c
 +++ b/drivers/thermal/airoha_thermal.c
 @@ -194,7 +194,7 @@
@@ -25,7 +23,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  	struct regmap *chip_scu;
  	struct resource scu_adc_res;
  
-@@ -265,8 +265,8 @@ static int airoha_thermal_set_trips(struct thermal_zone_device *tz, int low,
+@@ -265,8 +265,8 @@ static int airoha_thermal_set_trips(stru
  			       RAW_TO_TEMP(priv, FIELD_MAX(EN7581_DOUT_TADC_MASK)));
  
  		/* We offset the high temp of 1°C to trigger correct event */
@@ -36,7 +34,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  		enable_monitor = true;
  	}
-@@ -277,15 +277,15 @@ static int airoha_thermal_set_trips(struct thermal_zone_device *tz, int low,
+@@ -277,15 +277,15 @@ static int airoha_thermal_set_trips(stru
  			      RAW_TO_TEMP(priv, FIELD_MAX(EN7581_DOUT_TADC_MASK)));
  
  		/* We offset the low temp of 1°C to trigger correct event */
@@ -55,7 +53,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  	return 0;
  }
-@@ -302,7 +302,7 @@ static irqreturn_t airoha_thermal_irq(int irq, void *data)
+@@ -302,7 +302,7 @@ static irqreturn_t airoha_thermal_irq(in
  	bool update = false;
  	u32 status;
  
@@ -64,7 +62,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  	switch (status & (EN7581_HOFSINTSTS0 | EN7581_LOFSINTSTS0)) {
  	case EN7581_HOFSINTSTS0:
  		event = THERMAL_TRIP_VIOLATED;
-@@ -318,7 +318,7 @@ static irqreturn_t airoha_thermal_irq(int irq, void *data)
+@@ -318,7 +318,7 @@ static irqreturn_t airoha_thermal_irq(in
  	}
  
  	/* Reset Interrupt */
@@ -73,7 +71,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  	if (update)
  		thermal_zone_device_update(priv->tz, event);
-@@ -336,11 +336,11 @@ static void airoha_thermal_setup_adc_val(struct device *dev,
+@@ -336,11 +336,11 @@ static void airoha_thermal_setup_adc_val
  	/* sleep 10 ms for ADC to enable */
  	usleep_range(10 * USEC_PER_MSEC, 11 * USEC_PER_MSEC);
  
@@ -87,7 +85,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  		if (cpu_sensor) {
  			priv->default_slope = EN7581_SLOPE_X100_DIO_DEFAULT;
  			priv->init_temp = EN7581_INIT_TEMP_FTK_X10;
-@@ -359,8 +359,8 @@ static void airoha_thermal_setup_adc_val(struct device *dev,
+@@ -359,8 +359,8 @@ static void airoha_thermal_setup_adc_val
  static void airoha_thermal_setup_monitor(struct airoha_thermal_priv *priv)
  {
  	/* Set measure mode */
@@ -98,7 +96,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  	/*
  	 * Configure ADC valid reading addr
-@@ -375,15 +375,15 @@ static void airoha_thermal_setup_monitor(struct airoha_thermal_priv *priv)
+@@ -375,15 +375,15 @@ static void airoha_thermal_setup_monitor
  	 * We set valid instead of volt as we don't enable valid/volt
  	 * split reading and AHB read valid addr in such case.
  	 */
@@ -118,7 +116,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  	/*
  	 * AHB supports max 12 bytes for ADC voltage. Shift the read
-@@ -391,40 +391,52 @@ static void airoha_thermal_setup_monitor(struct airoha_thermal_priv *priv)
+@@ -391,40 +391,52 @@ static void airoha_thermal_setup_monitor
  	 * in the order of half a °C and is acceptable in the context
  	 * of triggering interrupt in critical condition.
  	 */
@@ -183,7 +181,7 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  	chip_scu_np = of_parse_phandle(dev->of_node, "airoha,chip-scu", 0);
  	if (!chip_scu_np)
-@@ -462,8 +474,8 @@ static int airoha_thermal_probe(struct platform_device *pdev)
+@@ -462,8 +474,8 @@ static int airoha_thermal_probe(struct p
  	platform_set_drvdata(pdev, priv);
  
  	/* Enable LOW and HIGH interrupt */
@@ -194,6 +192,3 @@ index 9a7a702a17de..04bda890dbb1 100644
  
  	return 0;
  }
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/402-02-thermal-drivers-airoha-Generalize-probe-function.patch
+++ b/target/linux/airoha/patches-6.6/402-02-thermal-drivers-airoha-Generalize-probe-function.patch
@@ -15,8 +15,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/thermal/airoha_thermal.c | 102 +++++++++++++++++++++++--------
  1 file changed, 75 insertions(+), 27 deletions(-)
 
-diff --git a/drivers/thermal/airoha_thermal.c b/drivers/thermal/airoha_thermal.c
-index 04bda890dbb1..9bfa59b97032 100644
 --- a/drivers/thermal/airoha_thermal.c
 +++ b/drivers/thermal/airoha_thermal.c
 @@ -198,12 +198,23 @@ struct airoha_thermal_priv {
@@ -43,7 +41,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  static int airoha_get_thermal_ADC(struct airoha_thermal_priv *priv)
  {
  	u32 val;
-@@ -220,7 +231,8 @@ static void airoha_init_thermal_ADC_mode(struct airoha_thermal_priv *priv)
+@@ -220,7 +231,8 @@ static void airoha_init_thermal_ADC_mode
  	regmap_read(priv->chip_scu, EN7581_PLLRG_PROTECT, &pllrg);
  
  	/* Give access to thermal regs */
@@ -53,7 +51,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  	adc_mux = FIELD_PREP(EN7581_MUX_TADC, EN7581_SCU_THERMAL_MUX_DIODE1);
  	regmap_write(priv->chip_scu, EN7581_PWD_TADC, adc_mux);
  
-@@ -228,7 +240,7 @@ static void airoha_init_thermal_ADC_mode(struct airoha_thermal_priv *priv)
+@@ -228,7 +240,7 @@ static void airoha_init_thermal_ADC_mode
  	regmap_write(priv->chip_scu, EN7581_PLLRG_PROTECT, pllrg);
  }
  
@@ -62,7 +60,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  {
  	struct airoha_thermal_priv *priv = thermal_zone_device_priv(tz);
  	int min_value, max_value, avg_value, value;
-@@ -253,7 +265,7 @@ static int airoha_thermal_get_temp(struct thermal_zone_device *tz, int *temp)
+@@ -253,7 +265,7 @@ static int airoha_thermal_get_temp(struc
  	return 0;
  }
  
@@ -71,7 +69,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  				    int high)
  {
  	struct airoha_thermal_priv *priv = thermal_zone_device_priv(tz);
-@@ -290,12 +302,12 @@ static int airoha_thermal_set_trips(struct thermal_zone_device *tz, int low,
+@@ -290,12 +302,12 @@ static int airoha_thermal_set_trips(stru
  	return 0;
  }
  
@@ -88,7 +86,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  {
  	struct airoha_thermal_priv *priv = data;
  	enum thermal_notify_event event;
-@@ -326,7 +338,7 @@ static irqreturn_t airoha_thermal_irq(int irq, void *data)
+@@ -326,7 +338,7 @@ static irqreturn_t airoha_thermal_irq(in
  	return IRQ_HANDLED;
  }
  
@@ -97,7 +95,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  					 struct airoha_thermal_priv *priv)
  {
  	u32 efuse_calib_info, cpu_sensor;
-@@ -356,7 +368,7 @@ static void airoha_thermal_setup_adc_val(struct device *dev,
+@@ -356,7 +368,7 @@ static void airoha_thermal_setup_adc_val
  	}
  }
  
@@ -106,7 +104,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  {
  	/* Set measure mode */
  	regmap_write(priv->map, EN7581_TEMPMSRCTL0,
-@@ -411,30 +423,26 @@ static void airoha_thermal_setup_monitor(struct airoha_thermal_priv *priv)
+@@ -411,30 +423,26 @@ static void airoha_thermal_setup_monitor
  		     FIELD_PREP(EN7581_ADC_POLL_INTVL, 146));
  }
  
@@ -141,7 +139,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  	if (IS_ERR(priv->map))
  		return PTR_ERR(priv->map);
  
-@@ -454,18 +462,55 @@ static int airoha_thermal_probe(struct platform_device *pdev)
+@@ -454,18 +462,55 @@ static int airoha_thermal_probe(struct p
  		return irq;
  
  	ret = devm_request_threaded_irq(&pdev->dev, irq, NULL,
@@ -201,7 +199,7 @@ index 04bda890dbb1..9bfa59b97032 100644
  	if (IS_ERR(priv->tz)) {
  		dev_err(dev, "register thermal zone sensor failed\n");
  		return PTR_ERR(priv->tz);
-@@ -473,15 +518,18 @@ static int airoha_thermal_probe(struct platform_device *pdev)
+@@ -473,15 +518,18 @@ static int airoha_thermal_probe(struct p
  
  	platform_set_drvdata(pdev, priv);
  
@@ -226,6 +224,3 @@ index 04bda890dbb1..9bfa59b97032 100644
  	{},
  };
  MODULE_DEVICE_TABLE(of, airoha_thermal_match);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/402-03-thermal-drivers-airoha-generalize-get_thermal_ADC-an.patch
+++ b/target/linux/airoha/patches-6.6/402-03-thermal-drivers-airoha-generalize-get_thermal_ADC-an.patch
@@ -18,8 +18,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/thermal/airoha_thermal.c | 54 +++++++++++++++++++++++++-------
  1 file changed, 42 insertions(+), 12 deletions(-)
 
-diff --git a/drivers/thermal/airoha_thermal.c b/drivers/thermal/airoha_thermal.c
-index 9bfa59b97032..4c973cce106a 100644
 --- a/drivers/thermal/airoha_thermal.c
 +++ b/drivers/thermal/airoha_thermal.c
 @@ -193,9 +193,18 @@
@@ -41,7 +39,7 @@ index 9bfa59b97032..4c973cce106a 100644
  	struct resource scu_adc_res;
  
  	u32 pllrg_protect;
-@@ -219,22 +228,29 @@ static int airoha_get_thermal_ADC(struct airoha_thermal_priv *priv)
+@@ -219,22 +228,29 @@ static int airoha_get_thermal_ADC(struct
  {
  	u32 val;
  
@@ -78,7 +76,7 @@ index 9bfa59b97032..4c973cce106a 100644
  
  	/* Restore PLLRG value on exit */
  	regmap_write(priv->chip_scu, EN7581_PLLRG_PROTECT, pllrg);
-@@ -343,10 +359,8 @@ static void en7581_thermal_setup_adc_val(struct device *dev,
+@@ -343,10 +359,8 @@ static void en7581_thermal_setup_adc_val
  {
  	u32 efuse_calib_info, cpu_sensor;
  
@@ -91,7 +89,7 @@ index 9bfa59b97032..4c973cce106a 100644
  
  	regmap_read(priv->map, EN7581_EFUSE_TEMP_OFFSET_REG, &efuse_calib_info);
  	if (efuse_calib_info) {
-@@ -429,13 +443,18 @@ static const struct regmap_config en7581_thermal_regmap_config = {
+@@ -429,13 +443,18 @@ static const struct regmap_config en7581
  	.val_bits		= 32,
  };
  
@@ -111,7 +109,7 @@ index 9bfa59b97032..4c973cce106a 100644
  
  	base = devm_platform_ioremap_resource(pdev, 0);
  	if (IS_ERR(base))
-@@ -454,6 +473,17 @@ static int en7581_thermal_probe(struct platform_device *pdev,
+@@ -454,6 +473,17 @@ static int en7581_thermal_probe(struct p
  	if (IS_ERR(priv->chip_scu))
  		return PTR_ERR(priv->chip_scu);
  
@@ -129,6 +127,3 @@ index 9bfa59b97032..4c973cce106a 100644
  	of_address_to_resource(chip_scu_np, 0, &priv->scu_adc_res);
  	of_node_put(chip_scu_np);
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/402-05-thermal-drivers-airoha-Add-support-for-AN7583.patch
+++ b/target/linux/airoha/patches-6.6/402-05-thermal-drivers-airoha-Add-support-for-AN7583.patch
@@ -26,8 +26,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/thermal/airoha_thermal.c | 158 ++++++++++++++++++++++++++++++-
  1 file changed, 154 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/thermal/airoha_thermal.c b/drivers/thermal/airoha_thermal.c
-index 4c973cce106a..e71548f9cee1 100644
 --- a/drivers/thermal/airoha_thermal.c
 +++ b/drivers/thermal/airoha_thermal.c
 @@ -18,6 +18,12 @@
@@ -128,7 +126,7 @@ index 4c973cce106a..e71548f9cee1 100644
  static int airoha_get_thermal_ADC(struct airoha_thermal_priv *priv)
  {
  	u32 val;
-@@ -234,7 +295,7 @@ static int airoha_get_thermal_ADC(struct airoha_thermal_priv *priv)
+@@ -234,7 +295,7 @@ static int airoha_get_thermal_ADC(struct
  }
  
  static void airoha_set_thermal_mux(struct airoha_thermal_priv *priv,
@@ -137,7 +135,7 @@ index 4c973cce106a..e71548f9cee1 100644
  {
  	u32 pllrg;
  
-@@ -245,9 +306,20 @@ static void airoha_set_thermal_mux(struct airoha_thermal_priv *priv,
+@@ -245,9 +306,20 @@ static void airoha_set_thermal_mux(struc
  	regmap_write(priv->chip_scu, EN7581_PLLRG_PROTECT,
  		     priv->pllrg_protect);
  
@@ -160,7 +158,7 @@ index 4c973cce106a..e71548f9cee1 100644
  
  	/* Sleep 10 ms for Thermal ADC to enable */
  	usleep_range(10 * USEC_PER_MSEC, 11 * USEC_PER_MSEC);
-@@ -360,7 +432,8 @@ static void en7581_thermal_setup_adc_val(struct device *dev,
+@@ -360,7 +432,8 @@ static void en7581_thermal_setup_adc_val
  	u32 efuse_calib_info, cpu_sensor;
  
  	/* Setup Thermal Sensor to ADC mode and setup the mux to DIODE1 */
@@ -170,7 +168,7 @@ index 4c973cce106a..e71548f9cee1 100644
  
  	regmap_read(priv->map, EN7581_EFUSE_TEMP_OFFSET_REG, &efuse_calib_info);
  	if (efuse_calib_info) {
-@@ -476,6 +549,10 @@ static int en7581_thermal_probe(struct platform_device *pdev,
+@@ -476,6 +549,10 @@ static int en7581_thermal_probe(struct p
  	for (i = 0; i < AIROHA_THERMAL_FIELD_MAX; i++) {
  		struct regmap_field *field;
  
@@ -181,7 +179,7 @@ index 4c973cce106a..e71548f9cee1 100644
  		field = devm_regmap_field_alloc(dev, priv->chip_scu,
  						en7581_chip_scu_fields[i]);
  		if (IS_ERR(field))
-@@ -516,6 +593,71 @@ static int en7581_thermal_post_probe(struct platform_device *pdev)
+@@ -516,6 +593,71 @@ static int en7581_thermal_post_probe(str
  	return 0;
  }
  
@@ -253,7 +251,7 @@ index 4c973cce106a..e71548f9cee1 100644
  static int airoha_thermal_probe(struct platform_device *pdev)
  {
  	const struct airoha_thermal_soc_data *soc_data;
-@@ -530,6 +672,7 @@ static int airoha_thermal_probe(struct platform_device *pdev)
+@@ -530,6 +672,7 @@ static int airoha_thermal_probe(struct p
  		return -ENOMEM;
  
  	priv->pllrg_protect = soc_data->pllrg_protect;
@@ -261,7 +259,7 @@ index 4c973cce106a..e71548f9cee1 100644
  
  	if (!soc_data->probe)
  		return -EINVAL;
-@@ -558,8 +701,15 @@ static const struct airoha_thermal_soc_data en7581_data = {
+@@ -558,8 +701,15 @@ static const struct airoha_thermal_soc_d
  	.post_probe = &en7581_thermal_post_probe,
  };
  
@@ -277,6 +275,3 @@ index 4c973cce106a..e71548f9cee1 100644
  	{},
  };
  MODULE_DEVICE_TABLE(of, airoha_thermal_match);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/403-cpufreq-airoha-Add-support-for-AN7583-SoC.patch
+++ b/target/linux/airoha/patches-6.6/403-cpufreq-airoha-Add-support-for-AN7583-SoC.patch
@@ -13,11 +13,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/cpufreq/cpufreq-dt-platdev.c | 1 +
  2 files changed, 2 insertions(+)
 
-diff --git a/drivers/cpufreq/airoha-cpufreq.c b/drivers/cpufreq/airoha-cpufreq.c
-index 4fe39eadd163..b6b1cdc4d11d 100644
 --- a/drivers/cpufreq/airoha-cpufreq.c
 +++ b/drivers/cpufreq/airoha-cpufreq.c
-@@ -107,6 +107,7 @@ static struct platform_driver airoha_cpufreq_driver = {
+@@ -122,6 +122,7 @@ static struct platform_driver airoha_cpu
  };
  
  static const struct of_device_id airoha_cpufreq_match_list[] __initconst = {
@@ -25,18 +23,13 @@ index 4fe39eadd163..b6b1cdc4d11d 100644
  	{ .compatible = "airoha,en7581" },
  	{},
  };
-diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
-index a010da0f6337..7a01c0ae904a 100644
 --- a/drivers/cpufreq/cpufreq-dt-platdev.c
 +++ b/drivers/cpufreq/cpufreq-dt-platdev.c
-@@ -103,6 +103,7 @@ static const struct of_device_id allowlist[] __initconst = {
+@@ -103,6 +103,7 @@ static const struct of_device_id allowli
   * platforms using "operating-points-v2" property.
   */
  static const struct of_device_id blocklist[] __initconst = {
 +	{ .compatible = "airoha,an7583", },
  	{ .compatible = "airoha,en7581", },
  
- 	{ .compatible = "allwinner,sun50i-a100" },
--- 
-2.50.0
-
+ 	{ .compatible = "allwinner,sun50i-h6", },

--- a/target/linux/airoha/patches-6.6/410-net-airoha-npu-Add-airoha_npu_soc_data-struct.patch
+++ b/target/linux/airoha/patches-6.6/410-net-airoha-npu-Add-airoha_npu_soc_data-struct.patch
@@ -112,7 +112,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  }
  
  static irqreturn_t airoha_npu_mbox_handler(int irq, void *npu_instance)
-@@ -551,12 +565,13 @@ struct airoha_npu *airoha_npu_get(struct
+@@ -553,12 +567,13 @@ struct airoha_npu *airoha_npu_get(struct
  		return ERR_PTR(-ENODEV);
  
  	pdev = of_find_device_by_node(np);
@@ -127,7 +127,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	if (!try_module_get(THIS_MODULE)) {
  		dev_err(dev, "failed to get the device driver module\n");
-@@ -596,8 +611,19 @@ void airoha_npu_put(struct airoha_npu *n
+@@ -609,8 +624,19 @@ void airoha_npu_put(struct airoha_npu *n
  }
  EXPORT_SYMBOL_GPL(airoha_npu_put);
  

--- a/target/linux/airoha/patches-6.6/411-net-airoha-npu-Add-7583-SoC-support.patch
+++ b/target/linux/airoha/patches-6.6/411-net-airoha-npu-Add-7583-SoC-support.patch
@@ -25,7 +25,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  #define NPU_EN7581_FIRMWARE_RV32_MAX_SIZE	0x200000
  #define NPU_EN7581_FIRMWARE_DATA_MAX_SIZE	0x10000
  #define NPU_DUMP_SIZE				512
-@@ -622,8 +624,20 @@ static const struct airoha_npu_soc_data
+@@ -635,8 +637,20 @@ static const struct airoha_npu_soc_data
  	},
  };
  
@@ -46,7 +46,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	{ /* sentinel */ }
  };
  MODULE_DEVICE_TABLE(of, of_airoha_npu_match);
-@@ -767,6 +781,10 @@ static struct platform_driver airoha_npu
+@@ -779,6 +793,10 @@ static struct platform_driver airoha_npu
  };
  module_platform_driver(airoha_npu_driver);
  

--- a/target/linux/airoha/patches-6.6/412-net-airoha-Add-airoha_eth_soc_data-struct.patch
+++ b/target/linux/airoha/patches-6.6/412-net-airoha-Add-airoha_eth_soc_data-struct.patch
@@ -21,7 +21,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1530,8 +1530,7 @@ static int airoha_hw_init(struct platfor
+@@ -1404,8 +1404,7 @@ static int airoha_hw_init(struct platfor
  	int err, i;
  
  	/* disable xsi */
@@ -31,7 +31,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	if (err)
  		return err;
  
-@@ -1539,7 +1538,8 @@ static int airoha_hw_init(struct platfor
+@@ -1413,7 +1412,8 @@ static int airoha_hw_init(struct platfor
  	if (err)
  		return err;
  
@@ -41,7 +41,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	if (err)
  		return err;
  
-@@ -3371,6 +3371,7 @@ free_metadata_dst:
+@@ -3071,6 +3071,7 @@ static int airoha_register_gdm_ports(str
  
  static int airoha_probe(struct platform_device *pdev)
  {
@@ -49,7 +49,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	struct device_node *np;
  	struct airoha_eth *eth;
  	int i, err;
-@@ -3379,6 +3380,10 @@ static int airoha_probe(struct platform_
+@@ -3079,6 +3080,10 @@ static int airoha_probe(struct platform_
  	if (!eth)
  		return -ENOMEM;
  
@@ -60,7 +60,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	eth->dev = &pdev->dev;
  
  	err = dma_set_mask_and_coherent(eth->dev, DMA_BIT_MASK(32));
-@@ -3403,12 +3408,18 @@ static int airoha_probe(struct platform_
+@@ -3103,12 +3108,18 @@ static int airoha_probe(struct platform_
  		return err;
  	}
  
@@ -84,7 +84,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  						    eth->xsi_rsts);
  	if (err) {
  		dev_err(eth->dev, "failed to get bulk xsi reset lines\n");
-@@ -3506,8 +3517,22 @@ static void airoha_remove(struct platfor
+@@ -3208,8 +3219,22 @@ static void airoha_remove(struct platfor
  	platform_set_drvdata(pdev, NULL);
  }
  
@@ -118,7 +118,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  #define AIROHA_MAX_MTU			9216
  #define AIROHA_MAX_PACKET_SIZE		2048
  #define AIROHA_NUM_QOS_CHANNELS		4
-@@ -575,9 +574,18 @@ struct airoha_ppe {
+@@ -564,9 +563,18 @@ struct airoha_ppe {
  	struct dentry *debugfs_dir;
  };
  
@@ -137,7 +137,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	unsigned long state;
  	void __iomem *fe_regs;
  
-@@ -587,7 +595,7 @@ struct airoha_eth {
+@@ -576,7 +584,7 @@ struct airoha_eth {
  	struct rhashtable flow_table;
  
  	struct reset_control_bulk_data rsts[AIROHA_MAX_NUM_RSTS];
@@ -146,7 +146,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	struct net_device *napi_dev;
  
-@@ -632,6 +640,11 @@ static inline bool airhoa_is_lan_gdm_por
+@@ -619,6 +627,11 @@ static inline bool airhoa_is_lan_gdm_por
  	return port->id == 1;
  }
  

--- a/target/linux/airoha/patches-6.6/413-net-airoha-Generalize-airoha_ppe2_is_enabled-routine.patch
+++ b/target/linux/airoha/patches-6.6/413-net-airoha-Generalize-airoha_ppe2_is_enabled-routine.patch
@@ -21,7 +21,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -304,8 +304,11 @@ static void airoha_fe_pse_ports_init(str
+@@ -303,8 +303,11 @@ static void airoha_fe_pse_ports_init(str
  	int q;
  
  	all_rsv = airoha_fe_get_pse_all_rsv(eth);
@@ -35,7 +35,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	airoha_fe_set(eth, REG_FE_PSE_BUF_SET, all_rsv);
  
  	/* CMD1 */
-@@ -342,13 +345,17 @@ static void airoha_fe_pse_ports_init(str
+@@ -341,13 +344,17 @@ static void airoha_fe_pse_ports_init(str
  	for (q = 4; q < pse_port_num_queues[FE_PSE_PORT_CDM4]; q++)
  		airoha_fe_set_pse_oq_rsv(eth, FE_PSE_PORT_CDM4, q,
  					 PSE_QUEUE_RSV_PAGES);
@@ -60,7 +60,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	}
  	/* GMD4 */
  	for (q = 0; q < pse_port_num_queues[FE_PSE_PORT_GDM4]; q++)
-@@ -1925,8 +1932,11 @@ static int airoha_dev_init(struct net_de
+@@ -1798,8 +1805,11 @@ static int airoha_dev_init(struct net_de
  			airhoha_set_gdm2_loopback(port);
  		fallthrough;
  	case 2:
@@ -76,7 +76,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		break;
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -648,6 +648,7 @@ static inline bool airoha_is_7581(struct
+@@ -635,6 +635,7 @@ static inline bool airoha_is_7581(struct
  bool airoha_is_valid_gdm_port(struct airoha_eth *eth,
  			      struct airoha_gdm_port *port);
  
@@ -110,7 +110,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		sram_num_entries =
  			PPE_RAM_NUM_ENTRIES_SHIFT(PPE1_SRAM_NUM_DATA_ENTRIES);
  		airoha_fe_rmw(eth, REG_PPE_TB_CFG(0),
-@@ -496,7 +499,7 @@ static u32 airoha_ppe_foe_get_entry_hash
+@@ -482,7 +485,7 @@ static u32 airoha_ppe_foe_get_entry_hash
  
  static u32 airoha_ppe_foe_get_flow_stats_index(struct airoha_ppe *ppe, u32 hash)
  {
@@ -119,7 +119,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		return hash;
  
  	return hash >= PPE_STATS_NUM_ENTRIES ? hash - PPE1_STATS_NUM_ENTRIES
-@@ -580,7 +583,7 @@ airoha_ppe_foe_get_entry_locked(struct a
+@@ -566,7 +569,7 @@ airoha_ppe_foe_get_entry_locked(struct a
  		u32 val;
  		int i;
  
@@ -128,7 +128,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		       hash >= PPE1_SRAM_NUM_ENTRIES;
  		airoha_fe_wr(ppe->eth, REG_PPE_RAM_CTRL(ppe2),
  			     FIELD_PREP(PPE_SRAM_CTRL_ENTRY_MASK, hash) |
-@@ -658,7 +661,7 @@ static int airoha_ppe_foe_commit_entry(s
+@@ -644,7 +647,7 @@ static int airoha_ppe_foe_commit_entry(s
  
  	if (hash < PPE_SRAM_NUM_ENTRIES) {
  		dma_addr_t addr = ppe->foe_dma + hash * sizeof(*hwe);
@@ -137,7 +137,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			    hash >= PPE1_SRAM_NUM_ENTRIES;
  
  		err = npu->ops.ppe_foe_commit_entry(npu, addr, sizeof(*hwe),
-@@ -1249,7 +1252,7 @@ static int airoha_ppe_flush_sram_entries
+@@ -1231,7 +1234,7 @@ static int airoha_ppe_flush_sram_entries
  	int i, sram_num_entries = PPE_SRAM_NUM_ENTRIES;
  	struct airoha_foe_entry *hwe = ppe->foe;
  

--- a/target/linux/airoha/patches-6.6/414-net-airoha-ppe-Dynamically-allocate-foe_check_time-a.patch
+++ b/target/linux/airoha/patches-6.6/414-net-airoha-ppe-Dynamically-allocate-foe_check_time-a.patch
@@ -18,7 +18,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -566,7 +566,7 @@ struct airoha_ppe {
+@@ -555,7 +555,7 @@ struct airoha_ppe {
  	struct rhashtable l2_flows;
  
  	struct hlist_head *foe_flow;
@@ -29,7 +29,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	dma_addr_t foe_stats_dma;
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1454,6 +1454,11 @@ int airoha_ppe_init(struct airoha_eth *e
+@@ -1436,6 +1436,11 @@ int airoha_ppe_init(struct airoha_eth *e
  			return -ENOMEM;
  	}
  

--- a/target/linux/airoha/patches-6.6/415-net-airoha-npu-Add-a-NPU-callback-to-initialize-stat.patch
+++ b/target/linux/airoha/patches-6.6/415-net-airoha-npu-Add-a-NPU-callback-to-initialize-stat.patch
@@ -24,7 +24,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
-@@ -390,15 +390,13 @@ out:
+@@ -395,15 +395,13 @@ out:
  	return err;
  }
  
@@ -44,7 +44,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	ppe_data = kzalloc(sizeof(*ppe_data), GFP_ATOMIC);
  	if (!ppe_data)
  		return -ENOMEM;
-@@ -553,7 +551,7 @@ static void airoha_npu_wlan_irq_disable(
+@@ -558,7 +556,7 @@ static void airoha_npu_wlan_irq_disable(
  	regmap_clear_bits(npu->regmap, REG_IRQ_RXDONE(q), NPU_IRQ_RX_MASK(q));
  }
  
@@ -53,7 +53,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  {
  	struct platform_device *pdev;
  	struct device_node *np;
-@@ -591,17 +589,6 @@ struct airoha_npu *airoha_npu_get(struct
+@@ -597,17 +595,6 @@ struct airoha_npu *airoha_npu_get(struct
  		goto error_module_put;
  	}
  
@@ -71,7 +71,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	return npu;
  
  error_module_put:
-@@ -655,6 +642,7 @@ static int airoha_npu_probe(struct platf
+@@ -683,6 +670,7 @@ static int airoha_npu_probe(struct platf
  	npu->dev = dev;
  	npu->ops.ppe_init = airoha_npu_ppe_init;
  	npu->ops.ppe_deinit = airoha_npu_ppe_deinit;
@@ -81,7 +81,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	npu->ops.wlan_init_reserved_memory = airoha_npu_wlan_init_memory;
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1264,12 +1264,11 @@ static int airoha_ppe_flush_sram_entries
+@@ -1246,12 +1246,11 @@ static int airoha_ppe_flush_sram_entries
  
  static struct airoha_npu *airoha_ppe_npu_get(struct airoha_eth *eth)
  {
@@ -96,7 +96,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	}
  
  	return npu;
-@@ -1278,6 +1277,7 @@ static struct airoha_npu *airoha_ppe_npu
+@@ -1260,6 +1259,7 @@ static struct airoha_npu *airoha_ppe_npu
  static int airoha_ppe_offload_setup(struct airoha_eth *eth)
  {
  	struct airoha_npu *npu = airoha_ppe_npu_get(eth);
@@ -104,7 +104,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	int err;
  
  	if (IS_ERR(npu))
-@@ -1287,12 +1287,19 @@ static int airoha_ppe_offload_setup(stru
+@@ -1269,12 +1269,19 @@ static int airoha_ppe_offload_setup(stru
  	if (err)
  		goto error_npu_put;
  

--- a/target/linux/airoha/patches-6.6/416-net-airoha-ppe-Move-PPE-memory-info-in-airoha_eth_so.patch
+++ b/target/linux/airoha/patches-6.6/416-net-airoha-ppe-Move-PPE-memory-info-in-airoha_eth_so.patch
@@ -20,7 +20,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -57,20 +57,9 @@
+@@ -47,20 +47,9 @@
  #define QDMA_METER_IDX(_n)		((_n) & 0xff)
  #define QDMA_METER_GROUP(_n)		(((_n) >> 8) & 0x3)
  
@@ -43,7 +43,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  #define PPE_ENTRY_SIZE			80
  #define PPE_RAM_NUM_ENTRIES_SHIFT(_n)	(__ffs((_n) >> 10))
  
-@@ -655,6 +644,7 @@ int airoha_ppe_setup_tc_block_cb(struct
+@@ -642,6 +631,7 @@ int airoha_ppe_setup_tc_block_cb(struct
  int airoha_ppe_init(struct airoha_eth *eth);
  void airoha_ppe_deinit(struct airoha_eth *eth);
  void airoha_ppe_init_upd_mem(struct airoha_gdm_port *port);
@@ -179,7 +179,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  }
  
  static void airoha_ppe_flow_mangle_eth(const struct flow_action_entry *act, void *eth)
-@@ -445,9 +469,11 @@ static int airoha_ppe_foe_entry_set_ipv6
+@@ -431,9 +455,11 @@ static int airoha_ppe_foe_entry_set_ipv6
  	return 0;
  }
  
@@ -192,7 +192,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	u32 hash, hv1, hv2, hv3;
  
  	switch (type) {
-@@ -485,25 +511,35 @@ static u32 airoha_ppe_foe_get_entry_hash
+@@ -471,25 +497,35 @@ static u32 airoha_ppe_foe_get_entry_hash
  	case PPE_PKT_TYPE_IPV6_6RD:
  	default:
  		WARN_ON_ONCE(1);
@@ -235,7 +235,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  }
  
  static void airoha_ppe_foe_flow_stat_entry_reset(struct airoha_ppe *ppe,
-@@ -517,9 +553,14 @@ static void airoha_ppe_foe_flow_stat_ent
+@@ -503,9 +539,14 @@ static void airoha_ppe_foe_flow_stat_ent
  static void airoha_ppe_foe_flow_stats_reset(struct airoha_ppe *ppe,
  					    struct airoha_npu *npu)
  {
@@ -251,7 +251,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		airoha_ppe_foe_flow_stat_entry_reset(ppe, npu, i);
  }
  
-@@ -528,12 +569,18 @@ static void airoha_ppe_foe_flow_stats_up
+@@ -514,12 +555,18 @@ static void airoha_ppe_foe_flow_stats_up
  					     struct airoha_foe_entry *hwe,
  					     u32 hash)
  {
@@ -273,7 +273,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		return;
  
  	if (type == PPE_PKT_TYPE_BRIDGE) {
-@@ -574,9 +621,11 @@ static void airoha_ppe_foe_flow_stats_up
+@@ -560,9 +607,11 @@ static void airoha_ppe_foe_flow_stats_up
  static struct airoha_foe_entry *
  airoha_ppe_foe_get_entry_locked(struct airoha_ppe *ppe, u32 hash)
  {
@@ -286,7 +286,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		u32 *hwe = ppe->foe + hash * sizeof(struct airoha_foe_entry);
  		struct airoha_eth *eth = ppe->eth;
  		bool ppe2;
-@@ -584,7 +633,7 @@ airoha_ppe_foe_get_entry_locked(struct a
+@@ -570,7 +619,7 @@ airoha_ppe_foe_get_entry_locked(struct a
  		int i;
  
  		ppe2 = airoha_ppe_is_enabled(ppe->eth, 1) &&
@@ -295,7 +295,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		airoha_fe_wr(ppe->eth, REG_PPE_RAM_CTRL(ppe2),
  			     FIELD_PREP(PPE_SRAM_CTRL_ENTRY_MASK, hash) |
  			     PPE_SRAM_CTRL_REQ_MASK);
-@@ -636,6 +685,7 @@ static int airoha_ppe_foe_commit_entry(s
+@@ -622,6 +671,7 @@ static int airoha_ppe_foe_commit_entry(s
  				       u32 hash, bool rx_wlan)
  {
  	struct airoha_foe_entry *hwe = ppe->foe + hash * sizeof(*hwe);
@@ -303,7 +303,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	u32 ts = airoha_ppe_get_timestamp(ppe);
  	struct airoha_eth *eth = ppe->eth;
  	struct airoha_npu *npu;
-@@ -659,10 +709,10 @@ static int airoha_ppe_foe_commit_entry(s
+@@ -645,10 +695,10 @@ static int airoha_ppe_foe_commit_entry(s
  	if (!rx_wlan)
  		airoha_ppe_foe_flow_stats_update(ppe, npu, hwe, hash);
  
@@ -316,7 +316,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  		err = npu->ops.ppe_foe_commit_entry(npu, addr, sizeof(*hwe),
  						    hash, ppe2);
-@@ -789,7 +839,7 @@ static void airoha_ppe_foe_insert_entry(
+@@ -775,7 +825,7 @@ static void airoha_ppe_foe_insert_entry(
  	if (state == AIROHA_FOE_STATE_BIND)
  		goto unlock;
  
@@ -325,7 +325,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	hlist_for_each_entry_safe(e, n, &ppe->foe_flow[index], list) {
  		if (e->type == FLOW_TYPE_L2_SUBFLOW) {
  			state = FIELD_GET(AIROHA_FOE_IB1_BIND_STATE, hwe->ib1);
-@@ -849,7 +899,7 @@ static int airoha_ppe_foe_flow_commit_en
+@@ -835,7 +885,7 @@ static int airoha_ppe_foe_flow_commit_en
  	if (type == PPE_PKT_TYPE_BRIDGE)
  		return airoha_ppe_foe_l2_flow_commit_entry(ppe, e);
  
@@ -334,7 +334,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	e->type = FLOW_TYPE_L4;
  	e->hash = 0xffff;
  
-@@ -1179,11 +1229,18 @@ static int airoha_ppe_flow_offload_destr
+@@ -1161,11 +1211,18 @@ static int airoha_ppe_flow_offload_destr
  void airoha_ppe_foe_entry_get_stats(struct airoha_ppe *ppe, u32 hash,
  				    struct airoha_foe_stats64 *stats)
  {
@@ -355,7 +355,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		return;
  
  	rcu_read_lock();
-@@ -1249,17 +1306,15 @@ static int airoha_ppe_flow_offload_cmd(s
+@@ -1231,17 +1288,15 @@ static int airoha_ppe_flow_offload_cmd(s
  static int airoha_ppe_flush_sram_entries(struct airoha_ppe *ppe,
  					 struct airoha_npu *npu)
  {
@@ -377,7 +377,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  }
  
  static struct airoha_npu *airoha_ppe_npu_get(struct airoha_eth *eth)
-@@ -1276,8 +1331,9 @@ static struct airoha_npu *airoha_ppe_npu
+@@ -1258,8 +1313,9 @@ static struct airoha_npu *airoha_ppe_npu
  
  static int airoha_ppe_offload_setup(struct airoha_eth *eth)
  {
@@ -388,7 +388,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	int err;
  
  	if (IS_ERR(npu))
-@@ -1287,9 +1343,10 @@ static int airoha_ppe_offload_setup(stru
+@@ -1269,9 +1325,10 @@ static int airoha_ppe_offload_setup(stru
  	if (err)
  		goto error_npu_put;
  
@@ -401,7 +401,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		if (err)
  			goto error_npu_put;
  	}
-@@ -1334,9 +1391,10 @@ void airoha_ppe_check_skb(struct airoha_
+@@ -1316,9 +1373,10 @@ void airoha_ppe_check_skb(struct airoha_
  			  u16 hash, bool rx_wlan)
  {
  	struct airoha_ppe *ppe = dev->priv;
@@ -413,7 +413,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		return;
  
  	now = (u16)jiffies;
-@@ -1426,6 +1484,7 @@ EXPORT_SYMBOL_GPL(airoha_ppe_put_dev);
+@@ -1408,6 +1466,7 @@ EXPORT_SYMBOL_GPL(airoha_ppe_put_dev);
  
  int airoha_ppe_init(struct airoha_eth *eth)
  {
@@ -421,7 +421,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	struct airoha_ppe *ppe;
  	int foe_size, err;
  
-@@ -1436,24 +1495,25 @@ int airoha_ppe_init(struct airoha_eth *e
+@@ -1418,24 +1477,25 @@ int airoha_ppe_init(struct airoha_eth *e
  	ppe->dev.ops.setup_tc_block_cb = airoha_ppe_setup_tc_block_cb;
  	ppe->dev.ops.check_skb = airoha_ppe_check_skb;
  	ppe->dev.priv = ppe;
@@ -454,7 +454,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		ppe->foe_stats = dmam_alloc_coherent(eth->dev, foe_size,
  						     &ppe->foe_stats_dma,
  						     GFP_KERNEL);
-@@ -1461,7 +1521,7 @@ int airoha_ppe_init(struct airoha_eth *e
+@@ -1443,7 +1503,7 @@ int airoha_ppe_init(struct airoha_eth *e
  			return -ENOMEM;
  	}
  

--- a/target/linux/airoha/patches-6.6/417-net-airoha-ppe-Remove-airoha_ppe_is_enabled-where-no.patch
+++ b/target/linux/airoha/patches-6.6/417-net-airoha-ppe-Remove-airoha_ppe_is_enabled-where-no.patch
@@ -18,7 +18,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -534,10 +534,8 @@ static int airoha_ppe_foe_get_flow_stats
+@@ -520,10 +520,8 @@ static int airoha_ppe_foe_get_flow_stats
  	if (err)
  		return err;
  
@@ -31,7 +31,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	return 0;
  }
-@@ -627,13 +625,11 @@ airoha_ppe_foe_get_entry_locked(struct a
+@@ -613,13 +611,11 @@ airoha_ppe_foe_get_entry_locked(struct a
  
  	if (hash < sram_num_entries) {
  		u32 *hwe = ppe->foe + hash * sizeof(struct airoha_foe_entry);
@@ -46,7 +46,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		airoha_fe_wr(ppe->eth, REG_PPE_RAM_CTRL(ppe2),
  			     FIELD_PREP(PPE_SRAM_CTRL_ENTRY_MASK, hash) |
  			     PPE_SRAM_CTRL_REQ_MASK);
-@@ -711,8 +707,7 @@ static int airoha_ppe_foe_commit_entry(s
+@@ -697,8 +693,7 @@ static int airoha_ppe_foe_commit_entry(s
  
  	if (hash < sram_num_entries) {
  		dma_addr_t addr = ppe->foe_dma + hash * sizeof(*hwe);

--- a/target/linux/airoha/patches-6.6/418-net-airoha-ppe-Configure-SRAM-PPE-entries-via-the-cp.patch
+++ b/target/linux/airoha/patches-6.6/418-net-airoha-ppe-Configure-SRAM-PPE-entries-via-the-cp.patch
@@ -18,7 +18,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -676,6 +676,27 @@ static bool airoha_ppe_foe_compare_entry
+@@ -662,6 +662,27 @@ static bool airoha_ppe_foe_compare_entry
  	return !memcmp(&e->data.d, &hwe->d, len - sizeof(hwe->ib1));
  }
  
@@ -46,7 +46,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static int airoha_ppe_foe_commit_entry(struct airoha_ppe *ppe,
  				       struct airoha_foe_entry *e,
  				       u32 hash, bool rx_wlan)
-@@ -705,13 +726,8 @@ static int airoha_ppe_foe_commit_entry(s
+@@ -691,13 +712,8 @@ static int airoha_ppe_foe_commit_entry(s
  	if (!rx_wlan)
  		airoha_ppe_foe_flow_stats_update(ppe, npu, hwe, hash);
  

--- a/target/linux/airoha/patches-6.6/419-net-airoha-ppe-Flush-PPE-SRAM-table-during-PPE-setup.patch
+++ b/target/linux/airoha/patches-6.6/419-net-airoha-ppe-Flush-PPE-SRAM-table-during-PPE-setup.patch
@@ -17,7 +17,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1314,18 +1314,22 @@ static int airoha_ppe_flow_offload_cmd(s
+@@ -1296,18 +1296,22 @@ static int airoha_ppe_flow_offload_cmd(s
  	return -EOPNOTSUPP;
  }
  
@@ -46,7 +46,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  }
  
  static struct airoha_npu *airoha_ppe_npu_get(struct airoha_eth *eth)
-@@ -1363,10 +1367,6 @@ static int airoha_ppe_offload_setup(stru
+@@ -1345,10 +1349,6 @@ static int airoha_ppe_offload_setup(stru
  	}
  
  	airoha_ppe_hw_init(ppe);
@@ -57,7 +57,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	airoha_ppe_foe_flow_stats_reset(ppe, npu);
  
  	rcu_assign_pointer(eth->npu, npu);
-@@ -1537,6 +1537,10 @@ int airoha_ppe_init(struct airoha_eth *e
+@@ -1519,6 +1519,10 @@ int airoha_ppe_init(struct airoha_eth *e
  	if (!ppe->foe_check_time)
  		return -ENOMEM;
  

--- a/target/linux/airoha/patches-6.6/420-net-airoha-Refactor-wan-port-configuration-in-airhoh.patch
+++ b/target/linux/airoha/patches-6.6/420-net-airoha-Refactor-wan-port-configuration-in-airhoh.patch
@@ -16,11 +16,9 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  drivers/net/ethernet/airoha/airoha_regs.h |  5 +---
  2 files changed, 12 insertions(+), 25 deletions(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 2c6504aaae7a..dfb72609ef89 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1685,8 +1685,8 @@ static int airoha_dev_set_macaddr(struct net_device *dev, void *p)
+@@ -1742,8 +1742,8 @@ static int airoha_dev_set_macaddr(struct
  static void airhoha_set_gdm2_loopback(struct airoha_gdm_port *port)
  {
  	u32 pse_port = port->id == 3 ? FE_PSE_PORT_GDM3 : FE_PSE_PORT_GDM4;
@@ -30,7 +28,7 @@ index 2c6504aaae7a..dfb72609ef89 100644
  
  	/* Forward the traffic to the proper GDM port */
  	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(2), pse_port);
-@@ -1709,29 +1709,19 @@ static void airhoha_set_gdm2_loopback(struct airoha_gdm_port *port)
+@@ -1764,29 +1764,19 @@ static void airhoha_set_gdm2_loopback(st
  	airoha_fe_clear(eth, REG_FE_VIP_PORT_EN, BIT(2));
  	airoha_fe_clear(eth, REG_FE_IFC_PORT_EN, BIT(2));
  
@@ -70,11 +68,9 @@ index 2c6504aaae7a..dfb72609ef89 100644
  }
  
  static int airoha_dev_init(struct net_device *dev)
-diff --git a/drivers/net/ethernet/airoha/airoha_regs.h b/drivers/net/ethernet/airoha/airoha_regs.h
-index 69c5a143db8c..cc230f61c004 100644
 --- a/drivers/net/ethernet/airoha/airoha_regs.h
 +++ b/drivers/net/ethernet/airoha/airoha_regs.h
-@@ -383,10 +383,7 @@
+@@ -386,10 +386,7 @@
  #define REG_MC_VLAN_DATA		0x2108
  
  #define REG_SP_DFT_CPORT(_n)		(0x20e0 + ((_n) << 2))
@@ -86,6 +82,3 @@ index 69c5a143db8c..cc230f61c004 100644
  
  #define REG_SRC_PORT_FC_MAP6		0x2298
  #define FC_ID_OF_SRC_PORT27_MASK	GENMASK(28, 24)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/421-net-airoha-Select-default-ppe-cpu-port-in-airoha_dev.patch
+++ b/target/linux/airoha/patches-6.6/421-net-airoha-Select-default-ppe-cpu-port-in-airoha_dev.patch
@@ -18,7 +18,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -574,25 +574,6 @@ static int airoha_fe_init(struct airoha_
+@@ -539,25 +539,6 @@ static int airoha_fe_init(struct airoha_
  	/* disable IFC by default */
  	airoha_fe_clear(eth, REG_FE_CSR_IFC_CFG, FE_IFC_EN_MASK);
  
@@ -44,7 +44,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	/* enable 1:N vlan action, init vlan table */
  	airoha_fe_set(eth, REG_MC_VLAN_EN, MC_VLAN_EN_MASK);
  
-@@ -1911,8 +1892,10 @@ static void airhoha_set_gdm2_loopback(st
+@@ -1782,8 +1763,10 @@ static void airhoha_set_gdm2_loopback(st
  static int airoha_dev_init(struct net_device *dev)
  {
  	struct airoha_gdm_port *port = netdev_priv(dev);
@@ -57,7 +57,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	airoha_set_macaddr(port, dev->dev_addr);
  
-@@ -1925,16 +1908,27 @@ static int airoha_dev_init(struct net_de
+@@ -1796,16 +1779,27 @@ static int airoha_dev_init(struct net_de
  		fallthrough;
  	case 2:
  		if (airoha_ppe_is_enabled(eth, 1)) {

--- a/target/linux/airoha/patches-6.6/422-net-airoha-Fix-loopback-mode-configuration-for-GDM2-.patch
+++ b/target/linux/airoha/patches-6.6/422-net-airoha-Fix-loopback-mode-configuration-for-GDM2-.patch
@@ -14,7 +14,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1861,7 +1861,9 @@ static void airhoha_set_gdm2_loopback(st
+@@ -1735,7 +1735,9 @@ static void airhoha_set_gdm2_loopback(st
  	airoha_fe_wr(eth, REG_GDM_RXCHN_EN(2), 0xffff);
  	airoha_fe_rmw(eth, REG_GDM_LPBK_CFG(2),
  		      LPBK_CHAN_MASK | LPBK_MODE_MASK | LPBK_EN_MASK,

--- a/target/linux/airoha/patches-6.6/423-net-airoha-Add-AN7583-SoC-support.patch
+++ b/target/linux/airoha/patches-6.6/423-net-airoha-Add-AN7583-SoC-support.patch
@@ -17,7 +17,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -117,11 +117,13 @@ static int airoha_set_vip_for_gdm_port(s
+@@ -116,11 +116,13 @@ static int airoha_set_vip_for_gdm_port(s
  	switch (port->id) {
  	case 3:
  		/* FIXME: handle XSI_PCIE1_PORT */
@@ -33,7 +33,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		break;
  	default:
  		return 0;
-@@ -1849,8 +1851,8 @@ static int airoha_dev_set_macaddr(struct
+@@ -1723,8 +1725,8 @@ static int airoha_dev_set_macaddr(struct
  static void airhoha_set_gdm2_loopback(struct airoha_gdm_port *port)
  {
  	u32 pse_port = port->id == 3 ? FE_PSE_PORT_GDM3 : FE_PSE_PORT_GDM4;
@@ -43,7 +43,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	/* Forward the traffic to the proper GDM port */
  	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(2), pse_port);
-@@ -1859,6 +1861,8 @@ static void airhoha_set_gdm2_loopback(st
+@@ -1733,6 +1735,8 @@ static void airhoha_set_gdm2_loopback(st
  	/* Enable GDM2 loopback */
  	airoha_fe_wr(eth, REG_GDM_TXCHN_EN(2), 0xffffffff);
  	airoha_fe_wr(eth, REG_GDM_RXCHN_EN(2), 0xffff);
@@ -52,7 +52,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	airoha_fe_rmw(eth, REG_GDM_LPBK_CFG(2),
  		      LPBK_CHAN_MASK | LPBK_MODE_MASK | LPBK_EN_MASK,
  		      FIELD_PREP(LPBK_CHAN_MASK, chan) |
-@@ -1882,7 +1886,7 @@ static void airhoha_set_gdm2_loopback(st
+@@ -1756,7 +1760,7 @@ static void airhoha_set_gdm2_loopback(st
  		      SP_CPORT_MASK(wan_port & 0x7),
  		      FE_PSE_PORT_CDM2 << __ffs(SP_CPORT_MASK(wan_port & 0x7)));
  
@@ -61,8 +61,8 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		airoha_fe_rmw(eth, REG_SRC_PORT_FC_MAP6,
  			      FC_ID_OF_SRC_PORT24_MASK,
  			      FIELD_PREP(FC_ID_OF_SRC_PORT24_MASK, 2));
-@@ -2084,6 +2088,20 @@ static bool airoha_dev_is_tx_busy(struct
- 	return index >= q->tail && (q->head < q->tail || q->head > index);
+@@ -1904,6 +1908,20 @@ static u32 airoha_get_dsa_tag(struct sk_
+ #endif
  }
  
 +static int airoha_get_fe_port(struct airoha_gdm_port *port)
@@ -82,7 +82,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
-@@ -2124,7 +2142,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+@@ -1944,7 +1962,7 @@ static netdev_tx_t airoha_dev_xmit(struc
  		}
  	}
  
@@ -91,7 +91,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	msg1 = FIELD_PREP(QDMA_ETH_TXMSG_FPORT_MASK, fport) |
  	       FIELD_PREP(QDMA_ETH_TXMSG_METER_MASK, 0x7f);
  
-@@ -3589,6 +3607,12 @@ static const char * const en7581_xsi_rst
+@@ -3222,6 +3240,12 @@ static const char * const en7581_xsi_rst
  	"xfp-mac",
  };
  
@@ -104,7 +104,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static const struct airoha_eth_soc_data en7581_soc_data = {
  	.version = 0x7581,
  	.xsi_rsts_names = en7581_xsi_rsts_names,
-@@ -3596,8 +3620,16 @@ static const struct airoha_eth_soc_data
+@@ -3229,8 +3253,16 @@ static const struct airoha_eth_soc_data
  	.num_ppe = 2,
  };
  
@@ -123,7 +123,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  MODULE_DEVICE_TABLE(of, of_airoha_match);
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -648,6 +648,11 @@ static inline bool airoha_is_7581(struct
+@@ -621,6 +621,11 @@ static inline bool airoha_is_7581(struct
  	return eth->soc->version == 0x7581;
  }
  

--- a/target/linux/airoha/patches-6.6/600-01-clk-en7523-convert-driver-to-regmap-API.patch
+++ b/target/linux/airoha/patches-6.6/600-01-clk-en7523-convert-driver-to-regmap-API.patch
@@ -12,8 +12,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 137 ++++++++++++++++++++++-----------------
  1 file changed, 76 insertions(+), 61 deletions(-)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index 15bbdeb60b8e..314e7450313f 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
 @@ -1,5 +1,6 @@
@@ -48,7 +46,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  	struct reset_controller_dev rcdev;
  };
  
-@@ -388,44 +390,44 @@ static u32 en7523_get_div(const struct en_clk_desc *desc, u32 val)
+@@ -388,44 +390,44 @@ static u32 en7523_get_div(const struct e
  static int en7523_pci_is_enabled(struct clk_hw *hw)
  {
  	struct en_clk_gate *cg = container_of(hw, struct en_clk_gate, hw);
@@ -108,7 +106,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  	msleep(250);
  
  	return 0;
-@@ -434,16 +436,13 @@ static int en7523_pci_prepare(struct clk_hw *hw)
+@@ -434,16 +436,13 @@ static int en7523_pci_prepare(struct clk
  static void en7523_pci_unprepare(struct clk_hw *hw)
  {
  	struct en_clk_gate *cg = container_of(hw, struct en_clk_gate, hw);
@@ -128,7 +126,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  {
  	const struct en_clk_soc_data *soc_data = device_get_match_data(dev);
  	struct clk_init_data init = {
-@@ -456,7 +455,7 @@ static struct clk_hw *en7523_register_pcie_clk(struct device *dev,
+@@ -456,7 +455,7 @@ static struct clk_hw *en7523_register_pc
  	if (!cg)
  		return NULL;
  
@@ -137,7 +135,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  	cg->hw.init = &init;
  
  	if (init.ops->unprepare)
-@@ -474,21 +473,20 @@ static int en7581_pci_is_enabled(struct clk_hw *hw)
+@@ -474,21 +473,20 @@ static int en7581_pci_is_enabled(struct
  	u32 val, mask;
  
  	mask = REG_PCI_CONTROL_REFCLK_EN0 | REG_PCI_CONTROL_REFCLK_EN1;
@@ -163,7 +161,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  
  	return 0;
  }
-@@ -496,19 +494,18 @@ static int en7581_pci_enable(struct clk_hw *hw)
+@@ -496,19 +494,18 @@ static int en7581_pci_enable(struct clk_
  static void en7581_pci_disable(struct clk_hw *hw)
  {
  	struct en_clk_gate *cg = container_of(hw, struct en_clk_gate, hw);
@@ -187,7 +185,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  {
  	struct clk_hw *hw;
  	u32 rate;
-@@ -517,10 +514,12 @@ static void en7523_register_clocks(struct device *dev, struct clk_hw_onecell_dat
+@@ -517,10 +514,12 @@ static void en7523_register_clocks(struc
  	for (i = 0; i < ARRAY_SIZE(en7523_base_clks); i++) {
  		const struct en_clk_desc *desc = &en7523_base_clks[i];
  		u32 reg = desc->div_reg ? desc->div_reg : desc->base_reg;
@@ -202,7 +200,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  		rate /= en7523_get_div(desc, val);
  
  		hw = clk_hw_register_fixed_rate(dev, desc->name, NULL, 0, rate);
-@@ -533,30 +532,47 @@ static void en7523_register_clocks(struct device *dev, struct clk_hw_onecell_dat
+@@ -533,30 +532,47 @@ static void en7523_register_clocks(struc
  		clk_data->hws[desc->id] = hw;
  	}
  
@@ -253,7 +251,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  {
  	struct clk_hw *hw;
  	u32 rate;
-@@ -593,7 +609,7 @@ static void en7581_register_clocks(struct device *dev, struct clk_hw_onecell_dat
+@@ -593,7 +609,7 @@ static void en7581_register_clocks(struc
  		clk_data->hws[desc->id] = hw;
  	}
  
@@ -262,7 +260,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  	clk_data->hws[EN7523_CLK_PCIE] = hw;
  }
  
-@@ -601,15 +617,10 @@ static int en7523_reset_update(struct reset_controller_dev *rcdev,
+@@ -601,15 +617,10 @@ static int en7523_reset_update(struct re
  			       unsigned long id, bool assert)
  {
  	struct en_rst_data *rst_data = container_of(rcdev, struct en_rst_data, rcdev);
@@ -281,7 +279,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  
  	return 0;
  }
-@@ -630,9 +641,11 @@ static int en7523_reset_status(struct reset_controller_dev *rcdev,
+@@ -630,9 +641,11 @@ static int en7523_reset_status(struct re
  			       unsigned long id)
  {
  	struct en_rst_data *rst_data = container_of(rcdev, struct en_rst_data, rcdev);
@@ -295,7 +293,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  }
  
  static int en7523_reset_xlate(struct reset_controller_dev *rcdev,
-@@ -652,7 +665,7 @@ static const struct reset_control_ops en7581_reset_ops = {
+@@ -652,7 +665,7 @@ static const struct reset_control_ops en
  	.status = en7523_reset_status,
  };
  
@@ -304,7 +302,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  {
  	struct en_rst_data *rst_data;
  
-@@ -662,7 +675,7 @@ static int en7581_reset_register(struct device *dev, void __iomem *base)
+@@ -662,7 +675,7 @@ static int en7581_reset_register(struct
  
  	rst_data->bank_ofs = en7581_rst_ofs;
  	rst_data->idx_map = en7581_rst_map;
@@ -313,7 +311,7 @@ index 15bbdeb60b8e..314e7450313f 100644
  
  	rst_data->rcdev.nr_resets = ARRAY_SIZE(en7581_rst_map);
  	rst_data->rcdev.of_xlate = en7523_reset_xlate;
-@@ -678,9 +691,8 @@ static int en7581_reset_register(struct device *dev, void __iomem *base)
+@@ -678,9 +691,8 @@ static int en7581_reset_register(struct
  static int en7581_clk_hw_init(struct platform_device *pdev,
  			      struct clk_hw_onecell_data *clk_data)
  {
@@ -324,22 +322,23 @@ index 15bbdeb60b8e..314e7450313f 100644
  
  	map = syscon_regmap_lookup_by_compatible("airoha,en7581-chip-scu");
  	if (IS_ERR(map))
-@@ -690,15 +702,18 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -690,15 +702,18 @@ static int en7581_clk_hw_init(struct pla
  	if (IS_ERR(base))
  		return PTR_ERR(base);
  
 -	en7581_register_clocks(&pdev->dev, clk_data, map, base);
-+	clk_map = devm_regmap_init_mmio(&pdev->dev, base, &en7523_clk_regmap_config);
-+	if (IS_ERR(clk_map))
-+		return PTR_ERR(clk_map);
-+
-+	en7581_register_clocks(&pdev->dev, clk_data, map, clk_map);
- 
+-
 -	val = readl(base + REG_NP_SCU_SSTR);
 -	val &= ~(REG_PCIE_XSI0_SEL_MASK | REG_PCIE_XSI1_SEL_MASK);
 -	writel(val, base + REG_NP_SCU_SSTR);
 -	val = readl(base + REG_NP_SCU_PCIC);
 -	writel(val | 3, base + REG_NP_SCU_PCIC);
++	clk_map = devm_regmap_init_mmio(&pdev->dev, base, &en7523_clk_regmap_config);
++	if (IS_ERR(clk_map))
++		return PTR_ERR(clk_map);
++
++	en7581_register_clocks(&pdev->dev, clk_data, map, clk_map);
++
 +	regmap_clear_bits(clk_map, REG_NP_SCU_SSTR,
 +			  REG_PCIE_XSI0_SEL_MASK | REG_PCIE_XSI1_SEL_MASK);
 +	regmap_update_bits(clk_map, REG_NP_SCU_PCIC, REG_PCIE_CTRL,
@@ -350,6 +349,3 @@ index 15bbdeb60b8e..314e7450313f 100644
  }
  
  static int en7523_clk_probe(struct platform_device *pdev)
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-02-clk-en7523-generalize-register-clocks-function.patch
+++ b/target/linux/airoha/patches-6.6/600-02-clk-en7523-generalize-register-clocks-function.patch
@@ -16,8 +16,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 148 +++++++++++++++++----------------------
  1 file changed, 66 insertions(+), 82 deletions(-)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index 314e7450313f..b040f0f0d727 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
 @@ -78,8 +78,10 @@ struct en_rst_data {
@@ -31,7 +29,7 @@ index 314e7450313f..b040f0f0d727 100644
  		       struct clk_hw_onecell_data *clk_data);
  };
  
-@@ -450,10 +452,11 @@ static struct clk_hw *en7523_register_pcie_clk(struct device *dev,
+@@ -450,10 +452,11 @@ static struct clk_hw *en7523_register_pc
  		.ops = &soc_data->pcie_ops,
  	};
  	struct en_clk_gate *cg;
@@ -44,7 +42,7 @@ index 314e7450313f..b040f0f0d727 100644
  
  	cg->map = clk_map;
  	cg->hw.init = &init;
-@@ -461,12 +464,62 @@ static struct clk_hw *en7523_register_pcie_clk(struct device *dev,
+@@ -461,12 +464,62 @@ static struct clk_hw *en7523_register_pc
  	if (init.ops->unprepare)
  		init.ops->unprepare(&cg->hw);
  
@@ -109,7 +107,7 @@ index 314e7450313f..b040f0f0d727 100644
  static int en7581_pci_is_enabled(struct clk_hw *hw)
  {
  	struct en_clk_gate *cg = container_of(hw, struct en_clk_gate, hw);
-@@ -504,38 +557,6 @@ static void en7581_pci_disable(struct clk_hw *hw)
+@@ -504,38 +557,6 @@ static void en7581_pci_disable(struct cl
  	usleep_range(1000, 2000);
  }
  
@@ -148,7 +146,7 @@ index 314e7450313f..b040f0f0d727 100644
  static const struct regmap_config en7523_clk_regmap_config = {
  	.reg_bits = 32,
  	.val_bits = 32,
-@@ -543,6 +564,7 @@ static const struct regmap_config en7523_clk_regmap_config = {
+@@ -543,6 +564,7 @@ static const struct regmap_config en7523
  };
  
  static int en7523_clk_hw_init(struct platform_device *pdev,
@@ -156,7 +154,7 @@ index 314e7450313f..b040f0f0d727 100644
  			      struct clk_hw_onecell_data *clk_data)
  {
  	void __iomem *base, *np_base;
-@@ -566,51 +588,7 @@ static int en7523_clk_hw_init(struct platform_device *pdev,
+@@ -566,51 +588,7 @@ static int en7523_clk_hw_init(struct pla
  	if (IS_ERR(clk_map))
  		return PTR_ERR(clk_map);
  
@@ -209,7 +207,7 @@ index 314e7450313f..b040f0f0d727 100644
  }
  
  static int en7523_reset_update(struct reset_controller_dev *rcdev,
-@@ -689,10 +667,12 @@ static int en7581_reset_register(struct device *dev, struct regmap *map)
+@@ -689,10 +667,12 @@ static int en7581_reset_register(struct
  }
  
  static int en7581_clk_hw_init(struct platform_device *pdev,
@@ -222,7 +220,7 @@ index 314e7450313f..b040f0f0d727 100644
  
  	map = syscon_regmap_lookup_by_compatible("airoha,en7581-chip-scu");
  	if (IS_ERR(map))
-@@ -706,7 +686,9 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -706,7 +686,9 @@ static int en7581_clk_hw_init(struct pla
  	if (IS_ERR(clk_map))
  		return PTR_ERR(clk_map);
  
@@ -233,7 +231,7 @@ index 314e7450313f..b040f0f0d727 100644
  
  	regmap_clear_bits(clk_map, REG_NP_SCU_SSTR,
  			  REG_PCIE_XSI0_SEL_MASK | REG_PCIE_XSI1_SEL_MASK);
-@@ -732,7 +714,7 @@ static int en7523_clk_probe(struct platform_device *pdev)
+@@ -732,7 +714,7 @@ static int en7523_clk_probe(struct platf
  		return -ENOMEM;
  
  	clk_data->num = soc_data->num_clocks;
@@ -242,7 +240,7 @@ index 314e7450313f..b040f0f0d727 100644
  	if (r)
  		return r;
  
-@@ -740,6 +722,7 @@ static int en7523_clk_probe(struct platform_device *pdev)
+@@ -740,6 +722,7 @@ static int en7523_clk_probe(struct platf
  }
  
  static const struct en_clk_soc_data en7523_data = {
@@ -250,7 +248,7 @@ index 314e7450313f..b040f0f0d727 100644
  	.num_clocks = ARRAY_SIZE(en7523_base_clks) + 1,
  	.pcie_ops = {
  		.is_enabled = en7523_pci_is_enabled,
-@@ -750,6 +733,7 @@ static const struct en_clk_soc_data en7523_data = {
+@@ -750,6 +733,7 @@ static const struct en_clk_soc_data en75
  };
  
  static const struct en_clk_soc_data en7581_data = {
@@ -258,6 +256,3 @@ index 314e7450313f..b040f0f0d727 100644
  	/* We increment num_clocks by 1 to account for additional PCIe clock */
  	.num_clocks = ARRAY_SIZE(en7581_base_clks) + 1,
  	.pcie_ops = {
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-03-clk-en7523-convert-to-full-clk_hw-implementation.patch
+++ b/target/linux/airoha/patches-6.6/600-03-clk-en7523-convert-to-full-clk_hw-implementation.patch
@@ -14,8 +14,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 83 ++++++++++++++++++++++++++++------------
  1 file changed, 59 insertions(+), 24 deletions(-)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index b040f0f0d727..10fb0dcdc88b 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
 @@ -69,6 +69,12 @@ struct en_clk_gate {
@@ -31,7 +29,7 @@ index b040f0f0d727..10fb0dcdc88b 100644
  struct en_rst_data {
  	const u16 *bank_ofs;
  	const u16 *idx_map;
-@@ -471,44 +477,73 @@ static struct clk_hw *en7523_register_pcie_clk(struct device *dev,
+@@ -471,44 +477,73 @@ static struct clk_hw *en7523_register_pc
  	return &cg->hw;
  }
  
@@ -125,7 +123,7 @@ index b040f0f0d727..10fb0dcdc88b 100644
  	}
  
  	hw = en7523_register_pcie_clk(dev, clk_map);
-@@ -672,7 +707,7 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -672,7 +707,7 @@ static int en7581_clk_hw_init(struct pla
  {
  	struct regmap *map, *clk_map;
  	void __iomem *base;
@@ -134,7 +132,7 @@ index b040f0f0d727..10fb0dcdc88b 100644
  
  	map = syscon_regmap_lookup_by_compatible("airoha,en7581-chip-scu");
  	if (IS_ERR(map))
-@@ -686,9 +721,9 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -686,9 +721,9 @@ static int en7581_clk_hw_init(struct pla
  	if (IS_ERR(clk_map))
  		return PTR_ERR(clk_map);
  
@@ -147,6 +145,3 @@ index b040f0f0d727..10fb0dcdc88b 100644
  
  	regmap_clear_bits(clk_map, REG_NP_SCU_SSTR,
  			  REG_PCIE_XSI0_SEL_MASK | REG_PCIE_XSI1_SEL_MASK);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-04-clk-en7523-add-support-for-.set_rate.patch
+++ b/target/linux/airoha/patches-6.6/600-04-clk-en7523-add-support-for-.set_rate.patch
@@ -19,11 +19,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 141 +++++++++++++++++++++++++++++++++++++++
  1 file changed, 141 insertions(+)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index 10fb0dcdc88b..54c0462c0dee 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
-@@ -506,8 +506,149 @@ static unsigned long en75xx_recalc_rate(struct clk_hw *hw,
+@@ -506,8 +506,149 @@ static unsigned long en75xx_recalc_rate(
  	return rate / en7523_get_div(desc, val);
  }
  
@@ -173,6 +171,3 @@ index 10fb0dcdc88b..54c0462c0dee 100644
  };
  
  static int en75xx_register_clocks(struct device *dev,
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-05-clk-en7523-permit-to-reference-Chip-SCU-from-phandle.patch
+++ b/target/linux/airoha/patches-6.6/600-05-clk-en7523-permit-to-reference-Chip-SCU-from-phandle.patch
@@ -15,11 +15,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 7 ++++++-
  1 file changed, 6 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index 54c0462c0dee..a768ba71feec 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
-@@ -846,11 +846,16 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -846,11 +846,16 @@ static int en7581_clk_hw_init(struct pla
  			      const struct en_clk_soc_data *soc_data,
  			      struct clk_hw_onecell_data *clk_data)
  {
@@ -37,6 +35,3 @@ index 54c0462c0dee..a768ba71feec 100644
  	if (IS_ERR(map))
  		return PTR_ERR(map);
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-07-clk-en7523-reword-and-clean-clk_probe-variables.patch
+++ b/target/linux/airoha/patches-6.6/600-07-clk-en7523-reword-and-clean-clk_probe-variables.patch
@@ -12,11 +12,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 20 +++++++++++---------
  1 file changed, 11 insertions(+), 9 deletions(-)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index a768ba71feec..5236119bca83 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
-@@ -881,25 +881,27 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -881,25 +881,27 @@ static int en7581_clk_hw_init(struct pla
  
  static int en7523_clk_probe(struct platform_device *pdev)
  {
@@ -53,6 +51,3 @@ index a768ba71feec..5236119bca83 100644
  }
  
  static const struct en_clk_soc_data en7523_data = {
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-08-clk-en7523-add-support-for-probing-SCU-child.patch
+++ b/target/linux/airoha/patches-6.6/600-08-clk-en7523-add-support-for-probing-SCU-child.patch
@@ -15,8 +15,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 17 +++++++++++++++--
  1 file changed, 15 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index 5236119bca83..00c80221a274 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
 @@ -5,6 +5,7 @@
@@ -35,7 +33,7 @@ index 5236119bca83..00c80221a274 100644
  	u32 num_clocks;
  	const struct en_clk_desc *base_clks;
  	const struct clk_ops pcie_ops;
-@@ -900,8 +902,19 @@ static int en7523_clk_probe(struct platform_device *pdev)
+@@ -900,8 +902,19 @@ static int en7523_clk_probe(struct platf
  	if (err)
  		return err;
  
@@ -57,6 +55,3 @@ index 5236119bca83..00c80221a274 100644
  }
  
  static const struct en_clk_soc_data en7523_data = {
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-09-dt-bindings-clock-airoha-Document-support-for-AN7583.patch
+++ b/target/linux/airoha/patches-6.6/600-09-dt-bindings-clock-airoha-Document-support-for-AN7583.patch
@@ -45,8 +45,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 #  additionalProperties: false
  
 #  examples:
-diff --git a/include/dt-bindings/clock/en7523-clk.h b/include/dt-bindings/clock/en7523-clk.h
-index edfa64045f52..0fbbcb7b1b25 100644
 --- a/include/dt-bindings/clock/en7523-clk.h
 +++ b/include/dt-bindings/clock/en7523-clk.h
 @@ -14,4 +14,7 @@
@@ -57,9 +55,6 @@ index edfa64045f52..0fbbcb7b1b25 100644
 +#define AN7583_CLK_MDIO1	10
 +
  #endif /* _DT_BINDINGS_CLOCK_AIROHA_EN7523_H_ */
-diff --git a/include/dt-bindings/reset/airoha,an7583-reset.h b/include/dt-bindings/reset/airoha,an7583-reset.h
-new file mode 100644
-index 000000000000..96cfe11d2943
 --- /dev/null
 +++ b/include/dt-bindings/reset/airoha,an7583-reset.h
 @@ -0,0 +1,62 @@
@@ -125,6 +120,3 @@ index 000000000000..96cfe11d2943
 +#define AN7583_XPON_MAC_RST		48
 +
 +#endif /* __DT_BINDINGS_RESET_CONTROLLER_AIROHA_AN7583_H_ */
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/600-10-clk-en7523-add-support-for-Airoha-AN7583-clock.patch
+++ b/target/linux/airoha/patches-6.6/600-10-clk-en7523-add-support-for-Airoha-AN7583-clock.patch
@@ -14,8 +14,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 264 +++++++++++++++++++++++++++++++++++++++
  1 file changed, 264 insertions(+)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index 00c80221a274..b3c57aac8480 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
 @@ -12,6 +12,7 @@
@@ -26,7 +24,7 @@ index 00c80221a274..b3c57aac8480 100644
  
  #define RST_NR_PER_BANK			32
  
-@@ -104,6 +105,14 @@ static const u32 bus7581_base[] = { 600000000, 540000000 };
+@@ -104,6 +105,14 @@ static const u32 bus7581_base[] = { 6000
  static const u32 npu7581_base[] = { 800000000, 750000000, 720000000, 600000000 };
  static const u32 crypto_base[] = { 540000000, 480000000 };
  static const u32 emmc7581_base[] = { 200000000, 150000000 };
@@ -41,7 +39,7 @@ index 00c80221a274..b3c57aac8480 100644
  
  static const struct en_clk_desc en7523_base_clks[] = {
  	{
-@@ -306,6 +315,138 @@ static const struct en_clk_desc en7581_base_clks[] = {
+@@ -306,6 +315,138 @@ static const struct en_clk_desc en7581_b
  	}
  };
  
@@ -241,7 +239,7 @@ index 00c80221a274..b3c57aac8480 100644
  static u32 en7523_get_base_rate(const struct en_clk_desc *desc, u32 val)
  {
  	if (!desc->base_bits)
-@@ -881,6 +1075,62 @@ static int en7581_clk_hw_init(struct platform_device *pdev,
+@@ -881,6 +1076,62 @@ static int en7581_clk_hw_init(struct pla
  	return en7581_reset_register(&pdev->dev, clk_map);
  }
  
@@ -304,7 +302,7 @@ index 00c80221a274..b3c57aac8480 100644
  static int en7523_clk_probe(struct platform_device *pdev)
  {
  	const struct en_clk_soc_data *soc_data;
-@@ -940,9 +1190,23 @@ static const struct en_clk_soc_data en7581_data = {
+@@ -940,9 +1191,23 @@ static const struct en_clk_soc_data en75
  	.hw_init = en7581_clk_hw_init,
  };
  
@@ -328,6 +326,3 @@ index 00c80221a274..b3c57aac8480 100644
  	{ /* sentinel */ }
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/602-02-phy-airoha-add-EN7581-tag-to-PCIe-PHY-driver.patch
+++ b/target/linux/airoha/patches-6.6/602-02-phy-airoha-add-EN7581-tag-to-PCIe-PHY-driver.patch
@@ -42,13 +42,11 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 #  AIROHA SPI SNFI DRIVER
 #  M:	Lorenzo Bianconi <lorenzo@kernel.org>
-diff --git a/drivers/phy/airoha/Kconfig b/drivers/phy/airoha/Kconfig
-index 1674134ea664..08cc1fe4a11c 100644
 --- a/drivers/phy/airoha/Kconfig
 +++ b/drivers/phy/airoha/Kconfig
-@@ -2,12 +2,12 @@
+@@ -2,13 +2,13 @@
  #
- # Phy drivers for Airoha platforms
+ # Phy drivers for Airoha devices
  #
 -config PHY_AIROHA_PCIE
 -	tristate "Airoha PCIe-PHY Driver"
@@ -62,49 +60,3592 @@ index 1674134ea664..08cc1fe4a11c 100644
 +	  Say Y here to add support for Airoha EN7581 PCIe PHY driver.
  	  This driver create the basic PHY instance and provides initialize
  	  callback for PCIe GEN3 port.
-diff --git a/drivers/phy/airoha/Makefile b/drivers/phy/airoha/Makefile
-index 616dc96302af..f8949a291486 100644
+ 
 --- a/drivers/phy/airoha/Makefile
 +++ b/drivers/phy/airoha/Makefile
-@@ -1,2 +1,2 @@
- # SPDX-License-Identifier: GPL-2.0-only
+@@ -1,4 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+ 
 -obj-$(CONFIG_PHY_AIROHA_PCIE)		+= phy-airoha-pcie.o
 +obj-$(CONFIG_PHY_AIROHA_EN7581_PCIE)	+= phy-airoha-en7581-pcie.o
-diff --git a/drivers/phy/airoha/phy-airoha-pcie-regs.h b/drivers/phy/airoha/phy-airoha-en7581-pcie-regs.h
-similarity index 100%
-rename from drivers/phy/airoha/phy-airoha-pcie-regs.h
-rename to drivers/phy/airoha/phy-airoha-en7581-pcie-regs.h
-diff --git a/drivers/phy/airoha/phy-airoha-pcie.c b/drivers/phy/airoha/phy-airoha-en7581-pcie.c
-similarity index 99%
-rename from drivers/phy/airoha/phy-airoha-pcie.c
-rename to drivers/phy/airoha/phy-airoha-en7581-pcie.c
-index 56e9ade8a9fd..ea448cdf9ae0 100644
+ obj-$(CONFIG_PHY_AIROHA_USB)		+= phy-airoha-usb.o
 --- a/drivers/phy/airoha/phy-airoha-pcie.c
-+++ b/drivers/phy/airoha/phy-airoha-en7581-pcie.c
-@@ -13,7 +13,7 @@
- #include <linux/platform_device.h>
- #include <linux/slab.h>
- 
++++ /dev/null
+@@ -1,1290 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0-only
+-/*
+- * Copyright (c) 2024 AIROHA Inc
+- * Author: Lorenzo Bianconi <lorenzo@kernel.org>
+- */
+-
+-#include <linux/bitfield.h>
+-#include <linux/delay.h>
+-#include <linux/io.h>
+-#include <linux/module.h>
+-#include <linux/of.h>
+-#include <linux/phy/phy.h>
+-#include <linux/platform_device.h>
+-#include <linux/slab.h>
+-
 -#include "phy-airoha-pcie-regs.h"
-+#include "phy-airoha-en7581-pcie-regs.h"
- 
- #define LEQ_LEN_CTRL_MAX_VAL	7
- #define FREQ_LOCK_MAX_ATTEMPT	10
-@@ -1279,12 +1279,12 @@ MODULE_DEVICE_TABLE(of, airoha_pcie_phy_of_match);
- static struct platform_driver airoha_pcie_phy_driver = {
- 	.probe	= airoha_pcie_phy_probe,
- 	.driver	= {
+-
+-#define LEQ_LEN_CTRL_MAX_VAL	7
+-#define FREQ_LOCK_MAX_ATTEMPT	10
+-
+-/* PCIe-PHY initialization time in ms needed by the hw to complete */
+-#define PHY_HW_INIT_TIME_MS	30
+-
+-enum airoha_pcie_port_gen {
+-	PCIE_PORT_GEN1 = 1,
+-	PCIE_PORT_GEN2,
+-	PCIE_PORT_GEN3,
+-};
+-
+-/**
+- * struct airoha_pcie_phy - PCIe phy driver main structure
+- * @dev: pointer to device
+- * @phy: pointer to generic phy
+- * @csr_2l: Analogic lane IO mapped register base address
+- * @pma0: IO mapped register base address of PMA0-PCIe
+- * @pma1: IO mapped register base address of PMA1-PCIe
+- * @p0_xr_dtime: IO mapped register base address of port0 Tx-Rx detection time
+- * @p1_xr_dtime: IO mapped register base address of port1 Tx-Rx detection time
+- * @rx_aeq: IO mapped register base address of Rx AEQ training
+- */
+-struct airoha_pcie_phy {
+-	struct device *dev;
+-	struct phy *phy;
+-	void __iomem *csr_2l;
+-	void __iomem *pma0;
+-	void __iomem *pma1;
+-	void __iomem *p0_xr_dtime;
+-	void __iomem *p1_xr_dtime;
+-	void __iomem *rx_aeq;
+-};
+-
+-static void airoha_phy_clear_bits(void __iomem *reg, u32 mask)
+-{
+-	u32 val = readl(reg) & ~mask;
+-
+-	writel(val, reg);
+-}
+-
+-static void airoha_phy_set_bits(void __iomem *reg, u32 mask)
+-{
+-	u32 val = readl(reg) | mask;
+-
+-	writel(val, reg);
+-}
+-
+-static void airoha_phy_update_bits(void __iomem *reg, u32 mask, u32 val)
+-{
+-	u32 tmp = readl(reg);
+-
+-	tmp &= ~mask;
+-	tmp |= val & mask;
+-	writel(tmp, reg);
+-}
+-
+-#define airoha_phy_update_field(reg, mask, val)					\
+-	do {									\
+-		BUILD_BUG_ON_MSG(!__builtin_constant_p((mask)),			\
+-				 "mask is not constant");			\
+-		airoha_phy_update_bits((reg), (mask),				\
+-				       FIELD_PREP((mask), (val)));		\
+-	} while (0)
+-
+-#define airoha_phy_csr_2l_clear_bits(pcie_phy, reg, mask)			\
+-	airoha_phy_clear_bits((pcie_phy)->csr_2l + (reg), (mask))
+-#define airoha_phy_csr_2l_set_bits(pcie_phy, reg, mask)				\
+-	airoha_phy_set_bits((pcie_phy)->csr_2l + (reg), (mask))
+-#define airoha_phy_csr_2l_update_field(pcie_phy, reg, mask, val)		\
+-	airoha_phy_update_field((pcie_phy)->csr_2l + (reg), (mask), (val))
+-#define airoha_phy_pma0_clear_bits(pcie_phy, reg, mask)				\
+-	airoha_phy_clear_bits((pcie_phy)->pma0 + (reg), (mask))
+-#define airoha_phy_pma1_clear_bits(pcie_phy, reg, mask)				\
+-	airoha_phy_clear_bits((pcie_phy)->pma1 + (reg), (mask))
+-#define airoha_phy_pma0_set_bits(pcie_phy, reg, mask)				\
+-	airoha_phy_set_bits((pcie_phy)->pma0 + (reg), (mask))
+-#define airoha_phy_pma1_set_bits(pcie_phy, reg, mask)				\
+-	airoha_phy_set_bits((pcie_phy)->pma1 + (reg), (mask))
+-#define airoha_phy_pma0_update_field(pcie_phy, reg, mask, val)			\
+-	airoha_phy_update_field((pcie_phy)->pma0 + (reg), (mask), (val))
+-#define airoha_phy_pma1_update_field(pcie_phy, reg, mask, val)			\
+-	airoha_phy_update_field((pcie_phy)->pma1 + (reg), (mask), (val))
+-
+-static void
+-airoha_phy_init_lane0_rx_fw_pre_calib(struct airoha_pcie_phy *pcie_phy,
+-				      enum airoha_pcie_port_gen gen)
+-{
+-	u32 fl_out_target = gen == PCIE_PORT_GEN3 ? 41600 : 41941;
+-	u32 lock_cyclecnt = gen == PCIE_PORT_GEN3 ? 26000 : 32767;
+-	u32 pr_idac, val, cdr_pr_idac_tmp = 0;
+-	int i;
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_SS_LCPLL_PWCTL_SETTING_1,
+-				 PCIE_LCPLL_MAN_PWDB);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
+-				     PCIE_LOCK_TARGET_BEG,
+-				     fl_out_target - 100);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
+-				     PCIE_LOCK_TARGET_END,
+-				     fl_out_target + 100);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
+-				     PCIE_PLL_FT_LOCK_CYCLECNT, lock_cyclecnt);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-				     PCIE_LOCK_LOCKTH, 0x3);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
+-				     PCIE_UNLOCK_TARGET_BEG,
+-				     fl_out_target - 100);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
+-				     PCIE_UNLOCK_TARGET_END,
+-				     fl_out_target + 100);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
+-				     PCIE_PLL_FT_UNLOCK_CYCLECNT,
+-				     lock_cyclecnt);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-				     PCIE_UNLOCK_LOCKTH, 0x3);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR0_PR_INJ_MODE,
+-				   CSR_2L_PXP_CDR0_INJ_FORCE_OFF);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				 PCIE_FORCE_DA_PXP_CDR_PR_LPF_R_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				   PCIE_FORCE_DA_PXP_CDR_PR_LPF_C_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				   PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				 PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
+-
+-	for (i = 0; i < LEQ_LEN_CTRL_MAX_VAL; i++) {
+-		airoha_phy_pma0_update_field(pcie_phy,
+-				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, i << 8);
+-		airoha_phy_pma0_clear_bits(pcie_phy,
+-					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					   PCIE_FREQLOCK_DET_EN);
+-		airoha_phy_pma0_update_field(pcie_phy,
+-					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					     PCIE_FREQLOCK_DET_EN, 0x3);
+-
+-		usleep_range(10000, 15000);
+-
+-		val = FIELD_GET(PCIE_RO_FL_OUT,
+-				readl(pcie_phy->pma0 +
+-				      REG_PCIE_PMA_RO_RX_FREQDET));
+-		if (val > fl_out_target)
+-			cdr_pr_idac_tmp = i << 8;
+-	}
+-
+-	for (i = LEQ_LEN_CTRL_MAX_VAL; i >= 0; i--) {
+-		pr_idac = cdr_pr_idac_tmp | (0x1 << i);
+-		airoha_phy_pma0_update_field(pcie_phy,
+-				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, pr_idac);
+-		airoha_phy_pma0_clear_bits(pcie_phy,
+-					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					   PCIE_FREQLOCK_DET_EN);
+-		airoha_phy_pma0_update_field(pcie_phy,
+-					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					     PCIE_FREQLOCK_DET_EN, 0x3);
+-
+-		usleep_range(10000, 15000);
+-
+-		val = FIELD_GET(PCIE_RO_FL_OUT,
+-				readl(pcie_phy->pma0 +
+-				      REG_PCIE_PMA_RO_RX_FREQDET));
+-		if (val < fl_out_target)
+-			pr_idac &= ~(0x1 << i);
+-
+-		cdr_pr_idac_tmp = pr_idac;
+-	}
+-
+-	airoha_phy_pma0_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				     PCIE_FORCE_DA_PXP_CDR_PR_IDAC,
+-				     cdr_pr_idac_tmp);
+-
+-	for (i = 0; i < FREQ_LOCK_MAX_ATTEMPT; i++) {
+-		u32 val;
+-
+-		airoha_phy_pma0_clear_bits(pcie_phy,
+-					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					   PCIE_FREQLOCK_DET_EN);
+-		airoha_phy_pma0_update_field(pcie_phy,
+-					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					     PCIE_FREQLOCK_DET_EN, 0x3);
+-
+-		usleep_range(10000, 15000);
+-
+-		val = readl(pcie_phy->pma0 + REG_PCIE_PMA_RO_RX_FREQDET);
+-		if (val & PCIE_RO_FBCK_LOCK)
+-			break;
+-	}
+-
+-	/* turn off force mode and update band values */
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_INJ_MODE,
+-				     CSR_2L_PXP_CDR0_INJ_FORCE_OFF);
+-
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
+-	if (gen == PCIE_PORT_GEN3) {
+-		airoha_phy_pma0_update_field(pcie_phy,
+-					     REG_PCIE_PMA_DIG_RESERVE_14,
+-					     PCIE_FLL_IDAC_PCIEG3,
+-					     cdr_pr_idac_tmp);
+-	} else {
+-		airoha_phy_pma0_update_field(pcie_phy,
+-					     REG_PCIE_PMA_DIG_RESERVE_13,
+-					     PCIE_FLL_IDAC_PCIEG1,
+-					     cdr_pr_idac_tmp);
+-		airoha_phy_pma0_update_field(pcie_phy,
+-					     REG_PCIE_PMA_DIG_RESERVE_13,
+-					     PCIE_FLL_IDAC_PCIEG2,
+-					     cdr_pr_idac_tmp);
+-	}
+-}
+-
+-static void
+-airoha_phy_init_lane1_rx_fw_pre_calib(struct airoha_pcie_phy *pcie_phy,
+-				      enum airoha_pcie_port_gen gen)
+-{
+-	u32 fl_out_target = gen == PCIE_PORT_GEN3 ? 41600 : 41941;
+-	u32 lock_cyclecnt = gen == PCIE_PORT_GEN3 ? 26000 : 32767;
+-	u32 pr_idac, val, cdr_pr_idac_tmp = 0;
+-	int i;
+-
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_SS_LCPLL_PWCTL_SETTING_1,
+-				 PCIE_LCPLL_MAN_PWDB);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
+-				     PCIE_LOCK_TARGET_BEG,
+-				     fl_out_target - 100);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
+-				     PCIE_LOCK_TARGET_END,
+-				     fl_out_target + 100);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
+-				     PCIE_PLL_FT_LOCK_CYCLECNT, lock_cyclecnt);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-				     PCIE_LOCK_LOCKTH, 0x3);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
+-				     PCIE_UNLOCK_TARGET_BEG,
+-				     fl_out_target - 100);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
+-				     PCIE_UNLOCK_TARGET_END,
+-				     fl_out_target + 100);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
+-				     PCIE_PLL_FT_UNLOCK_CYCLECNT,
+-				     lock_cyclecnt);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-				     PCIE_UNLOCK_LOCKTH, 0x3);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR1_PR_INJ_MODE,
+-				   CSR_2L_PXP_CDR1_INJ_FORCE_OFF);
+-
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				 PCIE_FORCE_DA_PXP_CDR_PR_LPF_R_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				   PCIE_FORCE_DA_PXP_CDR_PR_LPF_C_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				   PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				 PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
+-
+-	for (i = 0; i < LEQ_LEN_CTRL_MAX_VAL; i++) {
+-		airoha_phy_pma1_update_field(pcie_phy,
+-				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, i << 8);
+-		airoha_phy_pma1_clear_bits(pcie_phy,
+-					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					   PCIE_FREQLOCK_DET_EN);
+-		airoha_phy_pma1_update_field(pcie_phy,
+-					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					     PCIE_FREQLOCK_DET_EN, 0x3);
+-
+-		usleep_range(10000, 15000);
+-
+-		val = FIELD_GET(PCIE_RO_FL_OUT,
+-				readl(pcie_phy->pma1 +
+-				      REG_PCIE_PMA_RO_RX_FREQDET));
+-		if (val > fl_out_target)
+-			cdr_pr_idac_tmp = i << 8;
+-	}
+-
+-	for (i = LEQ_LEN_CTRL_MAX_VAL; i >= 0; i--) {
+-		pr_idac = cdr_pr_idac_tmp | (0x1 << i);
+-		airoha_phy_pma1_update_field(pcie_phy,
+-				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, pr_idac);
+-		airoha_phy_pma1_clear_bits(pcie_phy,
+-					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					   PCIE_FREQLOCK_DET_EN);
+-		airoha_phy_pma1_update_field(pcie_phy,
+-					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					     PCIE_FREQLOCK_DET_EN, 0x3);
+-
+-		usleep_range(10000, 15000);
+-
+-		val = FIELD_GET(PCIE_RO_FL_OUT,
+-				readl(pcie_phy->pma1 +
+-				      REG_PCIE_PMA_RO_RX_FREQDET));
+-		if (val < fl_out_target)
+-			pr_idac &= ~(0x1 << i);
+-
+-		cdr_pr_idac_tmp = pr_idac;
+-	}
+-
+-	airoha_phy_pma1_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				     PCIE_FORCE_DA_PXP_CDR_PR_IDAC,
+-				     cdr_pr_idac_tmp);
+-
+-	for (i = 0; i < FREQ_LOCK_MAX_ATTEMPT; i++) {
+-		u32 val;
+-
+-		airoha_phy_pma1_clear_bits(pcie_phy,
+-					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					   PCIE_FREQLOCK_DET_EN);
+-		airoha_phy_pma1_update_field(pcie_phy,
+-					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
+-					     PCIE_FREQLOCK_DET_EN, 0x3);
+-
+-		usleep_range(10000, 15000);
+-
+-		val = readl(pcie_phy->pma1 + REG_PCIE_PMA_RO_RX_FREQDET);
+-		if (val & PCIE_RO_FBCK_LOCK)
+-			break;
+-	}
+-
+-	/* turn off force mode and update band values */
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_INJ_MODE,
+-				     CSR_2L_PXP_CDR1_INJ_FORCE_OFF);
+-
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
+-	if (gen == PCIE_PORT_GEN3) {
+-		airoha_phy_pma1_update_field(pcie_phy,
+-					     REG_PCIE_PMA_DIG_RESERVE_14,
+-					     PCIE_FLL_IDAC_PCIEG3,
+-					     cdr_pr_idac_tmp);
+-	} else {
+-		airoha_phy_pma1_update_field(pcie_phy,
+-					     REG_PCIE_PMA_DIG_RESERVE_13,
+-					     PCIE_FLL_IDAC_PCIEG1,
+-					     cdr_pr_idac_tmp);
+-		airoha_phy_pma1_update_field(pcie_phy,
+-					     REG_PCIE_PMA_DIG_RESERVE_13,
+-					     PCIE_FLL_IDAC_PCIEG2,
+-					     cdr_pr_idac_tmp);
+-	}
+-}
+-
+-static void airoha_pcie_phy_init_default(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CMN,
+-				       CSR_2L_PXP_CMN_TRIM_MASK, 0x10);
+-	writel(0xcccbcccb, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_21);
+-	writel(0xcccb, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_22);
+-	writel(0xcccbcccb, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_21);
+-	writel(0xcccb, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_22);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CMN,
+-				   CSR_2L_PXP_CMN_LANE_EN);
+-}
+-
+-static void airoha_pcie_phy_init_clk_out(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_TXPLL_POSTDIV_D256,
+-				       CSR_2L_PXP_CLKTX0_AMP, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_CLKTX0_FORCE_OUT1,
+-				       CSR_2L_PXP_CLKTX1_AMP, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_TXPLL_POSTDIV_D256,
+-				       CSR_2L_PXP_CLKTX0_OFFSET, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CLKTX1_OFFSET,
+-				       CSR_2L_PXP_CLKTX1_OFFSET, 0x2);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CLKTX0_FORCE_OUT1,
+-				     CSR_2L_PXP_CLKTX0_HZ);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CLKTX1_OFFSET,
+-				     CSR_2L_PXP_CLKTX1_HZ);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_CLKTX0_FORCE_OUT1,
+-				       CSR_2L_PXP_CLKTX0_IMP_SEL, 0x12);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CLKTX1_IMP_SEL,
+-				       CSR_2L_PXP_CLKTX1_IMP_SEL, 0x12);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV_D256,
+-				     CSR_2L_PXP_CLKTX0_SR);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CLKTX1_OFFSET,
+-				     CSR_2L_PXP_CLKTX1_SR);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_PLL_CMN_RESERVE0,
+-				       CSR_2L_PXP_PLL_RESERVE_MASK, 0xd0d);
+-}
+-
+-static void airoha_pcie_phy_init_csr_2l(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
+-				 PCIE_SW_XFI_RXPCS_RST | PCIE_SW_REF_RST |
+-				 PCIE_SW_RX_RST);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
+-				 PCIE_SW_XFI_RXPCS_RST | PCIE_SW_REF_RST |
+-				 PCIE_SW_RX_RST);
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_TX_RESET,
+-				 PCIE_TX_TOP_RST | PCIE_TX_CAL_RST);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_TX_RESET,
+-				 PCIE_TX_TOP_RST | PCIE_TX_CAL_RST);
+-}
+-
+-static void airoha_pcie_phy_init_rx(struct airoha_pcie_phy *pcie_phy)
+-{
+-	writel(0x2a00090b, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_17);
+-	writel(0x2a00090b, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_17);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR0_PR_MONPI,
+-				   CSR_2L_PXP_CDR0_PR_XFICK_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR1_PR_MONPI,
+-				   CSR_2L_PXP_CDR1_PR_XFICK_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy,
+-				     REG_CSR_2L_CDR0_PD_PICAL_CKD8_INV,
+-				     CSR_2L_PXP_CDR0_PD_EDGE_DISABLE);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy,
+-				     REG_CSR_2L_CDR1_PD_PICAL_CKD8_INV,
+-				     CSR_2L_PXP_CDR1_PD_EDGE_DISABLE);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_PHYCK_DIV,
+-				       CSR_2L_PXP_RX0_PHYCK_SEL, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_PHYCK_DIV,
+-				       CSR_2L_PXP_RX1_PHYCK_SEL, 0x1);
+-}
+-
+-static void airoha_pcie_phy_init_jcpll(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				   PCIE_FORCE_DA_PXP_JCPLL_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				   PCIE_FORCE_DA_PXP_JCPLL_EN);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_TCL_VTP_EN,
+-				       CSR_2L_PXP_JCPLL_SPARE_LOW, 0x20);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
+-				   CSR_2L_PXP_JCPLL_RST);
+-	writel(0x0, pcie_phy->csr_2l + REG_CSR_2L_JCPLL_SSC_DELTA1);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC_PERIOD,
+-				     CSR_2L_PXP_JCPLL_SSC_PERIOD);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
+-				     CSR_2L_PXP_JCPLL_SSC_PHASE_INI);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
+-				     CSR_2L_PXP_JCPLL_SSC_TRI_EN);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
+-				       CSR_2L_PXP_JCPLL_LPF_BR, 0xa);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
+-				       CSR_2L_PXP_JCPLL_LPF_BP, 0xc);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
+-				       CSR_2L_PXP_JCPLL_LPF_BC, 0x1f);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BWC,
+-				       CSR_2L_PXP_JCPLL_LPF_BWC, 0x1e);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
+-				       CSR_2L_PXP_JCPLL_LPF_BWR, 0xa);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
+-				       CSR_2L_PXP_JCPLL_MMD_PREDIV_MODE,
+-				       0x1);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, CSR_2L_PXP_JCPLL_MONCK,
+-				     CSR_2L_PXP_JCPLL_REFIN_DIV);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_VOS,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_SDM_PCW);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_VOS,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_SDM_PCW);
+-	airoha_phy_pma0_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_JCPLL_SDM_PCW,
+-				     PCIE_FORCE_DA_PXP_JCPLL_SDM_PCW,
+-				     0x50000000);
+-	airoha_phy_pma1_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_JCPLL_SDM_PCW,
+-				     PCIE_FORCE_DA_PXP_JCPLL_SDM_PCW,
+-				     0x50000000);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy,
+-				   REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
+-				   CSR_2L_PXP_JCPLL_POSTDIV_D5);
+-	airoha_phy_csr_2l_set_bits(pcie_phy,
+-				   REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
+-				   CSR_2L_PXP_JCPLL_POSTDIV_D2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
+-				       CSR_2L_PXP_JCPLL_RST_DLY, 0x4);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
+-				     CSR_2L_PXP_JCPLL_SDM_DI_LS);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_TCL_KBAND_VREF,
+-				     CSR_2L_PXP_JCPLL_VCO_KBAND_MEAS_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_IB_EXT,
+-				     CSR_2L_PXP_JCPLL_CHP_IOFST);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_IB_EXT,
+-				       CSR_2L_PXP_JCPLL_CHP_IBIAS, 0xc);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
+-				       CSR_2L_PXP_JCPLL_MMD_PREDIV_MODE,
+-				       0x1);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_VCODIV,
+-				   CSR_2L_PXP_JCPLL_VCO_HALFLSB_EN);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_VCODIV,
+-				       CSR_2L_PXP_JCPLL_VCO_CFIX, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_VCODIV,
+-				       CSR_2L_PXP_JCPLL_VCO_SCAPWR, 0x4);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_IB_EXT,
+-				     REG_CSR_2L_JCPLL_LPF_SHCK_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
+-				   CSR_2L_PXP_JCPLL_POSTDIV_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
+-				     CSR_2L_PXP_JCPLL_KBAND_KFC);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
+-				       CSR_2L_PXP_JCPLL_KBAND_KF, 0x3);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
+-				     CSR_2L_PXP_JCPLL_KBAND_KS);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BWC,
+-				       CSR_2L_PXP_JCPLL_KBAND_DIV, 0x1);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SCAN_MODE,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_KBAND_LOAD_EN);
+-	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SCAN_MODE,
+-				   PCIE_FORCE_DA_PXP_JCPLL_KBAND_LOAD_EN);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BWC,
+-				       CSR_2L_PXP_JCPLL_KBAND_CODE, 0xe4);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
+-				   CSR_2L_PXP_JCPLL_TCL_AMP_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_TCL_CMP,
+-				   CSR_2L_PXP_JCPLL_TCL_LPF_EN);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_JCPLL_TCL_KBAND_VREF,
+-				       CSR_2L_PXP_JCPLL_TCL_KBAND_VREF, 0xf);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
+-				       CSR_2L_PXP_JCPLL_TCL_AMP_GAIN, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
+-				       CSR_2L_PXP_JCPLL_TCL_AMP_VREF, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_TCL_CMP,
+-				       CSR_2L_PXP_JCPLL_TCL_LPF_BW, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_VCO_TCLVAR,
+-				       CSR_2L_PXP_JCPLL_VCO_TCLVAR, 0x3);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_CKOUT_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_JCPLL_CKOUT_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_CKOUT_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_JCPLL_CKOUT_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_JCPLL_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_JCPLL_EN);
+-}
+-
+-static void airoha_pcie_phy_txpll(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				   PCIE_FORCE_DA_PXP_TXPLL_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				   PCIE_FORCE_DA_PXP_TXPLL_EN);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
+-				   CSR_2L_PXP_TXPLL_PLL_RSTB);
+-	writel(0x0, pcie_phy->csr_2l + REG_CSR_2L_TXPLL_SSC_DELTA1);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC_PERIOD,
+-				     CSR_2L_PXP_txpll_SSC_PERIOD);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
+-				       CSR_2L_PXP_TXPLL_CHP_IOFST, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_750M_SYS_CK,
+-				       CSR_2L_PXP_TXPLL_CHP_IBIAS, 0x2d);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
+-				     CSR_2L_PXP_TXPLL_REFIN_DIV);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
+-				       CSR_2L_PXP_TXPLL_VCO_CFIX, 0x3);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
+-	airoha_phy_pma0_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_SDM_PCW,
+-				     PCIE_FORCE_DA_PXP_TXPLL_SDM_PCW,
+-				     0xc800000);
+-	airoha_phy_pma1_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_SDM_PCW,
+-				     PCIE_FORCE_DA_PXP_TXPLL_SDM_PCW,
+-				     0xc800000);
+-
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SDM_DI_LS,
+-				     CSR_2L_PXP_TXPLL_SDM_IFM);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC,
+-				     CSR_2L_PXP_TXPLL_SSC_PHASE_INI);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
+-				       CSR_2L_PXP_TXPLL_RST_DLY, 0x4);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SDM_DI_LS,
+-				     CSR_2L_PXP_TXPLL_SDM_DI_LS);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_SDM_DI_LS,
+-				       CSR_2L_PXP_TXPLL_SDM_ORD, 0x3);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_KBAND_VREF,
+-				     CSR_2L_PXP_TXPLL_VCO_KBAND_MEAS_EN);
+-	writel(0x0, pcie_phy->csr_2l + REG_CSR_2L_TXPLL_SSC_DELTA1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
+-				       CSR_2L_PXP_TXPLL_LPF_BP, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
+-				       CSR_2L_PXP_TXPLL_LPF_BC, 0x18);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
+-				       CSR_2L_PXP_TXPLL_LPF_BR, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
+-				       CSR_2L_PXP_TXPLL_CHP_IOFST, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_750M_SYS_CK,
+-				       CSR_2L_PXP_TXPLL_CHP_IBIAS, 0x2d);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_VTP,
+-				       CSR_2L_PXP_TXPLL_SPARE_L, 0x1);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_LPF_BWR,
+-				     CSR_2L_PXP_TXPLL_LPF_BWC);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV,
+-				     CSR_2L_PXP_TXPLL_MMD_PREDIV_MODE);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
+-				     CSR_2L_PXP_TXPLL_REFIN_DIV);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
+-				   CSR_2L_PXP_TXPLL_VCO_HALFLSB_EN);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_VCO_SCAPWR,
+-				       CSR_2L_PXP_TXPLL_VCO_SCAPWR, 0x7);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
+-				       CSR_2L_PXP_TXPLL_VCO_CFIX, 0x3);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
+-
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC,
+-				     CSR_2L_PXP_TXPLL_SSC_PHASE_INI);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_LPF_BWR,
+-				     CSR_2L_PXP_TXPLL_LPF_BWR);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_PHY_CK2,
+-				   CSR_2L_PXP_TXPLL_REFIN_INTERNAL);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_KBAND_VREF,
+-				     CSR_2L_PXP_TXPLL_VCO_KBAND_MEAS_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_VTP,
+-				     CSR_2L_PXP_TXPLL_VTP_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV,
+-				     CSR_2L_PXP_TXPLL_PHY_CK1_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_PHY_CK2,
+-				   CSR_2L_PXP_TXPLL_REFIN_INTERNAL);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC,
+-				     CSR_2L_PXP_TXPLL_SSC_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_750M_SYS_CK,
+-				     CSR_2L_PXP_TXPLL_LPF_SHCK_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV,
+-				     CSR_2L_PXP_TXPLL_POSTDIV_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
+-				     CSR_2L_PXP_TXPLL_KBAND_KFC);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
+-				       CSR_2L_PXP_TXPLL_KBAND_KF, 0x3);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
+-				       CSR_2L_PXP_txpll_KBAND_KS, 0x1);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
+-				       CSR_2L_PXP_TXPLL_KBAND_DIV, 0x4);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_LPF_BWR,
+-				       CSR_2L_PXP_TXPLL_KBAND_CODE, 0xe4);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_SDM_OUT,
+-				   CSR_2L_PXP_TXPLL_TCL_AMP_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_AMP_VREF,
+-				   CSR_2L_PXP_TXPLL_TCL_LPF_EN);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_TXPLL_TCL_KBAND_VREF,
+-				       CSR_2L_PXP_TXPLL_TCL_KBAND_VREF, 0xf);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_SDM_OUT,
+-				       CSR_2L_PXP_TXPLL_TCL_AMP_GAIN, 0x3);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_TXPLL_TCL_AMP_VREF,
+-				       CSR_2L_PXP_TXPLL_TCL_AMP_VREF, 0xb);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
+-				       CSR_2L_PXP_TXPLL_TCL_LPF_BW, 0x3);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_CKOUT_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_TXPLL_CKOUT_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_CKOUT_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_TXPLL_CKOUT_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_TXPLL_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
+-				 PCIE_FORCE_DA_PXP_TXPLL_EN);
+-}
+-
+-static void airoha_pcie_phy_init_ssc_jcpll(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SSC_DELTA1,
+-				       CSR_2L_PXP_JCPLL_SSC_DELTA1, 0x106);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SSC_DELTA1,
+-				       CSR_2L_PXP_JCPLL_SSC_DELTA, 0x106);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SSC_PERIOD,
+-				       CSR_2L_PXP_JCPLL_SSC_PERIOD, 0x31b);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
+-				   CSR_2L_PXP_JCPLL_SSC_PHASE_INI);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
+-				   CSR_2L_PXP_JCPLL_SSC_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SDM_IFM,
+-				   CSR_2L_PXP_JCPLL_SDM_IFM);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
+-				   CSR_2L_PXP_JCPLL_SDM_HREN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
+-				     CSR_2L_PXP_JCPLL_SDM_DI_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
+-				   CSR_2L_PXP_JCPLL_SSC_TRI_EN);
+-}
+-
+-static void
+-airoha_pcie_phy_set_rxlan0_signal_detect(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR0_PR_COR_HBW,
+-				   CSR_2L_PXP_CDR0_PR_LDO_FORCE_ON);
+-
+-	usleep_range(100, 200);
+-
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_19,
+-				     PCIE_PCP_RX_REV0_PCIE_GEN1, 0x18b0);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
+-				     PCIE_PCP_RX_REV0_PCIE_GEN2, 0x18b0);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
+-				     PCIE_PCP_RX_REV0_PCIE_GEN3, 0x1030);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_SIGDET_DCTEST,
+-				       CSR_2L_PXP_RX0_SIGDET_PEAK, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_SIGDET_VTH_SEL,
+-				       CSR_2L_PXP_RX0_SIGDET_VTH_SEL, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_REV0,
+-				       CSR_2L_PXP_VOS_PNINV, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_SIGDET_DCTEST,
+-				       CSR_2L_PXP_RX0_SIGDET_LPF_CTRL, 0x1);
+-
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_CAL2,
+-				     PCIE_CAL_OUT_OS, 0x0);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_PXP_RX0_FE_VB_EQ2,
+-				   CSR_2L_PXP_RX0_FE_VCM_GEN_PWDB);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
+-				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
+-	airoha_phy_pma0_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
+-				     PCIE_FORCE_DA_PXP_RX_FE_GAIN_CTRL, 0x3);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_RX_FORCE_MODE0,
+-				     PCIE_FORCE_DA_XPON_RX_FE_GAIN_CTRL, 0x1);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_SIGDET0,
+-				     PCIE_SIGDET_WIN_NONVLD_TIMES, 0x3);
+-	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SEQUENCE_DISB_CTRL1,
+-				   PCIE_DISB_RX_SDCAL_EN);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
+-				 PCIE_FORCE_RX_SDCAL_EN);
+-	usleep_range(150, 200);
+-	airoha_phy_pma0_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
+-				   PCIE_FORCE_RX_SDCAL_EN);
+-}
+-
+-static void
+-airoha_pcie_phy_set_rxlan1_signal_detect(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR1_PR_COR_HBW,
+-				   CSR_2L_PXP_CDR1_PR_LDO_FORCE_ON);
+-
+-	usleep_range(100, 200);
+-
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_19,
+-				     PCIE_PCP_RX_REV0_PCIE_GEN1, 0x18b0);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
+-				     PCIE_PCP_RX_REV0_PCIE_GEN2, 0x18b0);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
+-				     PCIE_PCP_RX_REV0_PCIE_GEN3, 0x1030);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_SIGDET_NOVTH,
+-				       CSR_2L_PXP_RX1_SIGDET_PEAK, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_SIGDET_NOVTH,
+-				       CSR_2L_PXP_RX1_SIGDET_VTH_SEL, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_REV0,
+-				       CSR_2L_PXP_VOS_PNINV, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_DAC_RANGE_EYE,
+-				       CSR_2L_PXP_RX1_SIGDET_LPF_CTRL, 0x1);
+-
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_CAL2,
+-				     PCIE_CAL_OUT_OS, 0x0);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX1_FE_VB_EQ1,
+-				   CSR_2L_PXP_RX1_FE_VCM_GEN_PWDB);
+-
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
+-				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
+-	airoha_phy_pma1_update_field(pcie_phy,
+-				     REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
+-				     PCIE_FORCE_DA_PXP_RX_FE_GAIN_CTRL, 0x3);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_RX_FORCE_MODE0,
+-				     PCIE_FORCE_DA_XPON_RX_FE_GAIN_CTRL, 0x1);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_SIGDET0,
+-				     PCIE_SIGDET_WIN_NONVLD_TIMES, 0x3);
+-	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_SEQUENCE_DISB_CTRL1,
+-				   PCIE_DISB_RX_SDCAL_EN);
+-
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
+-				 PCIE_FORCE_RX_SDCAL_EN);
+-	usleep_range(150, 200);
+-	airoha_phy_pma1_clear_bits(pcie_phy,
+-				   REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
+-				   PCIE_FORCE_RX_SDCAL_EN);
+-}
+-
+-static void airoha_pcie_phy_set_rxflow(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_RX_SCAN_RST,
+-				 PCIE_FORCE_DA_PXP_RX_SIGDET_PWDB |
+-				 PCIE_FORCE_SEL_DA_PXP_RX_SIGDET_PWDB);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_RX_SCAN_RST,
+-				 PCIE_FORCE_DA_PXP_RX_SIGDET_PWDB |
+-				 PCIE_FORCE_SEL_DA_PXP_RX_SIGDET_PWDB);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PD_PWDB,
+-				 PCIE_FORCE_DA_PXP_CDR_PD_PWDB |
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PD_PWDB);
+-	airoha_phy_pma0_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_PWDB,
+-				 PCIE_FORCE_DA_PXP_RX_FE_PWDB |
+-				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PD_PWDB,
+-				 PCIE_FORCE_DA_PXP_CDR_PD_PWDB |
+-				 PCIE_FORCE_SEL_DA_PXP_CDR_PD_PWDB);
+-	airoha_phy_pma1_set_bits(pcie_phy,
+-				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_PWDB,
+-				 PCIE_FORCE_DA_PXP_RX_FE_PWDB |
+-				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX0_PHYCK_DIV,
+-				   CSR_2L_PXP_RX0_PHYCK_RSTB |
+-				   CSR_2L_PXP_RX0_TDC_CK_SEL);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX1_PHYCK_DIV,
+-				   CSR_2L_PXP_RX1_PHYCK_RSTB |
+-				   CSR_2L_PXP_RX1_TDC_CK_SEL);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
+-				 PCIE_SW_RX_FIFO_RST | PCIE_SW_TX_RST |
+-				 PCIE_SW_PMA_RST | PCIE_SW_ALLPCS_RST |
+-				 PCIE_SW_TX_FIFO_RST);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
+-				 PCIE_SW_RX_FIFO_RST | PCIE_SW_TX_RST |
+-				 PCIE_SW_PMA_RST | PCIE_SW_ALLPCS_RST |
+-				 PCIE_SW_TX_FIFO_RST);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_PXP_RX0_FE_VB_EQ2,
+-				   CSR_2L_PXP_RX0_FE_VB_EQ2_EN |
+-				   CSR_2L_PXP_RX0_FE_VB_EQ3_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX0_SIGDET_VTH_SEL,
+-				   CSR_2L_PXP_RX0_FE_VB_EQ1_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX1_FE_VB_EQ1,
+-				   CSR_2L_PXP_RX1_FE_VB_EQ1_EN |
+-				   CSR_2L_PXP_RX1_FE_VB_EQ2_EN |
+-				   CSR_2L_PXP_RX1_FE_VB_EQ3_EN);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_REV0,
+-				       CSR_2L_PXP_FE_GAIN_NORMAL_MODE, 0x4);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_REV0,
+-				       CSR_2L_PXP_FE_GAIN_TRAIN_MODE, 0x4);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_REV0,
+-				       CSR_2L_PXP_FE_GAIN_NORMAL_MODE, 0x4);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_REV0,
+-				       CSR_2L_PXP_FE_GAIN_TRAIN_MODE, 0x4);
+-}
+-
+-static void airoha_pcie_phy_set_pr(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_VREG_IBAND,
+-				       CSR_2L_PXP_CDR0_PR_VREG_IBAND, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_VREG_IBAND,
+-				       CSR_2L_PXP_CDR0_PR_VREG_CKBUF, 0x5);
+-
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_CKREF_DIV,
+-				     CSR_2L_PXP_CDR0_PR_CKREF_DIV);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_COR_HBW,
+-				     CSR_2L_PXP_CDR0_PR_CKREF_DIV1);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_CDR1_PR_VREG_IBAND_VAL,
+-				       CSR_2L_PXP_CDR1_PR_VREG_IBAND, 0x5);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_CDR1_PR_VREG_IBAND_VAL,
+-				       CSR_2L_PXP_CDR1_PR_VREG_CKBUF, 0x5);
+-
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_CKREF_DIV,
+-				     CSR_2L_PXP_CDR1_PR_CKREF_DIV);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_COR_HBW,
+-				     CSR_2L_PXP_CDR1_PR_CKREF_DIV1);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_LPF_RATIO,
+-				       CSR_2L_PXP_CDR0_LPF_TOP_LIM, 0x20000);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_LPF_RATIO,
+-				       CSR_2L_PXP_CDR1_LPF_TOP_LIM, 0x20000);
+-
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_BETA_DAC,
+-				       CSR_2L_PXP_CDR0_PR_BETA_SEL, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_PR_BETA_DAC,
+-				       CSR_2L_PXP_CDR1_PR_BETA_SEL, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_BETA_DAC,
+-				       CSR_2L_PXP_CDR0_PR_KBAND_DIV, 0x4);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_PR_BETA_DAC,
+-				       CSR_2L_PXP_CDR1_PR_KBAND_DIV, 0x4);
+-}
+-
+-static void airoha_pcie_phy_set_txflow(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX0_CKLDO,
+-				   CSR_2L_PXP_TX0_CKLDO_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX1_CKLDO,
+-				   CSR_2L_PXP_TX1_CKLDO_EN);
+-
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX0_CKLDO,
+-				   CSR_2L_PXP_TX0_DMEDGEGEN_EN);
+-	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX1_CKLDO,
+-				   CSR_2L_PXP_TX1_DMEDGEGEN_EN);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TX1_MULTLANE,
+-				     CSR_2L_PXP_TX1_MULTLANE_EN);
+-}
+-
+-static void airoha_pcie_phy_set_rx_mode(struct airoha_pcie_phy *pcie_phy)
+-{
+-	writel(0x804000, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_27);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
+-				     PCIE_PXP_RX_VTH_SEL_PCIE_G1, 0x5);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
+-				     PCIE_PXP_RX_VTH_SEL_PCIE_G2, 0x5);
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
+-				     PCIE_PXP_RX_VTH_SEL_PCIE_G3, 0x5);
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_30,
+-				 0x77700);
+-
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_MONCK,
+-				     CSR_2L_PXP_CDR0_PR_MONCK_ENABLE);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_MONCK,
+-				       CSR_2L_PXP_CDR0_PR_RESERVE0, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_PXP_RX0_OSCAL_CTLE1IOS,
+-				       CSR_2L_PXP_RX0_PR_OSCAL_VGA1IOS, 0x19);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_PXP_RX0_OSCA_VGA1VOS,
+-				       CSR_2L_PXP_RX0_PR_OSCAL_VGA1VOS, 0x19);
+-	airoha_phy_csr_2l_update_field(pcie_phy,
+-				       REG_CSR_2L_PXP_RX0_OSCA_VGA1VOS,
+-				       CSR_2L_PXP_RX0_PR_OSCAL_VGA2IOS, 0x14);
+-
+-	writel(0x804000, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_27);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
+-				     PCIE_PXP_RX_VTH_SEL_PCIE_G1, 0x5);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
+-				     PCIE_PXP_RX_VTH_SEL_PCIE_G2, 0x5);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
+-				     PCIE_PXP_RX_VTH_SEL_PCIE_G3, 0x5);
+-
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_30,
+-				 0x77700);
+-
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_MONCK,
+-				     CSR_2L_PXP_CDR1_PR_MONCK_ENABLE);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_PR_MONCK,
+-				       CSR_2L_PXP_CDR1_PR_RESERVE0, 0x2);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_OSCAL_VGA1IOS,
+-				       CSR_2L_PXP_RX1_PR_OSCAL_VGA1IOS, 0x19);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_OSCAL_VGA1IOS,
+-				       CSR_2L_PXP_RX1_PR_OSCAL_VGA1VOS, 0x19);
+-	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_OSCAL_VGA1IOS,
+-				       CSR_2L_PXP_RX1_PR_OSCAL_VGA2IOS, 0x14);
+-}
+-
+-static void airoha_pcie_phy_load_kflow(struct airoha_pcie_phy *pcie_phy)
+-{
+-	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
+-				     PCIE_FORCE_PMA_RX_SPEED, 0xa);
+-	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
+-				     PCIE_FORCE_PMA_RX_SPEED, 0xa);
+-	airoha_phy_init_lane0_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN3);
+-	airoha_phy_init_lane1_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN3);
+-
+-	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
+-				   PCIE_FORCE_PMA_RX_SPEED);
+-	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
+-				   PCIE_FORCE_PMA_RX_SPEED);
+-	usleep_range(100, 200);
+-
+-	airoha_phy_init_lane0_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN2);
+-	airoha_phy_init_lane1_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN2);
+-}
+-
+-/**
+- * airoha_pcie_phy_init() - Initialize the phy
+- * @phy: the phy to be initialized
+- *
+- * Initialize the phy registers.
+- * The hardware settings will be reset during suspend, it should be
+- * reinitialized when the consumer calls phy_init() again on resume.
+- */
+-static int airoha_pcie_phy_init(struct phy *phy)
+-{
+-	struct airoha_pcie_phy *pcie_phy = phy_get_drvdata(phy);
+-	u32 val;
+-
+-	/* Setup Tx-Rx detection time */
+-	val = FIELD_PREP(PCIE_XTP_RXDET_VCM_OFF_STB_T_SEL, 0x33) |
+-	      FIELD_PREP(PCIE_XTP_RXDET_EN_STB_T_SEL, 0x1) |
+-	      FIELD_PREP(PCIE_XTP_RXDET_FINISH_STB_T_SEL, 0x2) |
+-	      FIELD_PREP(PCIE_XTP_TXPD_TX_DATA_EN_DLY, 0x3) |
+-	      FIELD_PREP(PCIE_XTP_RXDET_LATCH_STB_T_SEL, 0x1);
+-	writel(val, pcie_phy->p0_xr_dtime + REG_PCIE_PEXTP_DIG_GLB44);
+-	writel(val, pcie_phy->p1_xr_dtime + REG_PCIE_PEXTP_DIG_GLB44);
+-	/* Setup Rx AEQ training time */
+-	val = FIELD_PREP(PCIE_XTP_LN_RX_PDOWN_L1P2_EXIT_WAIT, 0x32) |
+-	      FIELD_PREP(PCIE_XTP_LN_RX_PDOWN_E0_AEQEN_WAIT, 0x5050);
+-	writel(val, pcie_phy->rx_aeq + REG_PCIE_PEXTP_DIG_LN_RX30_P0);
+-	writel(val, pcie_phy->rx_aeq + REG_PCIE_PEXTP_DIG_LN_RX30_P1);
+-
+-	/* enable load FLL-K flow */
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_14,
+-				 PCIE_FLL_LOAD_EN);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_14,
+-				 PCIE_FLL_LOAD_EN);
+-
+-	airoha_pcie_phy_init_default(pcie_phy);
+-	airoha_pcie_phy_init_clk_out(pcie_phy);
+-	airoha_pcie_phy_init_csr_2l(pcie_phy);
+-
+-	usleep_range(100, 200);
+-
+-	airoha_pcie_phy_init_rx(pcie_phy);
+-	/* phase 1, no ssc for K TXPLL */
+-	airoha_pcie_phy_init_jcpll(pcie_phy);
+-
+-	usleep_range(500, 600);
+-
+-	/* TX PLL settings */
+-	airoha_pcie_phy_txpll(pcie_phy);
+-
+-	usleep_range(200, 300);
+-
+-	/* SSC JCPLL setting */
+-	airoha_pcie_phy_init_ssc_jcpll(pcie_phy);
+-
+-	usleep_range(100, 200);
+-
+-	/* Rx lan0 signal detect */
+-	airoha_pcie_phy_set_rxlan0_signal_detect(pcie_phy);
+-	/* Rx lan1 signal detect */
+-	airoha_pcie_phy_set_rxlan1_signal_detect(pcie_phy);
+-	/* RX FLOW */
+-	airoha_pcie_phy_set_rxflow(pcie_phy);
+-
+-	usleep_range(100, 200);
+-
+-	airoha_pcie_phy_set_pr(pcie_phy);
+-	/* TX FLOW */
+-	airoha_pcie_phy_set_txflow(pcie_phy);
+-
+-	usleep_range(100, 200);
+-	/* RX mode setting */
+-	airoha_pcie_phy_set_rx_mode(pcie_phy);
+-	/* Load K-Flow */
+-	airoha_pcie_phy_load_kflow(pcie_phy);
+-	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
+-				   PCIE_DA_XPON_CDR_PR_PWDB);
+-	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
+-				   PCIE_DA_XPON_CDR_PR_PWDB);
+-
+-	usleep_range(100, 200);
+-
+-	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
+-				 PCIE_DA_XPON_CDR_PR_PWDB);
+-	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
+-				 PCIE_DA_XPON_CDR_PR_PWDB);
+-
+-	/* Wait for the PCIe PHY to complete initialization before returning */
+-	msleep(PHY_HW_INIT_TIME_MS);
+-
+-	return 0;
+-}
+-
+-static int airoha_pcie_phy_exit(struct phy *phy)
+-{
+-	struct airoha_pcie_phy *pcie_phy = phy_get_drvdata(phy);
+-
+-	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
+-				   PCIE_PMA_SW_RST);
+-	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
+-				   PCIE_PMA_SW_RST);
+-	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
+-				     CSR_2L_PXP_JCPLL_SSC_PHASE_INI |
+-				     CSR_2L_PXP_JCPLL_SSC_TRI_EN |
+-				     CSR_2L_PXP_JCPLL_SSC_EN);
+-
+-	return 0;
+-}
+-
+-static const struct phy_ops airoha_pcie_phy_ops = {
+-	.init = airoha_pcie_phy_init,
+-	.exit = airoha_pcie_phy_exit,
+-	.owner = THIS_MODULE,
+-};
+-
+-static int airoha_pcie_phy_probe(struct platform_device *pdev)
+-{
+-	struct airoha_pcie_phy *pcie_phy;
+-	struct device *dev = &pdev->dev;
+-	struct phy_provider *provider;
+-
+-	pcie_phy = devm_kzalloc(dev, sizeof(*pcie_phy), GFP_KERNEL);
+-	if (!pcie_phy)
+-		return -ENOMEM;
+-
+-	pcie_phy->csr_2l = devm_platform_ioremap_resource_byname(pdev, "csr-2l");
+-	if (IS_ERR(pcie_phy->csr_2l))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->csr_2l),
+-				     "Failed to map phy-csr-2l base\n");
+-
+-	pcie_phy->pma0 = devm_platform_ioremap_resource_byname(pdev, "pma0");
+-	if (IS_ERR(pcie_phy->pma0))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->pma0),
+-				     "Failed to map phy-pma0 base\n");
+-
+-	pcie_phy->pma1 = devm_platform_ioremap_resource_byname(pdev, "pma1");
+-	if (IS_ERR(pcie_phy->pma1))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->pma1),
+-				     "Failed to map phy-pma1 base\n");
+-
+-	pcie_phy->phy = devm_phy_create(dev, dev->of_node, &airoha_pcie_phy_ops);
+-	if (IS_ERR(pcie_phy->phy))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->phy),
+-				     "Failed to create PCIe phy\n");
+-
+-	pcie_phy->p0_xr_dtime =
+-		devm_platform_ioremap_resource_byname(pdev, "p0-xr-dtime");
+-	if (IS_ERR(pcie_phy->p0_xr_dtime))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->p0_xr_dtime),
+-				     "Failed to map P0 Tx-Rx dtime base\n");
+-
+-	pcie_phy->p1_xr_dtime =
+-		devm_platform_ioremap_resource_byname(pdev, "p1-xr-dtime");
+-	if (IS_ERR(pcie_phy->p1_xr_dtime))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->p1_xr_dtime),
+-				     "Failed to map P1 Tx-Rx dtime base\n");
+-
+-	pcie_phy->rx_aeq = devm_platform_ioremap_resource_byname(pdev, "rx-aeq");
+-	if (IS_ERR(pcie_phy->rx_aeq))
+-		return dev_err_probe(dev, PTR_ERR(pcie_phy->rx_aeq),
+-				     "Failed to map Rx AEQ base\n");
+-
+-	pcie_phy->dev = dev;
+-	phy_set_drvdata(pcie_phy->phy, pcie_phy);
+-
+-	provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);
+-	if (IS_ERR(provider))
+-		return dev_err_probe(dev, PTR_ERR(provider),
+-				     "PCIe phy probe failed\n");
+-
+-	return 0;
+-}
+-
+-static const struct of_device_id airoha_pcie_phy_of_match[] = {
+-	{ .compatible = "airoha,en7581-pcie-phy" },
+-	{ /* sentinel */ }
+-};
+-MODULE_DEVICE_TABLE(of, airoha_pcie_phy_of_match);
+-
+-static struct platform_driver airoha_pcie_phy_driver = {
+-	.probe	= airoha_pcie_phy_probe,
+-	.driver	= {
 -		.name = "airoha-pcie-phy",
-+		.name = "airoha-en7581-pcie-phy",
- 		.of_match_table = airoha_pcie_phy_of_match,
- 	},
- };
- module_platform_driver(airoha_pcie_phy_driver);
- 
+-		.of_match_table = airoha_pcie_phy_of_match,
+-	},
+-};
+-module_platform_driver(airoha_pcie_phy_driver);
+-
 -MODULE_DESCRIPTION("Airoha PCIe PHY driver");
+-MODULE_AUTHOR("Lorenzo Bianconi <lorenzo@kernel.org>");
+-MODULE_LICENSE("GPL");
+--- /dev/null
++++ b/drivers/phy/airoha/phy-airoha-en7581-pcie.c
+@@ -0,0 +1,1290 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2024 AIROHA Inc
++ * Author: Lorenzo Bianconi <lorenzo@kernel.org>
++ */
++
++#include <linux/bitfield.h>
++#include <linux/delay.h>
++#include <linux/io.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/phy/phy.h>
++#include <linux/platform_device.h>
++#include <linux/slab.h>
++
++#include "phy-airoha-en7581-pcie-regs.h"
++
++#define LEQ_LEN_CTRL_MAX_VAL	7
++#define FREQ_LOCK_MAX_ATTEMPT	10
++
++/* PCIe-PHY initialization time in ms needed by the hw to complete */
++#define PHY_HW_INIT_TIME_MS	30
++
++enum airoha_pcie_port_gen {
++	PCIE_PORT_GEN1 = 1,
++	PCIE_PORT_GEN2,
++	PCIE_PORT_GEN3,
++};
++
++/**
++ * struct airoha_pcie_phy - PCIe phy driver main structure
++ * @dev: pointer to device
++ * @phy: pointer to generic phy
++ * @csr_2l: Analogic lane IO mapped register base address
++ * @pma0: IO mapped register base address of PMA0-PCIe
++ * @pma1: IO mapped register base address of PMA1-PCIe
++ * @p0_xr_dtime: IO mapped register base address of port0 Tx-Rx detection time
++ * @p1_xr_dtime: IO mapped register base address of port1 Tx-Rx detection time
++ * @rx_aeq: IO mapped register base address of Rx AEQ training
++ */
++struct airoha_pcie_phy {
++	struct device *dev;
++	struct phy *phy;
++	void __iomem *csr_2l;
++	void __iomem *pma0;
++	void __iomem *pma1;
++	void __iomem *p0_xr_dtime;
++	void __iomem *p1_xr_dtime;
++	void __iomem *rx_aeq;
++};
++
++static void airoha_phy_clear_bits(void __iomem *reg, u32 mask)
++{
++	u32 val = readl(reg) & ~mask;
++
++	writel(val, reg);
++}
++
++static void airoha_phy_set_bits(void __iomem *reg, u32 mask)
++{
++	u32 val = readl(reg) | mask;
++
++	writel(val, reg);
++}
++
++static void airoha_phy_update_bits(void __iomem *reg, u32 mask, u32 val)
++{
++	u32 tmp = readl(reg);
++
++	tmp &= ~mask;
++	tmp |= val & mask;
++	writel(tmp, reg);
++}
++
++#define airoha_phy_update_field(reg, mask, val)					\
++	do {									\
++		BUILD_BUG_ON_MSG(!__builtin_constant_p((mask)),			\
++				 "mask is not constant");			\
++		airoha_phy_update_bits((reg), (mask),				\
++				       FIELD_PREP((mask), (val)));		\
++	} while (0)
++
++#define airoha_phy_csr_2l_clear_bits(pcie_phy, reg, mask)			\
++	airoha_phy_clear_bits((pcie_phy)->csr_2l + (reg), (mask))
++#define airoha_phy_csr_2l_set_bits(pcie_phy, reg, mask)				\
++	airoha_phy_set_bits((pcie_phy)->csr_2l + (reg), (mask))
++#define airoha_phy_csr_2l_update_field(pcie_phy, reg, mask, val)		\
++	airoha_phy_update_field((pcie_phy)->csr_2l + (reg), (mask), (val))
++#define airoha_phy_pma0_clear_bits(pcie_phy, reg, mask)				\
++	airoha_phy_clear_bits((pcie_phy)->pma0 + (reg), (mask))
++#define airoha_phy_pma1_clear_bits(pcie_phy, reg, mask)				\
++	airoha_phy_clear_bits((pcie_phy)->pma1 + (reg), (mask))
++#define airoha_phy_pma0_set_bits(pcie_phy, reg, mask)				\
++	airoha_phy_set_bits((pcie_phy)->pma0 + (reg), (mask))
++#define airoha_phy_pma1_set_bits(pcie_phy, reg, mask)				\
++	airoha_phy_set_bits((pcie_phy)->pma1 + (reg), (mask))
++#define airoha_phy_pma0_update_field(pcie_phy, reg, mask, val)			\
++	airoha_phy_update_field((pcie_phy)->pma0 + (reg), (mask), (val))
++#define airoha_phy_pma1_update_field(pcie_phy, reg, mask, val)			\
++	airoha_phy_update_field((pcie_phy)->pma1 + (reg), (mask), (val))
++
++static void
++airoha_phy_init_lane0_rx_fw_pre_calib(struct airoha_pcie_phy *pcie_phy,
++				      enum airoha_pcie_port_gen gen)
++{
++	u32 fl_out_target = gen == PCIE_PORT_GEN3 ? 41600 : 41941;
++	u32 lock_cyclecnt = gen == PCIE_PORT_GEN3 ? 26000 : 32767;
++	u32 pr_idac, val, cdr_pr_idac_tmp = 0;
++	int i;
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_SS_LCPLL_PWCTL_SETTING_1,
++				 PCIE_LCPLL_MAN_PWDB);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
++				     PCIE_LOCK_TARGET_BEG,
++				     fl_out_target - 100);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
++				     PCIE_LOCK_TARGET_END,
++				     fl_out_target + 100);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
++				     PCIE_PLL_FT_LOCK_CYCLECNT, lock_cyclecnt);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
++				     PCIE_LOCK_LOCKTH, 0x3);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
++				     PCIE_UNLOCK_TARGET_BEG,
++				     fl_out_target - 100);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
++				     PCIE_UNLOCK_TARGET_END,
++				     fl_out_target + 100);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
++				     PCIE_PLL_FT_UNLOCK_CYCLECNT,
++				     lock_cyclecnt);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
++				     PCIE_UNLOCK_LOCKTH, 0x3);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR0_PR_INJ_MODE,
++				   CSR_2L_PXP_CDR0_INJ_FORCE_OFF);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				 PCIE_FORCE_DA_PXP_CDR_PR_LPF_R_EN);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				   PCIE_FORCE_DA_PXP_CDR_PR_LPF_C_EN);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				   PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				 PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
++
++	for (i = 0; i < LEQ_LEN_CTRL_MAX_VAL; i++) {
++		airoha_phy_pma0_update_field(pcie_phy,
++				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, i << 8);
++		airoha_phy_pma0_clear_bits(pcie_phy,
++					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					   PCIE_FREQLOCK_DET_EN);
++		airoha_phy_pma0_update_field(pcie_phy,
++					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					     PCIE_FREQLOCK_DET_EN, 0x3);
++
++		usleep_range(10000, 15000);
++
++		val = FIELD_GET(PCIE_RO_FL_OUT,
++				readl(pcie_phy->pma0 +
++				      REG_PCIE_PMA_RO_RX_FREQDET));
++		if (val > fl_out_target)
++			cdr_pr_idac_tmp = i << 8;
++	}
++
++	for (i = LEQ_LEN_CTRL_MAX_VAL; i >= 0; i--) {
++		pr_idac = cdr_pr_idac_tmp | (0x1 << i);
++		airoha_phy_pma0_update_field(pcie_phy,
++				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, pr_idac);
++		airoha_phy_pma0_clear_bits(pcie_phy,
++					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					   PCIE_FREQLOCK_DET_EN);
++		airoha_phy_pma0_update_field(pcie_phy,
++					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					     PCIE_FREQLOCK_DET_EN, 0x3);
++
++		usleep_range(10000, 15000);
++
++		val = FIELD_GET(PCIE_RO_FL_OUT,
++				readl(pcie_phy->pma0 +
++				      REG_PCIE_PMA_RO_RX_FREQDET));
++		if (val < fl_out_target)
++			pr_idac &= ~(0x1 << i);
++
++		cdr_pr_idac_tmp = pr_idac;
++	}
++
++	airoha_phy_pma0_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				     PCIE_FORCE_DA_PXP_CDR_PR_IDAC,
++				     cdr_pr_idac_tmp);
++
++	for (i = 0; i < FREQ_LOCK_MAX_ATTEMPT; i++) {
++		u32 val;
++
++		airoha_phy_pma0_clear_bits(pcie_phy,
++					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					   PCIE_FREQLOCK_DET_EN);
++		airoha_phy_pma0_update_field(pcie_phy,
++					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					     PCIE_FREQLOCK_DET_EN, 0x3);
++
++		usleep_range(10000, 15000);
++
++		val = readl(pcie_phy->pma0 + REG_PCIE_PMA_RO_RX_FREQDET);
++		if (val & PCIE_RO_FBCK_LOCK)
++			break;
++	}
++
++	/* turn off force mode and update band values */
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_INJ_MODE,
++				     CSR_2L_PXP_CDR0_INJ_FORCE_OFF);
++
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
++	if (gen == PCIE_PORT_GEN3) {
++		airoha_phy_pma0_update_field(pcie_phy,
++					     REG_PCIE_PMA_DIG_RESERVE_14,
++					     PCIE_FLL_IDAC_PCIEG3,
++					     cdr_pr_idac_tmp);
++	} else {
++		airoha_phy_pma0_update_field(pcie_phy,
++					     REG_PCIE_PMA_DIG_RESERVE_13,
++					     PCIE_FLL_IDAC_PCIEG1,
++					     cdr_pr_idac_tmp);
++		airoha_phy_pma0_update_field(pcie_phy,
++					     REG_PCIE_PMA_DIG_RESERVE_13,
++					     PCIE_FLL_IDAC_PCIEG2,
++					     cdr_pr_idac_tmp);
++	}
++}
++
++static void
++airoha_phy_init_lane1_rx_fw_pre_calib(struct airoha_pcie_phy *pcie_phy,
++				      enum airoha_pcie_port_gen gen)
++{
++	u32 fl_out_target = gen == PCIE_PORT_GEN3 ? 41600 : 41941;
++	u32 lock_cyclecnt = gen == PCIE_PORT_GEN3 ? 26000 : 32767;
++	u32 pr_idac, val, cdr_pr_idac_tmp = 0;
++	int i;
++
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_SS_LCPLL_PWCTL_SETTING_1,
++				 PCIE_LCPLL_MAN_PWDB);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
++				     PCIE_LOCK_TARGET_BEG,
++				     fl_out_target - 100);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET2,
++				     PCIE_LOCK_TARGET_END,
++				     fl_out_target + 100);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
++				     PCIE_PLL_FT_LOCK_CYCLECNT, lock_cyclecnt);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
++				     PCIE_LOCK_LOCKTH, 0x3);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
++				     PCIE_UNLOCK_TARGET_BEG,
++				     fl_out_target - 100);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET3,
++				     PCIE_UNLOCK_TARGET_END,
++				     fl_out_target + 100);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET1,
++				     PCIE_PLL_FT_UNLOCK_CYCLECNT,
++				     lock_cyclecnt);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_FREQ_DET4,
++				     PCIE_UNLOCK_LOCKTH, 0x3);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR1_PR_INJ_MODE,
++				   CSR_2L_PXP_CDR1_INJ_FORCE_OFF);
++
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				 PCIE_FORCE_DA_PXP_CDR_PR_LPF_R_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				   PCIE_FORCE_DA_PXP_CDR_PR_LPF_C_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				   PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				 PCIE_FORCE_DA_PXP_CDR_PR_PWDB);
++
++	for (i = 0; i < LEQ_LEN_CTRL_MAX_VAL; i++) {
++		airoha_phy_pma1_update_field(pcie_phy,
++				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, i << 8);
++		airoha_phy_pma1_clear_bits(pcie_phy,
++					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					   PCIE_FREQLOCK_DET_EN);
++		airoha_phy_pma1_update_field(pcie_phy,
++					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					     PCIE_FREQLOCK_DET_EN, 0x3);
++
++		usleep_range(10000, 15000);
++
++		val = FIELD_GET(PCIE_RO_FL_OUT,
++				readl(pcie_phy->pma1 +
++				      REG_PCIE_PMA_RO_RX_FREQDET));
++		if (val > fl_out_target)
++			cdr_pr_idac_tmp = i << 8;
++	}
++
++	for (i = LEQ_LEN_CTRL_MAX_VAL; i >= 0; i--) {
++		pr_idac = cdr_pr_idac_tmp | (0x1 << i);
++		airoha_phy_pma1_update_field(pcie_phy,
++				REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				PCIE_FORCE_DA_PXP_CDR_PR_IDAC, pr_idac);
++		airoha_phy_pma1_clear_bits(pcie_phy,
++					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					   PCIE_FREQLOCK_DET_EN);
++		airoha_phy_pma1_update_field(pcie_phy,
++					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					     PCIE_FREQLOCK_DET_EN, 0x3);
++
++		usleep_range(10000, 15000);
++
++		val = FIELD_GET(PCIE_RO_FL_OUT,
++				readl(pcie_phy->pma1 +
++				      REG_PCIE_PMA_RO_RX_FREQDET));
++		if (val < fl_out_target)
++			pr_idac &= ~(0x1 << i);
++
++		cdr_pr_idac_tmp = pr_idac;
++	}
++
++	airoha_phy_pma1_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				     PCIE_FORCE_DA_PXP_CDR_PR_IDAC,
++				     cdr_pr_idac_tmp);
++
++	for (i = 0; i < FREQ_LOCK_MAX_ATTEMPT; i++) {
++		u32 val;
++
++		airoha_phy_pma1_clear_bits(pcie_phy,
++					   REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					   PCIE_FREQLOCK_DET_EN);
++		airoha_phy_pma1_update_field(pcie_phy,
++					     REG_PCIE_PMA_SS_RX_FREQ_DET4,
++					     PCIE_FREQLOCK_DET_EN, 0x3);
++
++		usleep_range(10000, 15000);
++
++		val = readl(pcie_phy->pma1 + REG_PCIE_PMA_RO_RX_FREQDET);
++		if (val & PCIE_RO_FBCK_LOCK)
++			break;
++	}
++
++	/* turn off force mode and update band values */
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_INJ_MODE,
++				     CSR_2L_PXP_CDR1_INJ_FORCE_OFF);
++
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				   PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC);
++	if (gen == PCIE_PORT_GEN3) {
++		airoha_phy_pma1_update_field(pcie_phy,
++					     REG_PCIE_PMA_DIG_RESERVE_14,
++					     PCIE_FLL_IDAC_PCIEG3,
++					     cdr_pr_idac_tmp);
++	} else {
++		airoha_phy_pma1_update_field(pcie_phy,
++					     REG_PCIE_PMA_DIG_RESERVE_13,
++					     PCIE_FLL_IDAC_PCIEG1,
++					     cdr_pr_idac_tmp);
++		airoha_phy_pma1_update_field(pcie_phy,
++					     REG_PCIE_PMA_DIG_RESERVE_13,
++					     PCIE_FLL_IDAC_PCIEG2,
++					     cdr_pr_idac_tmp);
++	}
++}
++
++static void airoha_pcie_phy_init_default(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CMN,
++				       CSR_2L_PXP_CMN_TRIM_MASK, 0x10);
++	writel(0xcccbcccb, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_21);
++	writel(0xcccb, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_22);
++	writel(0xcccbcccb, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_21);
++	writel(0xcccb, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_22);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CMN,
++				   CSR_2L_PXP_CMN_LANE_EN);
++}
++
++static void airoha_pcie_phy_init_clk_out(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_TXPLL_POSTDIV_D256,
++				       CSR_2L_PXP_CLKTX0_AMP, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_CLKTX0_FORCE_OUT1,
++				       CSR_2L_PXP_CLKTX1_AMP, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_TXPLL_POSTDIV_D256,
++				       CSR_2L_PXP_CLKTX0_OFFSET, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CLKTX1_OFFSET,
++				       CSR_2L_PXP_CLKTX1_OFFSET, 0x2);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CLKTX0_FORCE_OUT1,
++				     CSR_2L_PXP_CLKTX0_HZ);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CLKTX1_OFFSET,
++				     CSR_2L_PXP_CLKTX1_HZ);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_CLKTX0_FORCE_OUT1,
++				       CSR_2L_PXP_CLKTX0_IMP_SEL, 0x12);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CLKTX1_IMP_SEL,
++				       CSR_2L_PXP_CLKTX1_IMP_SEL, 0x12);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV_D256,
++				     CSR_2L_PXP_CLKTX0_SR);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CLKTX1_OFFSET,
++				     CSR_2L_PXP_CLKTX1_SR);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_PLL_CMN_RESERVE0,
++				       CSR_2L_PXP_PLL_RESERVE_MASK, 0xd0d);
++}
++
++static void airoha_pcie_phy_init_csr_2l(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
++				 PCIE_SW_XFI_RXPCS_RST | PCIE_SW_REF_RST |
++				 PCIE_SW_RX_RST);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
++				 PCIE_SW_XFI_RXPCS_RST | PCIE_SW_REF_RST |
++				 PCIE_SW_RX_RST);
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_TX_RESET,
++				 PCIE_TX_TOP_RST | PCIE_TX_CAL_RST);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_TX_RESET,
++				 PCIE_TX_TOP_RST | PCIE_TX_CAL_RST);
++}
++
++static void airoha_pcie_phy_init_rx(struct airoha_pcie_phy *pcie_phy)
++{
++	writel(0x2a00090b, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_17);
++	writel(0x2a00090b, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_17);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR0_PR_MONPI,
++				   CSR_2L_PXP_CDR0_PR_XFICK_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR1_PR_MONPI,
++				   CSR_2L_PXP_CDR1_PR_XFICK_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy,
++				     REG_CSR_2L_CDR0_PD_PICAL_CKD8_INV,
++				     CSR_2L_PXP_CDR0_PD_EDGE_DISABLE);
++	airoha_phy_csr_2l_clear_bits(pcie_phy,
++				     REG_CSR_2L_CDR1_PD_PICAL_CKD8_INV,
++				     CSR_2L_PXP_CDR1_PD_EDGE_DISABLE);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_PHYCK_DIV,
++				       CSR_2L_PXP_RX0_PHYCK_SEL, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_PHYCK_DIV,
++				       CSR_2L_PXP_RX1_PHYCK_SEL, 0x1);
++}
++
++static void airoha_pcie_phy_init_jcpll(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				   PCIE_FORCE_DA_PXP_JCPLL_EN);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				   PCIE_FORCE_DA_PXP_JCPLL_EN);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_TCL_VTP_EN,
++				       CSR_2L_PXP_JCPLL_SPARE_LOW, 0x20);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
++				   CSR_2L_PXP_JCPLL_RST);
++	writel(0x0, pcie_phy->csr_2l + REG_CSR_2L_JCPLL_SSC_DELTA1);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC_PERIOD,
++				     CSR_2L_PXP_JCPLL_SSC_PERIOD);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
++				     CSR_2L_PXP_JCPLL_SSC_PHASE_INI);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
++				     CSR_2L_PXP_JCPLL_SSC_TRI_EN);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
++				       CSR_2L_PXP_JCPLL_LPF_BR, 0xa);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
++				       CSR_2L_PXP_JCPLL_LPF_BP, 0xc);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
++				       CSR_2L_PXP_JCPLL_LPF_BC, 0x1f);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BWC,
++				       CSR_2L_PXP_JCPLL_LPF_BWC, 0x1e);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BR,
++				       CSR_2L_PXP_JCPLL_LPF_BWR, 0xa);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
++				       CSR_2L_PXP_JCPLL_MMD_PREDIV_MODE,
++				       0x1);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, CSR_2L_PXP_JCPLL_MONCK,
++				     CSR_2L_PXP_JCPLL_REFIN_DIV);
++
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_VOS,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_SDM_PCW);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_VOS,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_SDM_PCW);
++	airoha_phy_pma0_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_JCPLL_SDM_PCW,
++				     PCIE_FORCE_DA_PXP_JCPLL_SDM_PCW,
++				     0x50000000);
++	airoha_phy_pma1_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_JCPLL_SDM_PCW,
++				     PCIE_FORCE_DA_PXP_JCPLL_SDM_PCW,
++				     0x50000000);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy,
++				   REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
++				   CSR_2L_PXP_JCPLL_POSTDIV_D5);
++	airoha_phy_csr_2l_set_bits(pcie_phy,
++				   REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
++				   CSR_2L_PXP_JCPLL_POSTDIV_D2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
++				       CSR_2L_PXP_JCPLL_RST_DLY, 0x4);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
++				     CSR_2L_PXP_JCPLL_SDM_DI_LS);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_TCL_KBAND_VREF,
++				     CSR_2L_PXP_JCPLL_VCO_KBAND_MEAS_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_IB_EXT,
++				     CSR_2L_PXP_JCPLL_CHP_IOFST);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_IB_EXT,
++				       CSR_2L_PXP_JCPLL_CHP_IBIAS, 0xc);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_JCPLL_MMD_PREDIV_MODE,
++				       CSR_2L_PXP_JCPLL_MMD_PREDIV_MODE,
++				       0x1);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_VCODIV,
++				   CSR_2L_PXP_JCPLL_VCO_HALFLSB_EN);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_VCODIV,
++				       CSR_2L_PXP_JCPLL_VCO_CFIX, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_VCODIV,
++				       CSR_2L_PXP_JCPLL_VCO_SCAPWR, 0x4);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_IB_EXT,
++				     REG_CSR_2L_JCPLL_LPF_SHCK_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
++				   CSR_2L_PXP_JCPLL_POSTDIV_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
++				     CSR_2L_PXP_JCPLL_KBAND_KFC);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
++				       CSR_2L_PXP_JCPLL_KBAND_KF, 0x3);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_KBAND_KFC,
++				     CSR_2L_PXP_JCPLL_KBAND_KS);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BWC,
++				       CSR_2L_PXP_JCPLL_KBAND_DIV, 0x1);
++
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SCAN_MODE,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_KBAND_LOAD_EN);
++	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SCAN_MODE,
++				   PCIE_FORCE_DA_PXP_JCPLL_KBAND_LOAD_EN);
++
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_LPF_BWC,
++				       CSR_2L_PXP_JCPLL_KBAND_CODE, 0xe4);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
++				   CSR_2L_PXP_JCPLL_TCL_AMP_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_TCL_CMP,
++				   CSR_2L_PXP_JCPLL_TCL_LPF_EN);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_JCPLL_TCL_KBAND_VREF,
++				       CSR_2L_PXP_JCPLL_TCL_KBAND_VREF, 0xf);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
++				       CSR_2L_PXP_JCPLL_TCL_AMP_GAIN, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
++				       CSR_2L_PXP_JCPLL_TCL_AMP_VREF, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_TCL_CMP,
++				       CSR_2L_PXP_JCPLL_TCL_LPF_BW, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_VCO_TCLVAR,
++				       CSR_2L_PXP_JCPLL_VCO_TCLVAR, 0x3);
++
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_CKOUT_EN);
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_JCPLL_CKOUT_EN);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_CKOUT_EN);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_JCPLL_CKOUT_EN);
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_JCPLL_EN);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_JCPLL_EN);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_JCPLL_EN);
++}
++
++static void airoha_pcie_phy_txpll(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				   PCIE_FORCE_DA_PXP_TXPLL_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				   PCIE_FORCE_DA_PXP_TXPLL_EN);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
++				   CSR_2L_PXP_TXPLL_PLL_RSTB);
++	writel(0x0, pcie_phy->csr_2l + REG_CSR_2L_TXPLL_SSC_DELTA1);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC_PERIOD,
++				     CSR_2L_PXP_txpll_SSC_PERIOD);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
++				       CSR_2L_PXP_TXPLL_CHP_IOFST, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_750M_SYS_CK,
++				       CSR_2L_PXP_TXPLL_CHP_IBIAS, 0x2d);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
++				     CSR_2L_PXP_TXPLL_REFIN_DIV);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
++				       CSR_2L_PXP_TXPLL_VCO_CFIX, 0x3);
++
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
++	airoha_phy_pma0_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_SDM_PCW,
++				     PCIE_FORCE_DA_PXP_TXPLL_SDM_PCW,
++				     0xc800000);
++	airoha_phy_pma1_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_SDM_PCW,
++				     PCIE_FORCE_DA_PXP_TXPLL_SDM_PCW,
++				     0xc800000);
++
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SDM_DI_LS,
++				     CSR_2L_PXP_TXPLL_SDM_IFM);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC,
++				     CSR_2L_PXP_TXPLL_SSC_PHASE_INI);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
++				       CSR_2L_PXP_TXPLL_RST_DLY, 0x4);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SDM_DI_LS,
++				     CSR_2L_PXP_TXPLL_SDM_DI_LS);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_SDM_DI_LS,
++				       CSR_2L_PXP_TXPLL_SDM_ORD, 0x3);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_KBAND_VREF,
++				     CSR_2L_PXP_TXPLL_VCO_KBAND_MEAS_EN);
++	writel(0x0, pcie_phy->csr_2l + REG_CSR_2L_TXPLL_SSC_DELTA1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
++				       CSR_2L_PXP_TXPLL_LPF_BP, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
++				       CSR_2L_PXP_TXPLL_LPF_BC, 0x18);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
++				       CSR_2L_PXP_TXPLL_LPF_BR, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_CHP_IOFST,
++				       CSR_2L_PXP_TXPLL_CHP_IOFST, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_750M_SYS_CK,
++				       CSR_2L_PXP_TXPLL_CHP_IBIAS, 0x2d);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_VTP,
++				       CSR_2L_PXP_TXPLL_SPARE_L, 0x1);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_LPF_BWR,
++				     CSR_2L_PXP_TXPLL_LPF_BWC);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV,
++				     CSR_2L_PXP_TXPLL_MMD_PREDIV_MODE);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_REFIN_DIV,
++				     CSR_2L_PXP_TXPLL_REFIN_DIV);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
++				   CSR_2L_PXP_TXPLL_VCO_HALFLSB_EN);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_VCO_SCAPWR,
++				       CSR_2L_PXP_TXPLL_VCO_SCAPWR, 0x7);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
++				       CSR_2L_PXP_TXPLL_VCO_CFIX, 0x3);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW);
++
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC,
++				     CSR_2L_PXP_TXPLL_SSC_PHASE_INI);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_LPF_BWR,
++				     CSR_2L_PXP_TXPLL_LPF_BWR);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_PHY_CK2,
++				   CSR_2L_PXP_TXPLL_REFIN_INTERNAL);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_KBAND_VREF,
++				     CSR_2L_PXP_TXPLL_VCO_KBAND_MEAS_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_VTP,
++				     CSR_2L_PXP_TXPLL_VTP_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV,
++				     CSR_2L_PXP_TXPLL_PHY_CK1_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_PHY_CK2,
++				   CSR_2L_PXP_TXPLL_REFIN_INTERNAL);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_SSC,
++				     CSR_2L_PXP_TXPLL_SSC_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_750M_SYS_CK,
++				     CSR_2L_PXP_TXPLL_LPF_SHCK_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_POSTDIV,
++				     CSR_2L_PXP_TXPLL_POSTDIV_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
++				     CSR_2L_PXP_TXPLL_KBAND_KFC);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
++				       CSR_2L_PXP_TXPLL_KBAND_KF, 0x3);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
++				       CSR_2L_PXP_txpll_KBAND_KS, 0x1);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_KBAND_DIV,
++				       CSR_2L_PXP_TXPLL_KBAND_DIV, 0x4);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_LPF_BWR,
++				       CSR_2L_PXP_TXPLL_KBAND_CODE, 0xe4);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_SDM_OUT,
++				   CSR_2L_PXP_TXPLL_TCL_AMP_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TXPLL_TCL_AMP_VREF,
++				   CSR_2L_PXP_TXPLL_TCL_LPF_EN);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_TXPLL_TCL_KBAND_VREF,
++				       CSR_2L_PXP_TXPLL_TCL_KBAND_VREF, 0xf);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_SDM_OUT,
++				       CSR_2L_PXP_TXPLL_TCL_AMP_GAIN, 0x3);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_TXPLL_TCL_AMP_VREF,
++				       CSR_2L_PXP_TXPLL_TCL_AMP_VREF, 0xb);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_TXPLL_TCL_LPF_BW,
++				       CSR_2L_PXP_TXPLL_TCL_LPF_BW, 0x3);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_CKOUT_EN);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_TXPLL_CKOUT_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_CKOUT_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_TXPLL_CKOUT_EN);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_TXPLL_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_SEL_DA_PXP_TXPLL_EN);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT,
++				 PCIE_FORCE_DA_PXP_TXPLL_EN);
++}
++
++static void airoha_pcie_phy_init_ssc_jcpll(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SSC_DELTA1,
++				       CSR_2L_PXP_JCPLL_SSC_DELTA1, 0x106);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SSC_DELTA1,
++				       CSR_2L_PXP_JCPLL_SSC_DELTA, 0x106);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_JCPLL_SSC_PERIOD,
++				       CSR_2L_PXP_JCPLL_SSC_PERIOD, 0x31b);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
++				   CSR_2L_PXP_JCPLL_SSC_PHASE_INI);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
++				   CSR_2L_PXP_JCPLL_SSC_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SDM_IFM,
++				   CSR_2L_PXP_JCPLL_SDM_IFM);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SDM_HREN,
++				   CSR_2L_PXP_JCPLL_SDM_HREN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_RST_DLY,
++				     CSR_2L_PXP_JCPLL_SDM_DI_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
++				   CSR_2L_PXP_JCPLL_SSC_TRI_EN);
++}
++
++static void
++airoha_pcie_phy_set_rxlan0_signal_detect(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR0_PR_COR_HBW,
++				   CSR_2L_PXP_CDR0_PR_LDO_FORCE_ON);
++
++	usleep_range(100, 200);
++
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_19,
++				     PCIE_PCP_RX_REV0_PCIE_GEN1, 0x18b0);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
++				     PCIE_PCP_RX_REV0_PCIE_GEN2, 0x18b0);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
++				     PCIE_PCP_RX_REV0_PCIE_GEN3, 0x1030);
++
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_SIGDET_DCTEST,
++				       CSR_2L_PXP_RX0_SIGDET_PEAK, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_SIGDET_VTH_SEL,
++				       CSR_2L_PXP_RX0_SIGDET_VTH_SEL, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_REV0,
++				       CSR_2L_PXP_VOS_PNINV, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_SIGDET_DCTEST,
++				       CSR_2L_PXP_RX0_SIGDET_LPF_CTRL, 0x1);
++
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_CAL2,
++				     PCIE_CAL_OUT_OS, 0x0);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_PXP_RX0_FE_VB_EQ2,
++				   CSR_2L_PXP_RX0_FE_VCM_GEN_PWDB);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
++				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
++	airoha_phy_pma0_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
++				     PCIE_FORCE_DA_PXP_RX_FE_GAIN_CTRL, 0x3);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_RX_FORCE_MODE0,
++				     PCIE_FORCE_DA_XPON_RX_FE_GAIN_CTRL, 0x1);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_SIGDET0,
++				     PCIE_SIGDET_WIN_NONVLD_TIMES, 0x3);
++	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SEQUENCE_DISB_CTRL1,
++				   PCIE_DISB_RX_SDCAL_EN);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
++				 PCIE_FORCE_RX_SDCAL_EN);
++	usleep_range(150, 200);
++	airoha_phy_pma0_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
++				   PCIE_FORCE_RX_SDCAL_EN);
++}
++
++static void
++airoha_pcie_phy_set_rxlan1_signal_detect(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_CDR1_PR_COR_HBW,
++				   CSR_2L_PXP_CDR1_PR_LDO_FORCE_ON);
++
++	usleep_range(100, 200);
++
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_19,
++				     PCIE_PCP_RX_REV0_PCIE_GEN1, 0x18b0);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
++				     PCIE_PCP_RX_REV0_PCIE_GEN2, 0x18b0);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_20,
++				     PCIE_PCP_RX_REV0_PCIE_GEN3, 0x1030);
++
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_SIGDET_NOVTH,
++				       CSR_2L_PXP_RX1_SIGDET_PEAK, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_SIGDET_NOVTH,
++				       CSR_2L_PXP_RX1_SIGDET_VTH_SEL, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_REV0,
++				       CSR_2L_PXP_VOS_PNINV, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_DAC_RANGE_EYE,
++				       CSR_2L_PXP_RX1_SIGDET_LPF_CTRL, 0x1);
++
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_CAL2,
++				     PCIE_CAL_OUT_OS, 0x0);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX1_FE_VB_EQ1,
++				   CSR_2L_PXP_RX1_FE_VCM_GEN_PWDB);
++
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
++				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
++	airoha_phy_pma1_update_field(pcie_phy,
++				     REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL,
++				     PCIE_FORCE_DA_PXP_RX_FE_GAIN_CTRL, 0x3);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_RX_FORCE_MODE0,
++				     PCIE_FORCE_DA_XPON_RX_FE_GAIN_CTRL, 0x1);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_SS_RX_SIGDET0,
++				     PCIE_SIGDET_WIN_NONVLD_TIMES, 0x3);
++	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_SEQUENCE_DISB_CTRL1,
++				   PCIE_DISB_RX_SDCAL_EN);
++
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
++				 PCIE_FORCE_RX_SDCAL_EN);
++	usleep_range(150, 200);
++	airoha_phy_pma1_clear_bits(pcie_phy,
++				   REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1,
++				   PCIE_FORCE_RX_SDCAL_EN);
++}
++
++static void airoha_pcie_phy_set_rxflow(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_RX_SCAN_RST,
++				 PCIE_FORCE_DA_PXP_RX_SIGDET_PWDB |
++				 PCIE_FORCE_SEL_DA_PXP_RX_SIGDET_PWDB);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_RX_SCAN_RST,
++				 PCIE_FORCE_DA_PXP_RX_SIGDET_PWDB |
++				 PCIE_FORCE_SEL_DA_PXP_RX_SIGDET_PWDB);
++
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PD_PWDB,
++				 PCIE_FORCE_DA_PXP_CDR_PD_PWDB |
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PD_PWDB);
++	airoha_phy_pma0_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_PWDB,
++				 PCIE_FORCE_DA_PXP_RX_FE_PWDB |
++				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_CDR_PD_PWDB,
++				 PCIE_FORCE_DA_PXP_CDR_PD_PWDB |
++				 PCIE_FORCE_SEL_DA_PXP_CDR_PD_PWDB);
++	airoha_phy_pma1_set_bits(pcie_phy,
++				 REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_PWDB,
++				 PCIE_FORCE_DA_PXP_RX_FE_PWDB |
++				 PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX0_PHYCK_DIV,
++				   CSR_2L_PXP_RX0_PHYCK_RSTB |
++				   CSR_2L_PXP_RX0_TDC_CK_SEL);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX1_PHYCK_DIV,
++				   CSR_2L_PXP_RX1_PHYCK_RSTB |
++				   CSR_2L_PXP_RX1_TDC_CK_SEL);
++
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
++				 PCIE_SW_RX_FIFO_RST | PCIE_SW_TX_RST |
++				 PCIE_SW_PMA_RST | PCIE_SW_ALLPCS_RST |
++				 PCIE_SW_TX_FIFO_RST);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
++				 PCIE_SW_RX_FIFO_RST | PCIE_SW_TX_RST |
++				 PCIE_SW_PMA_RST | PCIE_SW_ALLPCS_RST |
++				 PCIE_SW_TX_FIFO_RST);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_PXP_RX0_FE_VB_EQ2,
++				   CSR_2L_PXP_RX0_FE_VB_EQ2_EN |
++				   CSR_2L_PXP_RX0_FE_VB_EQ3_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX0_SIGDET_VTH_SEL,
++				   CSR_2L_PXP_RX0_FE_VB_EQ1_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_RX1_FE_VB_EQ1,
++				   CSR_2L_PXP_RX1_FE_VB_EQ1_EN |
++				   CSR_2L_PXP_RX1_FE_VB_EQ2_EN |
++				   CSR_2L_PXP_RX1_FE_VB_EQ3_EN);
++
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_REV0,
++				       CSR_2L_PXP_FE_GAIN_NORMAL_MODE, 0x4);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX0_REV0,
++				       CSR_2L_PXP_FE_GAIN_TRAIN_MODE, 0x4);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_REV0,
++				       CSR_2L_PXP_FE_GAIN_NORMAL_MODE, 0x4);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_REV0,
++				       CSR_2L_PXP_FE_GAIN_TRAIN_MODE, 0x4);
++}
++
++static void airoha_pcie_phy_set_pr(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_VREG_IBAND,
++				       CSR_2L_PXP_CDR0_PR_VREG_IBAND, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_VREG_IBAND,
++				       CSR_2L_PXP_CDR0_PR_VREG_CKBUF, 0x5);
++
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_CKREF_DIV,
++				     CSR_2L_PXP_CDR0_PR_CKREF_DIV);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_COR_HBW,
++				     CSR_2L_PXP_CDR0_PR_CKREF_DIV1);
++
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_CDR1_PR_VREG_IBAND_VAL,
++				       CSR_2L_PXP_CDR1_PR_VREG_IBAND, 0x5);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_CDR1_PR_VREG_IBAND_VAL,
++				       CSR_2L_PXP_CDR1_PR_VREG_CKBUF, 0x5);
++
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_CKREF_DIV,
++				     CSR_2L_PXP_CDR1_PR_CKREF_DIV);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_COR_HBW,
++				     CSR_2L_PXP_CDR1_PR_CKREF_DIV1);
++
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_LPF_RATIO,
++				       CSR_2L_PXP_CDR0_LPF_TOP_LIM, 0x20000);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_LPF_RATIO,
++				       CSR_2L_PXP_CDR1_LPF_TOP_LIM, 0x20000);
++
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_BETA_DAC,
++				       CSR_2L_PXP_CDR0_PR_BETA_SEL, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_PR_BETA_DAC,
++				       CSR_2L_PXP_CDR1_PR_BETA_SEL, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_BETA_DAC,
++				       CSR_2L_PXP_CDR0_PR_KBAND_DIV, 0x4);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_PR_BETA_DAC,
++				       CSR_2L_PXP_CDR1_PR_KBAND_DIV, 0x4);
++}
++
++static void airoha_pcie_phy_set_txflow(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX0_CKLDO,
++				   CSR_2L_PXP_TX0_CKLDO_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX1_CKLDO,
++				   CSR_2L_PXP_TX1_CKLDO_EN);
++
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX0_CKLDO,
++				   CSR_2L_PXP_TX0_DMEDGEGEN_EN);
++	airoha_phy_csr_2l_set_bits(pcie_phy, REG_CSR_2L_TX1_CKLDO,
++				   CSR_2L_PXP_TX1_DMEDGEGEN_EN);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_TX1_MULTLANE,
++				     CSR_2L_PXP_TX1_MULTLANE_EN);
++}
++
++static void airoha_pcie_phy_set_rx_mode(struct airoha_pcie_phy *pcie_phy)
++{
++	writel(0x804000, pcie_phy->pma0 + REG_PCIE_PMA_DIG_RESERVE_27);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
++				     PCIE_PXP_RX_VTH_SEL_PCIE_G1, 0x5);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
++				     PCIE_PXP_RX_VTH_SEL_PCIE_G2, 0x5);
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
++				     PCIE_PXP_RX_VTH_SEL_PCIE_G3, 0x5);
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_30,
++				 0x77700);
++
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR0_PR_MONCK,
++				     CSR_2L_PXP_CDR0_PR_MONCK_ENABLE);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR0_PR_MONCK,
++				       CSR_2L_PXP_CDR0_PR_RESERVE0, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_PXP_RX0_OSCAL_CTLE1IOS,
++				       CSR_2L_PXP_RX0_PR_OSCAL_VGA1IOS, 0x19);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_PXP_RX0_OSCA_VGA1VOS,
++				       CSR_2L_PXP_RX0_PR_OSCAL_VGA1VOS, 0x19);
++	airoha_phy_csr_2l_update_field(pcie_phy,
++				       REG_CSR_2L_PXP_RX0_OSCA_VGA1VOS,
++				       CSR_2L_PXP_RX0_PR_OSCAL_VGA2IOS, 0x14);
++
++	writel(0x804000, pcie_phy->pma1 + REG_PCIE_PMA_DIG_RESERVE_27);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
++				     PCIE_PXP_RX_VTH_SEL_PCIE_G1, 0x5);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
++				     PCIE_PXP_RX_VTH_SEL_PCIE_G2, 0x5);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_18,
++				     PCIE_PXP_RX_VTH_SEL_PCIE_G3, 0x5);
++
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_30,
++				 0x77700);
++
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_CDR1_PR_MONCK,
++				     CSR_2L_PXP_CDR1_PR_MONCK_ENABLE);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_CDR1_PR_MONCK,
++				       CSR_2L_PXP_CDR1_PR_RESERVE0, 0x2);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_OSCAL_VGA1IOS,
++				       CSR_2L_PXP_RX1_PR_OSCAL_VGA1IOS, 0x19);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_OSCAL_VGA1IOS,
++				       CSR_2L_PXP_RX1_PR_OSCAL_VGA1VOS, 0x19);
++	airoha_phy_csr_2l_update_field(pcie_phy, REG_CSR_2L_RX1_OSCAL_VGA1IOS,
++				       CSR_2L_PXP_RX1_PR_OSCAL_VGA2IOS, 0x14);
++}
++
++static void airoha_pcie_phy_load_kflow(struct airoha_pcie_phy *pcie_phy)
++{
++	airoha_phy_pma0_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
++				     PCIE_FORCE_PMA_RX_SPEED, 0xa);
++	airoha_phy_pma1_update_field(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
++				     PCIE_FORCE_PMA_RX_SPEED, 0xa);
++	airoha_phy_init_lane0_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN3);
++	airoha_phy_init_lane1_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN3);
++
++	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
++				   PCIE_FORCE_PMA_RX_SPEED);
++	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_12,
++				   PCIE_FORCE_PMA_RX_SPEED);
++	usleep_range(100, 200);
++
++	airoha_phy_init_lane0_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN2);
++	airoha_phy_init_lane1_rx_fw_pre_calib(pcie_phy, PCIE_PORT_GEN2);
++}
++
++/**
++ * airoha_pcie_phy_init() - Initialize the phy
++ * @phy: the phy to be initialized
++ *
++ * Initialize the phy registers.
++ * The hardware settings will be reset during suspend, it should be
++ * reinitialized when the consumer calls phy_init() again on resume.
++ */
++static int airoha_pcie_phy_init(struct phy *phy)
++{
++	struct airoha_pcie_phy *pcie_phy = phy_get_drvdata(phy);
++	u32 val;
++
++	/* Setup Tx-Rx detection time */
++	val = FIELD_PREP(PCIE_XTP_RXDET_VCM_OFF_STB_T_SEL, 0x33) |
++	      FIELD_PREP(PCIE_XTP_RXDET_EN_STB_T_SEL, 0x1) |
++	      FIELD_PREP(PCIE_XTP_RXDET_FINISH_STB_T_SEL, 0x2) |
++	      FIELD_PREP(PCIE_XTP_TXPD_TX_DATA_EN_DLY, 0x3) |
++	      FIELD_PREP(PCIE_XTP_RXDET_LATCH_STB_T_SEL, 0x1);
++	writel(val, pcie_phy->p0_xr_dtime + REG_PCIE_PEXTP_DIG_GLB44);
++	writel(val, pcie_phy->p1_xr_dtime + REG_PCIE_PEXTP_DIG_GLB44);
++	/* Setup Rx AEQ training time */
++	val = FIELD_PREP(PCIE_XTP_LN_RX_PDOWN_L1P2_EXIT_WAIT, 0x32) |
++	      FIELD_PREP(PCIE_XTP_LN_RX_PDOWN_E0_AEQEN_WAIT, 0x5050);
++	writel(val, pcie_phy->rx_aeq + REG_PCIE_PEXTP_DIG_LN_RX30_P0);
++	writel(val, pcie_phy->rx_aeq + REG_PCIE_PEXTP_DIG_LN_RX30_P1);
++
++	/* enable load FLL-K flow */
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_14,
++				 PCIE_FLL_LOAD_EN);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_DIG_RESERVE_14,
++				 PCIE_FLL_LOAD_EN);
++
++	airoha_pcie_phy_init_default(pcie_phy);
++	airoha_pcie_phy_init_clk_out(pcie_phy);
++	airoha_pcie_phy_init_csr_2l(pcie_phy);
++
++	usleep_range(100, 200);
++
++	airoha_pcie_phy_init_rx(pcie_phy);
++	/* phase 1, no ssc for K TXPLL */
++	airoha_pcie_phy_init_jcpll(pcie_phy);
++
++	usleep_range(500, 600);
++
++	/* TX PLL settings */
++	airoha_pcie_phy_txpll(pcie_phy);
++
++	usleep_range(200, 300);
++
++	/* SSC JCPLL setting */
++	airoha_pcie_phy_init_ssc_jcpll(pcie_phy);
++
++	usleep_range(100, 200);
++
++	/* Rx lan0 signal detect */
++	airoha_pcie_phy_set_rxlan0_signal_detect(pcie_phy);
++	/* Rx lan1 signal detect */
++	airoha_pcie_phy_set_rxlan1_signal_detect(pcie_phy);
++	/* RX FLOW */
++	airoha_pcie_phy_set_rxflow(pcie_phy);
++
++	usleep_range(100, 200);
++
++	airoha_pcie_phy_set_pr(pcie_phy);
++	/* TX FLOW */
++	airoha_pcie_phy_set_txflow(pcie_phy);
++
++	usleep_range(100, 200);
++	/* RX mode setting */
++	airoha_pcie_phy_set_rx_mode(pcie_phy);
++	/* Load K-Flow */
++	airoha_pcie_phy_load_kflow(pcie_phy);
++	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
++				   PCIE_DA_XPON_CDR_PR_PWDB);
++	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
++				   PCIE_DA_XPON_CDR_PR_PWDB);
++
++	usleep_range(100, 200);
++
++	airoha_phy_pma0_set_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
++				 PCIE_DA_XPON_CDR_PR_PWDB);
++	airoha_phy_pma1_set_bits(pcie_phy, REG_PCIE_PMA_SS_DA_XPON_PWDB0,
++				 PCIE_DA_XPON_CDR_PR_PWDB);
++
++	/* Wait for the PCIe PHY to complete initialization before returning */
++	msleep(PHY_HW_INIT_TIME_MS);
++
++	return 0;
++}
++
++static int airoha_pcie_phy_exit(struct phy *phy)
++{
++	struct airoha_pcie_phy *pcie_phy = phy_get_drvdata(phy);
++
++	airoha_phy_pma0_clear_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
++				   PCIE_PMA_SW_RST);
++	airoha_phy_pma1_clear_bits(pcie_phy, REG_PCIE_PMA_SW_RESET,
++				   PCIE_PMA_SW_RST);
++	airoha_phy_csr_2l_clear_bits(pcie_phy, REG_CSR_2L_JCPLL_SSC,
++				     CSR_2L_PXP_JCPLL_SSC_PHASE_INI |
++				     CSR_2L_PXP_JCPLL_SSC_TRI_EN |
++				     CSR_2L_PXP_JCPLL_SSC_EN);
++
++	return 0;
++}
++
++static const struct phy_ops airoha_pcie_phy_ops = {
++	.init = airoha_pcie_phy_init,
++	.exit = airoha_pcie_phy_exit,
++	.owner = THIS_MODULE,
++};
++
++static int airoha_pcie_phy_probe(struct platform_device *pdev)
++{
++	struct airoha_pcie_phy *pcie_phy;
++	struct device *dev = &pdev->dev;
++	struct phy_provider *provider;
++
++	pcie_phy = devm_kzalloc(dev, sizeof(*pcie_phy), GFP_KERNEL);
++	if (!pcie_phy)
++		return -ENOMEM;
++
++	pcie_phy->csr_2l = devm_platform_ioremap_resource_byname(pdev, "csr-2l");
++	if (IS_ERR(pcie_phy->csr_2l))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->csr_2l),
++				     "Failed to map phy-csr-2l base\n");
++
++	pcie_phy->pma0 = devm_platform_ioremap_resource_byname(pdev, "pma0");
++	if (IS_ERR(pcie_phy->pma0))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->pma0),
++				     "Failed to map phy-pma0 base\n");
++
++	pcie_phy->pma1 = devm_platform_ioremap_resource_byname(pdev, "pma1");
++	if (IS_ERR(pcie_phy->pma1))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->pma1),
++				     "Failed to map phy-pma1 base\n");
++
++	pcie_phy->phy = devm_phy_create(dev, dev->of_node, &airoha_pcie_phy_ops);
++	if (IS_ERR(pcie_phy->phy))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->phy),
++				     "Failed to create PCIe phy\n");
++
++	pcie_phy->p0_xr_dtime =
++		devm_platform_ioremap_resource_byname(pdev, "p0-xr-dtime");
++	if (IS_ERR(pcie_phy->p0_xr_dtime))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->p0_xr_dtime),
++				     "Failed to map P0 Tx-Rx dtime base\n");
++
++	pcie_phy->p1_xr_dtime =
++		devm_platform_ioremap_resource_byname(pdev, "p1-xr-dtime");
++	if (IS_ERR(pcie_phy->p1_xr_dtime))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->p1_xr_dtime),
++				     "Failed to map P1 Tx-Rx dtime base\n");
++
++	pcie_phy->rx_aeq = devm_platform_ioremap_resource_byname(pdev, "rx-aeq");
++	if (IS_ERR(pcie_phy->rx_aeq))
++		return dev_err_probe(dev, PTR_ERR(pcie_phy->rx_aeq),
++				     "Failed to map Rx AEQ base\n");
++
++	pcie_phy->dev = dev;
++	phy_set_drvdata(pcie_phy->phy, pcie_phy);
++
++	provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);
++	if (IS_ERR(provider))
++		return dev_err_probe(dev, PTR_ERR(provider),
++				     "PCIe phy probe failed\n");
++
++	return 0;
++}
++
++static const struct of_device_id airoha_pcie_phy_of_match[] = {
++	{ .compatible = "airoha,en7581-pcie-phy" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, airoha_pcie_phy_of_match);
++
++static struct platform_driver airoha_pcie_phy_driver = {
++	.probe	= airoha_pcie_phy_probe,
++	.driver	= {
++		.name = "airoha-en7581-pcie-phy",
++		.of_match_table = airoha_pcie_phy_of_match,
++	},
++};
++module_platform_driver(airoha_pcie_phy_driver);
++
 +MODULE_DESCRIPTION("Airoha EN7581 PCIe PHY driver");
- MODULE_AUTHOR("Lorenzo Bianconi <lorenzo@kernel.org>");
- MODULE_LICENSE("GPL");
--- 
-2.48.1
-
++MODULE_AUTHOR("Lorenzo Bianconi <lorenzo@kernel.org>");
++MODULE_LICENSE("GPL");
+--- /dev/null
++++ b/drivers/phy/airoha/phy-airoha-en7581-pcie-regs.h
+@@ -0,0 +1,494 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2024 AIROHA Inc
++ * Author: Lorenzo Bianconi <lorenzo@kernel.org>
++ */
++
++#ifndef _PHY_AIROHA_PCIE_H
++#define _PHY_AIROHA_PCIE_H
++
++/* CSR_2L */
++#define REG_CSR_2L_CMN				0x0000
++#define CSR_2L_PXP_CMN_LANE_EN			BIT(0)
++#define CSR_2L_PXP_CMN_TRIM_MASK		GENMASK(28, 24)
++
++#define REG_CSR_2L_JCPLL_IB_EXT			0x0004
++#define REG_CSR_2L_JCPLL_LPF_SHCK_EN		BIT(8)
++#define CSR_2L_PXP_JCPLL_CHP_IBIAS		GENMASK(21, 16)
++#define CSR_2L_PXP_JCPLL_CHP_IOFST		GENMASK(29, 24)
++
++#define REG_CSR_2L_JCPLL_LPF_BR			0x0008
++#define CSR_2L_PXP_JCPLL_LPF_BR			GENMASK(4, 0)
++#define CSR_2L_PXP_JCPLL_LPF_BC			GENMASK(12, 8)
++#define CSR_2L_PXP_JCPLL_LPF_BP			GENMASK(20, 16)
++#define CSR_2L_PXP_JCPLL_LPF_BWR		GENMASK(28, 24)
++
++#define REG_CSR_2L_JCPLL_LPF_BWC		0x000c
++#define CSR_2L_PXP_JCPLL_LPF_BWC		GENMASK(4, 0)
++#define CSR_2L_PXP_JCPLL_KBAND_CODE		GENMASK(23, 16)
++#define CSR_2L_PXP_JCPLL_KBAND_DIV		GENMASK(26, 24)
++
++#define REG_CSR_2L_JCPLL_KBAND_KFC		0x0010
++#define CSR_2L_PXP_JCPLL_KBAND_KFC		GENMASK(1, 0)
++#define CSR_2L_PXP_JCPLL_KBAND_KF		GENMASK(9, 8)
++#define CSR_2L_PXP_JCPLL_KBAND_KS		GENMASK(17, 16)
++#define CSR_2L_PXP_JCPLL_POSTDIV_EN		BIT(24)
++
++#define REG_CSR_2L_JCPLL_MMD_PREDIV_MODE	0x0014
++#define CSR_2L_PXP_JCPLL_MMD_PREDIV_MODE	GENMASK(1, 0)
++#define CSR_2L_PXP_JCPLL_POSTDIV_D2		BIT(16)
++#define CSR_2L_PXP_JCPLL_POSTDIV_D5		BIT(24)
++
++#define CSR_2L_PXP_JCPLL_MONCK			0x0018
++#define CSR_2L_PXP_JCPLL_REFIN_DIV		GENMASK(25, 24)
++
++#define REG_CSR_2L_JCPLL_RST_DLY		0x001c
++#define CSR_2L_PXP_JCPLL_RST_DLY		GENMASK(2, 0)
++#define CSR_2L_PXP_JCPLL_RST			BIT(8)
++#define CSR_2L_PXP_JCPLL_SDM_DI_EN		BIT(16)
++#define CSR_2L_PXP_JCPLL_SDM_DI_LS		GENMASK(25, 24)
++
++#define REG_CSR_2L_JCPLL_SDM_IFM		0x0020
++#define CSR_2L_PXP_JCPLL_SDM_IFM		BIT(0)
++
++#define REG_CSR_2L_JCPLL_SDM_HREN		0x0024
++#define CSR_2L_PXP_JCPLL_SDM_HREN		BIT(0)
++#define CSR_2L_PXP_JCPLL_TCL_AMP_EN		BIT(8)
++#define CSR_2L_PXP_JCPLL_TCL_AMP_GAIN		GENMASK(18, 16)
++#define CSR_2L_PXP_JCPLL_TCL_AMP_VREF		GENMASK(28, 24)
++
++#define REG_CSR_2L_JCPLL_TCL_CMP		0x0028
++#define CSR_2L_PXP_JCPLL_TCL_LPF_EN		BIT(16)
++#define CSR_2L_PXP_JCPLL_TCL_LPF_BW		GENMASK(26, 24)
++
++#define REG_CSR_2L_JCPLL_VCODIV			0x002c
++#define CSR_2L_PXP_JCPLL_VCO_CFIX		GENMASK(9, 8)
++#define CSR_2L_PXP_JCPLL_VCO_HALFLSB_EN		BIT(16)
++#define CSR_2L_PXP_JCPLL_VCO_SCAPWR		GENMASK(26, 24)
++
++#define REG_CSR_2L_JCPLL_VCO_TCLVAR		0x0030
++#define CSR_2L_PXP_JCPLL_VCO_TCLVAR		GENMASK(2, 0)
++
++#define REG_CSR_2L_JCPLL_SSC				0x0038
++#define CSR_2L_PXP_JCPLL_SSC_EN			BIT(0)
++#define CSR_2L_PXP_JCPLL_SSC_PHASE_INI		BIT(8)
++#define CSR_2L_PXP_JCPLL_SSC_TRI_EN		BIT(16)
++
++#define REG_CSR_2L_JCPLL_SSC_DELTA1		0x003c
++#define CSR_2L_PXP_JCPLL_SSC_DELTA1		GENMASK(15, 0)
++#define CSR_2L_PXP_JCPLL_SSC_DELTA		GENMASK(31, 16)
++
++#define REG_CSR_2L_JCPLL_SSC_PERIOD		0x0040
++#define CSR_2L_PXP_JCPLL_SSC_PERIOD		GENMASK(15, 0)
++
++#define REG_CSR_2L_JCPLL_TCL_VTP_EN		0x004c
++#define CSR_2L_PXP_JCPLL_SPARE_LOW		GENMASK(31, 24)
++
++#define REG_CSR_2L_JCPLL_TCL_KBAND_VREF		0x0050
++#define CSR_2L_PXP_JCPLL_TCL_KBAND_VREF		GENMASK(4, 0)
++#define CSR_2L_PXP_JCPLL_VCO_KBAND_MEAS_EN	BIT(24)
++
++#define REG_CSR_2L_750M_SYS_CK			0x0054
++#define CSR_2L_PXP_TXPLL_LPF_SHCK_EN		BIT(16)
++#define CSR_2L_PXP_TXPLL_CHP_IBIAS		GENMASK(29, 24)
++
++#define REG_CSR_2L_TXPLL_CHP_IOFST		0x0058
++#define CSR_2L_PXP_TXPLL_CHP_IOFST		GENMASK(5, 0)
++#define CSR_2L_PXP_TXPLL_LPF_BR			GENMASK(12, 8)
++#define CSR_2L_PXP_TXPLL_LPF_BC			GENMASK(20, 16)
++#define CSR_2L_PXP_TXPLL_LPF_BP			GENMASK(28, 24)
++
++#define REG_CSR_2L_TXPLL_LPF_BWR		0x005c
++#define CSR_2L_PXP_TXPLL_LPF_BWR		GENMASK(4, 0)
++#define CSR_2L_PXP_TXPLL_LPF_BWC		GENMASK(12, 8)
++#define CSR_2L_PXP_TXPLL_KBAND_CODE		GENMASK(31, 24)
++
++#define REG_CSR_2L_TXPLL_KBAND_DIV		0x0060
++#define CSR_2L_PXP_TXPLL_KBAND_DIV		GENMASK(2, 0)
++#define CSR_2L_PXP_TXPLL_KBAND_KFC		GENMASK(9, 8)
++#define CSR_2L_PXP_TXPLL_KBAND_KF		GENMASK(17, 16)
++#define CSR_2L_PXP_txpll_KBAND_KS		GENMASK(25, 24)
++
++#define REG_CSR_2L_TXPLL_POSTDIV		0x0064
++#define CSR_2L_PXP_TXPLL_POSTDIV_EN		BIT(0)
++#define CSR_2L_PXP_TXPLL_MMD_PREDIV_MODE	GENMASK(9, 8)
++#define CSR_2L_PXP_TXPLL_PHY_CK1_EN		BIT(24)
++
++#define REG_CSR_2L_TXPLL_PHY_CK2		0x0068
++#define CSR_2L_PXP_TXPLL_REFIN_INTERNAL		BIT(24)
++
++#define REG_CSR_2L_TXPLL_REFIN_DIV		0x006c
++#define CSR_2L_PXP_TXPLL_REFIN_DIV		GENMASK(1, 0)
++#define CSR_2L_PXP_TXPLL_RST_DLY		GENMASK(10, 8)
++#define CSR_2L_PXP_TXPLL_PLL_RSTB		BIT(16)
++
++#define REG_CSR_2L_TXPLL_SDM_DI_LS		0x0070
++#define CSR_2L_PXP_TXPLL_SDM_DI_LS		GENMASK(1, 0)
++#define CSR_2L_PXP_TXPLL_SDM_IFM		BIT(8)
++#define CSR_2L_PXP_TXPLL_SDM_ORD		GENMASK(25, 24)
++
++#define REG_CSR_2L_TXPLL_SDM_OUT		0x0074
++#define CSR_2L_PXP_TXPLL_TCL_AMP_EN		BIT(16)
++#define CSR_2L_PXP_TXPLL_TCL_AMP_GAIN		GENMASK(26, 24)
++
++#define REG_CSR_2L_TXPLL_TCL_AMP_VREF		0x0078
++#define CSR_2L_PXP_TXPLL_TCL_AMP_VREF		GENMASK(4, 0)
++#define CSR_2L_PXP_TXPLL_TCL_LPF_EN		BIT(24)
++
++#define REG_CSR_2L_TXPLL_TCL_LPF_BW		0x007c
++#define CSR_2L_PXP_TXPLL_TCL_LPF_BW		GENMASK(2, 0)
++#define CSR_2L_PXP_TXPLL_VCO_CFIX		GENMASK(17, 16)
++#define CSR_2L_PXP_TXPLL_VCO_HALFLSB_EN		BIT(24)
++
++#define REG_CSR_2L_TXPLL_VCO_SCAPWR		0x0080
++#define CSR_2L_PXP_TXPLL_VCO_SCAPWR		GENMASK(2, 0)
++
++#define REG_CSR_2L_TXPLL_SSC			0x0084
++#define CSR_2L_PXP_TXPLL_SSC_EN			BIT(0)
++#define CSR_2L_PXP_TXPLL_SSC_PHASE_INI		BIT(8)
++
++#define REG_CSR_2L_TXPLL_SSC_DELTA1		0x0088
++#define CSR_2L_PXP_TXPLL_SSC_DELTA1		GENMASK(15, 0)
++#define CSR_2L_PXP_TXPLL_SSC_DELTA		GENMASK(31, 16)
++
++#define REG_CSR_2L_TXPLL_SSC_PERIOD		0x008c
++#define CSR_2L_PXP_txpll_SSC_PERIOD		GENMASK(15, 0)
++
++#define REG_CSR_2L_TXPLL_VTP			0x0090
++#define CSR_2L_PXP_TXPLL_VTP_EN			BIT(0)
++
++#define REG_CSR_2L_TXPLL_TCL_VTP		0x0098
++#define CSR_2L_PXP_TXPLL_SPARE_L		GENMASK(31, 24)
++
++#define REG_CSR_2L_TXPLL_TCL_KBAND_VREF		0x009c
++#define CSR_2L_PXP_TXPLL_TCL_KBAND_VREF		GENMASK(4, 0)
++#define CSR_2L_PXP_TXPLL_VCO_KBAND_MEAS_EN	BIT(24)
++
++#define REG_CSR_2L_TXPLL_POSTDIV_D256		0x00a0
++#define CSR_2L_PXP_CLKTX0_AMP			GENMASK(10, 8)
++#define CSR_2L_PXP_CLKTX0_OFFSET		GENMASK(17, 16)
++#define CSR_2L_PXP_CLKTX0_SR			GENMASK(25, 24)
++
++#define REG_CSR_2L_CLKTX0_FORCE_OUT1		0x00a4
++#define CSR_2L_PXP_CLKTX0_HZ			BIT(8)
++#define CSR_2L_PXP_CLKTX0_IMP_SEL		GENMASK(20, 16)
++#define CSR_2L_PXP_CLKTX1_AMP			GENMASK(26, 24)
++
++#define REG_CSR_2L_CLKTX1_OFFSET		0x00a8
++#define CSR_2L_PXP_CLKTX1_OFFSET		GENMASK(1, 0)
++#define CSR_2L_PXP_CLKTX1_SR			GENMASK(9, 8)
++#define CSR_2L_PXP_CLKTX1_HZ			BIT(24)
++
++#define REG_CSR_2L_CLKTX1_IMP_SEL		0x00ac
++#define CSR_2L_PXP_CLKTX1_IMP_SEL		GENMASK(4, 0)
++
++#define REG_CSR_2L_PLL_CMN_RESERVE0		0x00b0
++#define CSR_2L_PXP_PLL_RESERVE_MASK		GENMASK(15, 0)
++
++#define REG_CSR_2L_TX0_CKLDO			0x00cc
++#define CSR_2L_PXP_TX0_CKLDO_EN			BIT(0)
++#define CSR_2L_PXP_TX0_DMEDGEGEN_EN		BIT(24)
++
++#define REG_CSR_2L_TX1_CKLDO			0x00e8
++#define CSR_2L_PXP_TX1_CKLDO_EN			BIT(0)
++#define CSR_2L_PXP_TX1_DMEDGEGEN_EN		BIT(24)
++
++#define REG_CSR_2L_TX1_MULTLANE			0x00ec
++#define CSR_2L_PXP_TX1_MULTLANE_EN		BIT(0)
++
++#define REG_CSR_2L_RX0_REV0			0x00fc
++#define CSR_2L_PXP_VOS_PNINV			GENMASK(19, 18)
++#define CSR_2L_PXP_FE_GAIN_NORMAL_MODE		GENMASK(22, 20)
++#define CSR_2L_PXP_FE_GAIN_TRAIN_MODE		GENMASK(26, 24)
++
++#define REG_CSR_2L_RX0_PHYCK_DIV		0x0100
++#define CSR_2L_PXP_RX0_PHYCK_SEL		GENMASK(9, 8)
++#define CSR_2L_PXP_RX0_PHYCK_RSTB		BIT(16)
++#define CSR_2L_PXP_RX0_TDC_CK_SEL		BIT(24)
++
++#define REG_CSR_2L_CDR0_PD_PICAL_CKD8_INV	0x0104
++#define CSR_2L_PXP_CDR0_PD_EDGE_DISABLE		BIT(8)
++
++#define REG_CSR_2L_CDR0_LPF_RATIO		0x0110
++#define CSR_2L_PXP_CDR0_LPF_TOP_LIM		GENMASK(26, 8)
++
++#define REG_CSR_2L_CDR0_PR_INJ_MODE		0x011c
++#define CSR_2L_PXP_CDR0_INJ_FORCE_OFF		BIT(24)
++
++#define REG_CSR_2L_CDR0_PR_BETA_DAC		0x0120
++#define CSR_2L_PXP_CDR0_PR_BETA_SEL		GENMASK(19, 16)
++#define CSR_2L_PXP_CDR0_PR_KBAND_DIV		GENMASK(26, 24)
++
++#define REG_CSR_2L_CDR0_PR_VREG_IBAND		0x0124
++#define CSR_2L_PXP_CDR0_PR_VREG_IBAND		GENMASK(2, 0)
++#define CSR_2L_PXP_CDR0_PR_VREG_CKBUF		GENMASK(10, 8)
++
++#define REG_CSR_2L_CDR0_PR_CKREF_DIV		0x0128
++#define CSR_2L_PXP_CDR0_PR_CKREF_DIV		GENMASK(1, 0)
++
++#define REG_CSR_2L_CDR0_PR_MONCK		0x012c
++#define CSR_2L_PXP_CDR0_PR_MONCK_ENABLE		BIT(0)
++#define CSR_2L_PXP_CDR0_PR_RESERVE0		GENMASK(19, 16)
++
++#define REG_CSR_2L_CDR0_PR_COR_HBW		0x0130
++#define CSR_2L_PXP_CDR0_PR_LDO_FORCE_ON		BIT(8)
++#define CSR_2L_PXP_CDR0_PR_CKREF_DIV1		GENMASK(17, 16)
++
++#define REG_CSR_2L_CDR0_PR_MONPI		0x0134
++#define CSR_2L_PXP_CDR0_PR_XFICK_EN		BIT(8)
++
++#define REG_CSR_2L_RX0_SIGDET_DCTEST		0x0140
++#define CSR_2L_PXP_RX0_SIGDET_LPF_CTRL		GENMASK(9, 8)
++#define CSR_2L_PXP_RX0_SIGDET_PEAK		GENMASK(25, 24)
++
++#define REG_CSR_2L_RX0_SIGDET_VTH_SEL		0x0144
++#define CSR_2L_PXP_RX0_SIGDET_VTH_SEL		GENMASK(4, 0)
++#define CSR_2L_PXP_RX0_FE_VB_EQ1_EN		BIT(24)
++
++#define REG_CSR_2L_PXP_RX0_FE_VB_EQ2		0x0148
++#define CSR_2L_PXP_RX0_FE_VB_EQ2_EN		BIT(0)
++#define CSR_2L_PXP_RX0_FE_VB_EQ3_EN		BIT(8)
++#define CSR_2L_PXP_RX0_FE_VCM_GEN_PWDB		BIT(16)
++
++#define REG_CSR_2L_PXP_RX0_OSCAL_CTLE1IOS	0x0158
++#define CSR_2L_PXP_RX0_PR_OSCAL_VGA1IOS		GENMASK(29, 24)
++
++#define REG_CSR_2L_PXP_RX0_OSCA_VGA1VOS		0x015c
++#define CSR_2L_PXP_RX0_PR_OSCAL_VGA1VOS		GENMASK(5, 0)
++#define CSR_2L_PXP_RX0_PR_OSCAL_VGA2IOS		GENMASK(13, 8)
++
++#define REG_CSR_2L_RX1_REV0			0x01b4
++
++#define REG_CSR_2L_RX1_PHYCK_DIV		0x01b8
++#define CSR_2L_PXP_RX1_PHYCK_SEL		GENMASK(9, 8)
++#define CSR_2L_PXP_RX1_PHYCK_RSTB		BIT(16)
++#define CSR_2L_PXP_RX1_TDC_CK_SEL		BIT(24)
++
++#define REG_CSR_2L_CDR1_PD_PICAL_CKD8_INV	0x01bc
++#define CSR_2L_PXP_CDR1_PD_EDGE_DISABLE		BIT(8)
++
++#define REG_CSR_2L_CDR1_PR_BETA_DAC		0x01d8
++#define CSR_2L_PXP_CDR1_PR_BETA_SEL		GENMASK(19, 16)
++#define CSR_2L_PXP_CDR1_PR_KBAND_DIV		GENMASK(26, 24)
++
++#define REG_CSR_2L_CDR1_PR_MONCK		0x01e4
++#define CSR_2L_PXP_CDR1_PR_MONCK_ENABLE		BIT(0)
++#define CSR_2L_PXP_CDR1_PR_RESERVE0		GENMASK(19, 16)
++
++#define REG_CSR_2L_CDR1_LPF_RATIO		0x01c8
++#define CSR_2L_PXP_CDR1_LPF_TOP_LIM		GENMASK(26, 8)
++
++#define REG_CSR_2L_CDR1_PR_INJ_MODE		0x01d4
++#define CSR_2L_PXP_CDR1_INJ_FORCE_OFF		BIT(24)
++
++#define REG_CSR_2L_CDR1_PR_VREG_IBAND_VAL	0x01dc
++#define CSR_2L_PXP_CDR1_PR_VREG_IBAND		GENMASK(2, 0)
++#define CSR_2L_PXP_CDR1_PR_VREG_CKBUF		GENMASK(10, 8)
++
++#define REG_CSR_2L_CDR1_PR_CKREF_DIV		0x01e0
++#define CSR_2L_PXP_CDR1_PR_CKREF_DIV		GENMASK(1, 0)
++
++#define REG_CSR_2L_CDR1_PR_COR_HBW		0x01e8
++#define CSR_2L_PXP_CDR1_PR_LDO_FORCE_ON		BIT(8)
++#define CSR_2L_PXP_CDR1_PR_CKREF_DIV1		GENMASK(17, 16)
++
++#define REG_CSR_2L_CDR1_PR_MONPI		0x01ec
++#define CSR_2L_PXP_CDR1_PR_XFICK_EN		BIT(8)
++
++#define REG_CSR_2L_RX1_DAC_RANGE_EYE		0x01f4
++#define CSR_2L_PXP_RX1_SIGDET_LPF_CTRL		GENMASK(25, 24)
++
++#define REG_CSR_2L_RX1_SIGDET_NOVTH		0x01f8
++#define CSR_2L_PXP_RX1_SIGDET_PEAK		GENMASK(9, 8)
++#define CSR_2L_PXP_RX1_SIGDET_VTH_SEL		GENMASK(20, 16)
++
++#define REG_CSR_2L_RX1_FE_VB_EQ1		0x0200
++#define CSR_2L_PXP_RX1_FE_VB_EQ1_EN		BIT(0)
++#define CSR_2L_PXP_RX1_FE_VB_EQ2_EN		BIT(8)
++#define CSR_2L_PXP_RX1_FE_VB_EQ3_EN		BIT(16)
++#define CSR_2L_PXP_RX1_FE_VCM_GEN_PWDB		BIT(24)
++
++#define REG_CSR_2L_RX1_OSCAL_VGA1IOS		0x0214
++#define CSR_2L_PXP_RX1_PR_OSCAL_VGA1IOS		GENMASK(5, 0)
++#define CSR_2L_PXP_RX1_PR_OSCAL_VGA1VOS		GENMASK(13, 8)
++#define CSR_2L_PXP_RX1_PR_OSCAL_VGA2IOS		GENMASK(21, 16)
++
++/* PMA */
++#define REG_PCIE_PMA_SS_LCPLL_PWCTL_SETTING_1	0x0004
++#define PCIE_LCPLL_MAN_PWDB			BIT(0)
++
++#define REG_PCIE_PMA_SEQUENCE_DISB_CTRL1	0x010c
++#define PCIE_DISB_RX_SDCAL_EN			BIT(0)
++
++#define REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1	0x0114
++#define PCIE_FORCE_RX_SDCAL_EN			BIT(0)
++
++#define REG_PCIE_PMA_SS_RX_FREQ_DET1		0x014c
++#define PCIE_PLL_FT_LOCK_CYCLECNT		GENMASK(15, 0)
++#define PCIE_PLL_FT_UNLOCK_CYCLECNT		GENMASK(31, 16)
++
++#define REG_PCIE_PMA_SS_RX_FREQ_DET2		0x0150
++#define PCIE_LOCK_TARGET_BEG			GENMASK(15, 0)
++#define PCIE_LOCK_TARGET_END			GENMASK(31, 16)
++
++#define REG_PCIE_PMA_SS_RX_FREQ_DET3		0x0154
++#define PCIE_UNLOCK_TARGET_BEG			GENMASK(15, 0)
++#define PCIE_UNLOCK_TARGET_END			GENMASK(31, 16)
++
++#define REG_PCIE_PMA_SS_RX_FREQ_DET4		0x0158
++#define PCIE_FREQLOCK_DET_EN			GENMASK(2, 0)
++#define PCIE_LOCK_LOCKTH			GENMASK(11, 8)
++#define PCIE_UNLOCK_LOCKTH			GENMASK(15, 12)
++
++#define REG_PCIE_PMA_SS_RX_CAL1			0x0160
++#define REG_PCIE_PMA_SS_RX_CAL2			0x0164
++#define PCIE_CAL_OUT_OS				GENMASK(11, 8)
++
++#define REG_PCIE_PMA_SS_RX_SIGDET0		0x0168
++#define PCIE_SIGDET_WIN_NONVLD_TIMES		GENMASK(28, 24)
++
++#define REG_PCIE_PMA_TX_RESET			0x0260
++#define PCIE_TX_TOP_RST				BIT(0)
++#define PCIE_TX_CAL_RST				BIT(8)
++
++#define REG_PCIE_PMA_RX_FORCE_MODE0		0x0294
++#define PCIE_FORCE_DA_XPON_RX_FE_GAIN_CTRL	GENMASK(1, 0)
++
++#define REG_PCIE_PMA_SS_DA_XPON_PWDB0		0x034c
++#define PCIE_DA_XPON_CDR_PR_PWDB		BIT(8)
++
++#define REG_PCIE_PMA_SW_RESET			0x0460
++#define PCIE_SW_RX_FIFO_RST			BIT(0)
++#define PCIE_SW_RX_RST				BIT(1)
++#define PCIE_SW_TX_RST				BIT(2)
++#define PCIE_SW_PMA_RST				BIT(3)
++#define PCIE_SW_ALLPCS_RST			BIT(4)
++#define PCIE_SW_REF_RST				BIT(5)
++#define PCIE_SW_TX_FIFO_RST			BIT(6)
++#define PCIE_SW_XFI_TXPCS_RST			BIT(7)
++#define PCIE_SW_XFI_RXPCS_RST			BIT(8)
++#define PCIE_SW_XFI_RXPCS_BIST_RST		BIT(9)
++#define PCIE_SW_HSG_TXPCS_RST			BIT(10)
++#define PCIE_SW_HSG_RXPCS_RST			BIT(11)
++#define PCIE_PMA_SW_RST				(PCIE_SW_RX_FIFO_RST | \
++						 PCIE_SW_RX_RST | \
++						 PCIE_SW_TX_RST | \
++						 PCIE_SW_PMA_RST | \
++						 PCIE_SW_ALLPCS_RST | \
++						 PCIE_SW_REF_RST | \
++						 PCIE_SW_TX_FIFO_RST | \
++						 PCIE_SW_XFI_TXPCS_RST | \
++						 PCIE_SW_XFI_RXPCS_RST | \
++						 PCIE_SW_XFI_RXPCS_BIST_RST | \
++						 PCIE_SW_HSG_TXPCS_RST | \
++						 PCIE_SW_HSG_RXPCS_RST)
++
++#define REG_PCIE_PMA_RO_RX_FREQDET		0x0530
++#define PCIE_RO_FBCK_LOCK			BIT(0)
++#define PCIE_RO_FL_OUT				GENMASK(31, 16)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC	0x0794
++#define PCIE_FORCE_DA_PXP_CDR_PR_IDAC		GENMASK(10, 0)
++#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC	BIT(16)
++#define PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW	BIT(24)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_SDM_PCW	0x0798
++#define PCIE_FORCE_DA_PXP_TXPLL_SDM_PCW		GENMASK(30, 0)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_VOS	0x079c
++#define PCIE_FORCE_SEL_DA_PXP_JCPLL_SDM_PCW	BIT(16)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_JCPLL_SDM_PCW	0x0800
++#define PCIE_FORCE_DA_PXP_JCPLL_SDM_PCW		GENMASK(30, 0)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PD_PWDB	0x081c
++#define PCIE_FORCE_DA_PXP_CDR_PD_PWDB		BIT(0)
++#define PCIE_FORCE_SEL_DA_PXP_CDR_PD_PWDB	BIT(8)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C	0x0820
++#define PCIE_FORCE_DA_PXP_CDR_PR_LPF_C_EN	BIT(0)
++#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN	BIT(8)
++#define PCIE_FORCE_DA_PXP_CDR_PR_LPF_R_EN	BIT(16)
++#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN	BIT(24)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB	0x0824
++#define PCIE_FORCE_DA_PXP_CDR_PR_PWDB			BIT(16)
++#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB		BIT(24)
++
++#define REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT	0x0828
++#define PCIE_FORCE_DA_PXP_JCPLL_CKOUT_EN	BIT(0)
++#define PCIE_FORCE_SEL_DA_PXP_JCPLL_CKOUT_EN	BIT(8)
++#define PCIE_FORCE_DA_PXP_JCPLL_EN		BIT(16)
++#define PCIE_FORCE_SEL_DA_PXP_JCPLL_EN		BIT(24)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_RX_SCAN_RST	0x0084c
++#define PCIE_FORCE_DA_PXP_RX_SIGDET_PWDB	BIT(16)
++#define PCIE_FORCE_SEL_DA_PXP_RX_SIGDET_PWDB	BIT(24)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT	0x0854
++#define PCIE_FORCE_DA_PXP_TXPLL_CKOUT_EN	BIT(0)
++#define PCIE_FORCE_SEL_DA_PXP_TXPLL_CKOUT_EN	BIT(8)
++#define PCIE_FORCE_DA_PXP_TXPLL_EN		BIT(16)
++#define PCIE_FORCE_SEL_DA_PXP_TXPLL_EN		BIT(24)
++
++#define REG_PCIE_PMA_SCAN_MODE				0x0884
++#define PCIE_FORCE_DA_PXP_JCPLL_KBAND_LOAD_EN		BIT(0)
++#define PCIE_FORCE_SEL_DA_PXP_JCPLL_KBAND_LOAD_EN	BIT(8)
++
++#define REG_PCIE_PMA_DIG_RESERVE_13		0x08bc
++#define PCIE_FLL_IDAC_PCIEG1			GENMASK(10, 0)
++#define PCIE_FLL_IDAC_PCIEG2			GENMASK(26, 16)
++
++#define REG_PCIE_PMA_DIG_RESERVE_14		0x08c0
++#define PCIE_FLL_IDAC_PCIEG3			GENMASK(10, 0)
++#define PCIE_FLL_LOAD_EN			BIT(16)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL	0x088c
++#define PCIE_FORCE_DA_PXP_RX_FE_GAIN_CTRL		GENMASK(1, 0)
++#define PCIE_FORCE_SEL_DA_PXP_RX_FE_GAIN_CTRL		BIT(8)
++
++#define REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_PWDB	0x0894
++#define PCIE_FORCE_DA_PXP_RX_FE_PWDB		BIT(0)
++#define PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB	BIT(8)
++
++#define REG_PCIE_PMA_DIG_RESERVE_12		0x08b8
++#define PCIE_FORCE_PMA_RX_SPEED			GENMASK(7, 4)
++#define PCIE_FORCE_SEL_PMA_RX_SPEED		BIT(7)
++
++#define REG_PCIE_PMA_DIG_RESERVE_17		0x08e0
++
++#define REG_PCIE_PMA_DIG_RESERVE_18		0x08e4
++#define PCIE_PXP_RX_VTH_SEL_PCIE_G1		GENMASK(4, 0)
++#define PCIE_PXP_RX_VTH_SEL_PCIE_G2		GENMASK(12, 8)
++#define PCIE_PXP_RX_VTH_SEL_PCIE_G3		GENMASK(20, 16)
++
++#define REG_PCIE_PMA_DIG_RESERVE_19		0x08e8
++#define PCIE_PCP_RX_REV0_PCIE_GEN1		GENMASK(31, 16)
++
++#define REG_PCIE_PMA_DIG_RESERVE_20		0x08ec
++#define PCIE_PCP_RX_REV0_PCIE_GEN2		GENMASK(15, 0)
++#define PCIE_PCP_RX_REV0_PCIE_GEN3		GENMASK(31, 16)
++
++#define REG_PCIE_PMA_DIG_RESERVE_21		0x08f0
++#define REG_PCIE_PMA_DIG_RESERVE_22		0x08f4
++#define REG_PCIE_PMA_DIG_RESERVE_27		0x0908
++#define REG_PCIE_PMA_DIG_RESERVE_30		0x0914
++
++/* DTIME */
++#define REG_PCIE_PEXTP_DIG_GLB44		0x00
++#define PCIE_XTP_RXDET_VCM_OFF_STB_T_SEL	GENMASK(7, 0)
++#define PCIE_XTP_RXDET_EN_STB_T_SEL		GENMASK(15, 8)
++#define PCIE_XTP_RXDET_FINISH_STB_T_SEL		GENMASK(23, 16)
++#define PCIE_XTP_TXPD_TX_DATA_EN_DLY		GENMASK(27, 24)
++#define PCIE_XTP_TXPD_RXDET_DONE_CDT		BIT(28)
++#define PCIE_XTP_RXDET_LATCH_STB_T_SEL		GENMASK(31, 29)
++
++/* RX AEQ */
++#define REG_PCIE_PEXTP_DIG_LN_RX30_P0		0x0000
++#define PCIE_XTP_LN_RX_PDOWN_L1P2_EXIT_WAIT	GENMASK(7, 0)
++#define PCIE_XTP_LN_RX_PDOWN_T2RLB_DIG_EN	BIT(8)
++#define PCIE_XTP_LN_RX_PDOWN_E0_AEQEN_WAIT	GENMASK(31, 16)
++
++#define REG_PCIE_PEXTP_DIG_LN_RX30_P1		0x0100
++
++#endif /* _PHY_AIROHA_PCIE_H */
+--- a/drivers/phy/airoha/phy-airoha-pcie-regs.h
++++ /dev/null
+@@ -1,494 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0-only
+-/*
+- * Copyright (c) 2024 AIROHA Inc
+- * Author: Lorenzo Bianconi <lorenzo@kernel.org>
+- */
+-
+-#ifndef _PHY_AIROHA_PCIE_H
+-#define _PHY_AIROHA_PCIE_H
+-
+-/* CSR_2L */
+-#define REG_CSR_2L_CMN				0x0000
+-#define CSR_2L_PXP_CMN_LANE_EN			BIT(0)
+-#define CSR_2L_PXP_CMN_TRIM_MASK		GENMASK(28, 24)
+-
+-#define REG_CSR_2L_JCPLL_IB_EXT			0x0004
+-#define REG_CSR_2L_JCPLL_LPF_SHCK_EN		BIT(8)
+-#define CSR_2L_PXP_JCPLL_CHP_IBIAS		GENMASK(21, 16)
+-#define CSR_2L_PXP_JCPLL_CHP_IOFST		GENMASK(29, 24)
+-
+-#define REG_CSR_2L_JCPLL_LPF_BR			0x0008
+-#define CSR_2L_PXP_JCPLL_LPF_BR			GENMASK(4, 0)
+-#define CSR_2L_PXP_JCPLL_LPF_BC			GENMASK(12, 8)
+-#define CSR_2L_PXP_JCPLL_LPF_BP			GENMASK(20, 16)
+-#define CSR_2L_PXP_JCPLL_LPF_BWR		GENMASK(28, 24)
+-
+-#define REG_CSR_2L_JCPLL_LPF_BWC		0x000c
+-#define CSR_2L_PXP_JCPLL_LPF_BWC		GENMASK(4, 0)
+-#define CSR_2L_PXP_JCPLL_KBAND_CODE		GENMASK(23, 16)
+-#define CSR_2L_PXP_JCPLL_KBAND_DIV		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_JCPLL_KBAND_KFC		0x0010
+-#define CSR_2L_PXP_JCPLL_KBAND_KFC		GENMASK(1, 0)
+-#define CSR_2L_PXP_JCPLL_KBAND_KF		GENMASK(9, 8)
+-#define CSR_2L_PXP_JCPLL_KBAND_KS		GENMASK(17, 16)
+-#define CSR_2L_PXP_JCPLL_POSTDIV_EN		BIT(24)
+-
+-#define REG_CSR_2L_JCPLL_MMD_PREDIV_MODE	0x0014
+-#define CSR_2L_PXP_JCPLL_MMD_PREDIV_MODE	GENMASK(1, 0)
+-#define CSR_2L_PXP_JCPLL_POSTDIV_D2		BIT(16)
+-#define CSR_2L_PXP_JCPLL_POSTDIV_D5		BIT(24)
+-
+-#define CSR_2L_PXP_JCPLL_MONCK			0x0018
+-#define CSR_2L_PXP_JCPLL_REFIN_DIV		GENMASK(25, 24)
+-
+-#define REG_CSR_2L_JCPLL_RST_DLY		0x001c
+-#define CSR_2L_PXP_JCPLL_RST_DLY		GENMASK(2, 0)
+-#define CSR_2L_PXP_JCPLL_RST			BIT(8)
+-#define CSR_2L_PXP_JCPLL_SDM_DI_EN		BIT(16)
+-#define CSR_2L_PXP_JCPLL_SDM_DI_LS		GENMASK(25, 24)
+-
+-#define REG_CSR_2L_JCPLL_SDM_IFM		0x0020
+-#define CSR_2L_PXP_JCPLL_SDM_IFM		BIT(0)
+-
+-#define REG_CSR_2L_JCPLL_SDM_HREN		0x0024
+-#define CSR_2L_PXP_JCPLL_SDM_HREN		BIT(0)
+-#define CSR_2L_PXP_JCPLL_TCL_AMP_EN		BIT(8)
+-#define CSR_2L_PXP_JCPLL_TCL_AMP_GAIN		GENMASK(18, 16)
+-#define CSR_2L_PXP_JCPLL_TCL_AMP_VREF		GENMASK(28, 24)
+-
+-#define REG_CSR_2L_JCPLL_TCL_CMP		0x0028
+-#define CSR_2L_PXP_JCPLL_TCL_LPF_EN		BIT(16)
+-#define CSR_2L_PXP_JCPLL_TCL_LPF_BW		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_JCPLL_VCODIV			0x002c
+-#define CSR_2L_PXP_JCPLL_VCO_CFIX		GENMASK(9, 8)
+-#define CSR_2L_PXP_JCPLL_VCO_HALFLSB_EN		BIT(16)
+-#define CSR_2L_PXP_JCPLL_VCO_SCAPWR		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_JCPLL_VCO_TCLVAR		0x0030
+-#define CSR_2L_PXP_JCPLL_VCO_TCLVAR		GENMASK(2, 0)
+-
+-#define REG_CSR_2L_JCPLL_SSC				0x0038
+-#define CSR_2L_PXP_JCPLL_SSC_EN			BIT(0)
+-#define CSR_2L_PXP_JCPLL_SSC_PHASE_INI		BIT(8)
+-#define CSR_2L_PXP_JCPLL_SSC_TRI_EN		BIT(16)
+-
+-#define REG_CSR_2L_JCPLL_SSC_DELTA1		0x003c
+-#define CSR_2L_PXP_JCPLL_SSC_DELTA1		GENMASK(15, 0)
+-#define CSR_2L_PXP_JCPLL_SSC_DELTA		GENMASK(31, 16)
+-
+-#define REG_CSR_2L_JCPLL_SSC_PERIOD		0x0040
+-#define CSR_2L_PXP_JCPLL_SSC_PERIOD		GENMASK(15, 0)
+-
+-#define REG_CSR_2L_JCPLL_TCL_VTP_EN		0x004c
+-#define CSR_2L_PXP_JCPLL_SPARE_LOW		GENMASK(31, 24)
+-
+-#define REG_CSR_2L_JCPLL_TCL_KBAND_VREF		0x0050
+-#define CSR_2L_PXP_JCPLL_TCL_KBAND_VREF		GENMASK(4, 0)
+-#define CSR_2L_PXP_JCPLL_VCO_KBAND_MEAS_EN	BIT(24)
+-
+-#define REG_CSR_2L_750M_SYS_CK			0x0054
+-#define CSR_2L_PXP_TXPLL_LPF_SHCK_EN		BIT(16)
+-#define CSR_2L_PXP_TXPLL_CHP_IBIAS		GENMASK(29, 24)
+-
+-#define REG_CSR_2L_TXPLL_CHP_IOFST		0x0058
+-#define CSR_2L_PXP_TXPLL_CHP_IOFST		GENMASK(5, 0)
+-#define CSR_2L_PXP_TXPLL_LPF_BR			GENMASK(12, 8)
+-#define CSR_2L_PXP_TXPLL_LPF_BC			GENMASK(20, 16)
+-#define CSR_2L_PXP_TXPLL_LPF_BP			GENMASK(28, 24)
+-
+-#define REG_CSR_2L_TXPLL_LPF_BWR		0x005c
+-#define CSR_2L_PXP_TXPLL_LPF_BWR		GENMASK(4, 0)
+-#define CSR_2L_PXP_TXPLL_LPF_BWC		GENMASK(12, 8)
+-#define CSR_2L_PXP_TXPLL_KBAND_CODE		GENMASK(31, 24)
+-
+-#define REG_CSR_2L_TXPLL_KBAND_DIV		0x0060
+-#define CSR_2L_PXP_TXPLL_KBAND_DIV		GENMASK(2, 0)
+-#define CSR_2L_PXP_TXPLL_KBAND_KFC		GENMASK(9, 8)
+-#define CSR_2L_PXP_TXPLL_KBAND_KF		GENMASK(17, 16)
+-#define CSR_2L_PXP_txpll_KBAND_KS		GENMASK(25, 24)
+-
+-#define REG_CSR_2L_TXPLL_POSTDIV		0x0064
+-#define CSR_2L_PXP_TXPLL_POSTDIV_EN		BIT(0)
+-#define CSR_2L_PXP_TXPLL_MMD_PREDIV_MODE	GENMASK(9, 8)
+-#define CSR_2L_PXP_TXPLL_PHY_CK1_EN		BIT(24)
+-
+-#define REG_CSR_2L_TXPLL_PHY_CK2		0x0068
+-#define CSR_2L_PXP_TXPLL_REFIN_INTERNAL		BIT(24)
+-
+-#define REG_CSR_2L_TXPLL_REFIN_DIV		0x006c
+-#define CSR_2L_PXP_TXPLL_REFIN_DIV		GENMASK(1, 0)
+-#define CSR_2L_PXP_TXPLL_RST_DLY		GENMASK(10, 8)
+-#define CSR_2L_PXP_TXPLL_PLL_RSTB		BIT(16)
+-
+-#define REG_CSR_2L_TXPLL_SDM_DI_LS		0x0070
+-#define CSR_2L_PXP_TXPLL_SDM_DI_LS		GENMASK(1, 0)
+-#define CSR_2L_PXP_TXPLL_SDM_IFM		BIT(8)
+-#define CSR_2L_PXP_TXPLL_SDM_ORD		GENMASK(25, 24)
+-
+-#define REG_CSR_2L_TXPLL_SDM_OUT		0x0074
+-#define CSR_2L_PXP_TXPLL_TCL_AMP_EN		BIT(16)
+-#define CSR_2L_PXP_TXPLL_TCL_AMP_GAIN		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_TXPLL_TCL_AMP_VREF		0x0078
+-#define CSR_2L_PXP_TXPLL_TCL_AMP_VREF		GENMASK(4, 0)
+-#define CSR_2L_PXP_TXPLL_TCL_LPF_EN		BIT(24)
+-
+-#define REG_CSR_2L_TXPLL_TCL_LPF_BW		0x007c
+-#define CSR_2L_PXP_TXPLL_TCL_LPF_BW		GENMASK(2, 0)
+-#define CSR_2L_PXP_TXPLL_VCO_CFIX		GENMASK(17, 16)
+-#define CSR_2L_PXP_TXPLL_VCO_HALFLSB_EN		BIT(24)
+-
+-#define REG_CSR_2L_TXPLL_VCO_SCAPWR		0x0080
+-#define CSR_2L_PXP_TXPLL_VCO_SCAPWR		GENMASK(2, 0)
+-
+-#define REG_CSR_2L_TXPLL_SSC			0x0084
+-#define CSR_2L_PXP_TXPLL_SSC_EN			BIT(0)
+-#define CSR_2L_PXP_TXPLL_SSC_PHASE_INI		BIT(8)
+-
+-#define REG_CSR_2L_TXPLL_SSC_DELTA1		0x0088
+-#define CSR_2L_PXP_TXPLL_SSC_DELTA1		GENMASK(15, 0)
+-#define CSR_2L_PXP_TXPLL_SSC_DELTA		GENMASK(31, 16)
+-
+-#define REG_CSR_2L_TXPLL_SSC_PERIOD		0x008c
+-#define CSR_2L_PXP_txpll_SSC_PERIOD		GENMASK(15, 0)
+-
+-#define REG_CSR_2L_TXPLL_VTP			0x0090
+-#define CSR_2L_PXP_TXPLL_VTP_EN			BIT(0)
+-
+-#define REG_CSR_2L_TXPLL_TCL_VTP		0x0098
+-#define CSR_2L_PXP_TXPLL_SPARE_L		GENMASK(31, 24)
+-
+-#define REG_CSR_2L_TXPLL_TCL_KBAND_VREF		0x009c
+-#define CSR_2L_PXP_TXPLL_TCL_KBAND_VREF		GENMASK(4, 0)
+-#define CSR_2L_PXP_TXPLL_VCO_KBAND_MEAS_EN	BIT(24)
+-
+-#define REG_CSR_2L_TXPLL_POSTDIV_D256		0x00a0
+-#define CSR_2L_PXP_CLKTX0_AMP			GENMASK(10, 8)
+-#define CSR_2L_PXP_CLKTX0_OFFSET		GENMASK(17, 16)
+-#define CSR_2L_PXP_CLKTX0_SR			GENMASK(25, 24)
+-
+-#define REG_CSR_2L_CLKTX0_FORCE_OUT1		0x00a4
+-#define CSR_2L_PXP_CLKTX0_HZ			BIT(8)
+-#define CSR_2L_PXP_CLKTX0_IMP_SEL		GENMASK(20, 16)
+-#define CSR_2L_PXP_CLKTX1_AMP			GENMASK(26, 24)
+-
+-#define REG_CSR_2L_CLKTX1_OFFSET		0x00a8
+-#define CSR_2L_PXP_CLKTX1_OFFSET		GENMASK(1, 0)
+-#define CSR_2L_PXP_CLKTX1_SR			GENMASK(9, 8)
+-#define CSR_2L_PXP_CLKTX1_HZ			BIT(24)
+-
+-#define REG_CSR_2L_CLKTX1_IMP_SEL		0x00ac
+-#define CSR_2L_PXP_CLKTX1_IMP_SEL		GENMASK(4, 0)
+-
+-#define REG_CSR_2L_PLL_CMN_RESERVE0		0x00b0
+-#define CSR_2L_PXP_PLL_RESERVE_MASK		GENMASK(15, 0)
+-
+-#define REG_CSR_2L_TX0_CKLDO			0x00cc
+-#define CSR_2L_PXP_TX0_CKLDO_EN			BIT(0)
+-#define CSR_2L_PXP_TX0_DMEDGEGEN_EN		BIT(24)
+-
+-#define REG_CSR_2L_TX1_CKLDO			0x00e8
+-#define CSR_2L_PXP_TX1_CKLDO_EN			BIT(0)
+-#define CSR_2L_PXP_TX1_DMEDGEGEN_EN		BIT(24)
+-
+-#define REG_CSR_2L_TX1_MULTLANE			0x00ec
+-#define CSR_2L_PXP_TX1_MULTLANE_EN		BIT(0)
+-
+-#define REG_CSR_2L_RX0_REV0			0x00fc
+-#define CSR_2L_PXP_VOS_PNINV			GENMASK(19, 18)
+-#define CSR_2L_PXP_FE_GAIN_NORMAL_MODE		GENMASK(22, 20)
+-#define CSR_2L_PXP_FE_GAIN_TRAIN_MODE		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_RX0_PHYCK_DIV		0x0100
+-#define CSR_2L_PXP_RX0_PHYCK_SEL		GENMASK(9, 8)
+-#define CSR_2L_PXP_RX0_PHYCK_RSTB		BIT(16)
+-#define CSR_2L_PXP_RX0_TDC_CK_SEL		BIT(24)
+-
+-#define REG_CSR_2L_CDR0_PD_PICAL_CKD8_INV	0x0104
+-#define CSR_2L_PXP_CDR0_PD_EDGE_DISABLE		BIT(8)
+-
+-#define REG_CSR_2L_CDR0_LPF_RATIO		0x0110
+-#define CSR_2L_PXP_CDR0_LPF_TOP_LIM		GENMASK(26, 8)
+-
+-#define REG_CSR_2L_CDR0_PR_INJ_MODE		0x011c
+-#define CSR_2L_PXP_CDR0_INJ_FORCE_OFF		BIT(24)
+-
+-#define REG_CSR_2L_CDR0_PR_BETA_DAC		0x0120
+-#define CSR_2L_PXP_CDR0_PR_BETA_SEL		GENMASK(19, 16)
+-#define CSR_2L_PXP_CDR0_PR_KBAND_DIV		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_CDR0_PR_VREG_IBAND		0x0124
+-#define CSR_2L_PXP_CDR0_PR_VREG_IBAND		GENMASK(2, 0)
+-#define CSR_2L_PXP_CDR0_PR_VREG_CKBUF		GENMASK(10, 8)
+-
+-#define REG_CSR_2L_CDR0_PR_CKREF_DIV		0x0128
+-#define CSR_2L_PXP_CDR0_PR_CKREF_DIV		GENMASK(1, 0)
+-
+-#define REG_CSR_2L_CDR0_PR_MONCK		0x012c
+-#define CSR_2L_PXP_CDR0_PR_MONCK_ENABLE		BIT(0)
+-#define CSR_2L_PXP_CDR0_PR_RESERVE0		GENMASK(19, 16)
+-
+-#define REG_CSR_2L_CDR0_PR_COR_HBW		0x0130
+-#define CSR_2L_PXP_CDR0_PR_LDO_FORCE_ON		BIT(8)
+-#define CSR_2L_PXP_CDR0_PR_CKREF_DIV1		GENMASK(17, 16)
+-
+-#define REG_CSR_2L_CDR0_PR_MONPI		0x0134
+-#define CSR_2L_PXP_CDR0_PR_XFICK_EN		BIT(8)
+-
+-#define REG_CSR_2L_RX0_SIGDET_DCTEST		0x0140
+-#define CSR_2L_PXP_RX0_SIGDET_LPF_CTRL		GENMASK(9, 8)
+-#define CSR_2L_PXP_RX0_SIGDET_PEAK		GENMASK(25, 24)
+-
+-#define REG_CSR_2L_RX0_SIGDET_VTH_SEL		0x0144
+-#define CSR_2L_PXP_RX0_SIGDET_VTH_SEL		GENMASK(4, 0)
+-#define CSR_2L_PXP_RX0_FE_VB_EQ1_EN		BIT(24)
+-
+-#define REG_CSR_2L_PXP_RX0_FE_VB_EQ2		0x0148
+-#define CSR_2L_PXP_RX0_FE_VB_EQ2_EN		BIT(0)
+-#define CSR_2L_PXP_RX0_FE_VB_EQ3_EN		BIT(8)
+-#define CSR_2L_PXP_RX0_FE_VCM_GEN_PWDB		BIT(16)
+-
+-#define REG_CSR_2L_PXP_RX0_OSCAL_CTLE1IOS	0x0158
+-#define CSR_2L_PXP_RX0_PR_OSCAL_VGA1IOS		GENMASK(29, 24)
+-
+-#define REG_CSR_2L_PXP_RX0_OSCA_VGA1VOS		0x015c
+-#define CSR_2L_PXP_RX0_PR_OSCAL_VGA1VOS		GENMASK(5, 0)
+-#define CSR_2L_PXP_RX0_PR_OSCAL_VGA2IOS		GENMASK(13, 8)
+-
+-#define REG_CSR_2L_RX1_REV0			0x01b4
+-
+-#define REG_CSR_2L_RX1_PHYCK_DIV		0x01b8
+-#define CSR_2L_PXP_RX1_PHYCK_SEL		GENMASK(9, 8)
+-#define CSR_2L_PXP_RX1_PHYCK_RSTB		BIT(16)
+-#define CSR_2L_PXP_RX1_TDC_CK_SEL		BIT(24)
+-
+-#define REG_CSR_2L_CDR1_PD_PICAL_CKD8_INV	0x01bc
+-#define CSR_2L_PXP_CDR1_PD_EDGE_DISABLE		BIT(8)
+-
+-#define REG_CSR_2L_CDR1_PR_BETA_DAC		0x01d8
+-#define CSR_2L_PXP_CDR1_PR_BETA_SEL		GENMASK(19, 16)
+-#define CSR_2L_PXP_CDR1_PR_KBAND_DIV		GENMASK(26, 24)
+-
+-#define REG_CSR_2L_CDR1_PR_MONCK		0x01e4
+-#define CSR_2L_PXP_CDR1_PR_MONCK_ENABLE		BIT(0)
+-#define CSR_2L_PXP_CDR1_PR_RESERVE0		GENMASK(19, 16)
+-
+-#define REG_CSR_2L_CDR1_LPF_RATIO		0x01c8
+-#define CSR_2L_PXP_CDR1_LPF_TOP_LIM		GENMASK(26, 8)
+-
+-#define REG_CSR_2L_CDR1_PR_INJ_MODE		0x01d4
+-#define CSR_2L_PXP_CDR1_INJ_FORCE_OFF		BIT(24)
+-
+-#define REG_CSR_2L_CDR1_PR_VREG_IBAND_VAL	0x01dc
+-#define CSR_2L_PXP_CDR1_PR_VREG_IBAND		GENMASK(2, 0)
+-#define CSR_2L_PXP_CDR1_PR_VREG_CKBUF		GENMASK(10, 8)
+-
+-#define REG_CSR_2L_CDR1_PR_CKREF_DIV		0x01e0
+-#define CSR_2L_PXP_CDR1_PR_CKREF_DIV		GENMASK(1, 0)
+-
+-#define REG_CSR_2L_CDR1_PR_COR_HBW		0x01e8
+-#define CSR_2L_PXP_CDR1_PR_LDO_FORCE_ON		BIT(8)
+-#define CSR_2L_PXP_CDR1_PR_CKREF_DIV1		GENMASK(17, 16)
+-
+-#define REG_CSR_2L_CDR1_PR_MONPI		0x01ec
+-#define CSR_2L_PXP_CDR1_PR_XFICK_EN		BIT(8)
+-
+-#define REG_CSR_2L_RX1_DAC_RANGE_EYE		0x01f4
+-#define CSR_2L_PXP_RX1_SIGDET_LPF_CTRL		GENMASK(25, 24)
+-
+-#define REG_CSR_2L_RX1_SIGDET_NOVTH		0x01f8
+-#define CSR_2L_PXP_RX1_SIGDET_PEAK		GENMASK(9, 8)
+-#define CSR_2L_PXP_RX1_SIGDET_VTH_SEL		GENMASK(20, 16)
+-
+-#define REG_CSR_2L_RX1_FE_VB_EQ1		0x0200
+-#define CSR_2L_PXP_RX1_FE_VB_EQ1_EN		BIT(0)
+-#define CSR_2L_PXP_RX1_FE_VB_EQ2_EN		BIT(8)
+-#define CSR_2L_PXP_RX1_FE_VB_EQ3_EN		BIT(16)
+-#define CSR_2L_PXP_RX1_FE_VCM_GEN_PWDB		BIT(24)
+-
+-#define REG_CSR_2L_RX1_OSCAL_VGA1IOS		0x0214
+-#define CSR_2L_PXP_RX1_PR_OSCAL_VGA1IOS		GENMASK(5, 0)
+-#define CSR_2L_PXP_RX1_PR_OSCAL_VGA1VOS		GENMASK(13, 8)
+-#define CSR_2L_PXP_RX1_PR_OSCAL_VGA2IOS		GENMASK(21, 16)
+-
+-/* PMA */
+-#define REG_PCIE_PMA_SS_LCPLL_PWCTL_SETTING_1	0x0004
+-#define PCIE_LCPLL_MAN_PWDB			BIT(0)
+-
+-#define REG_PCIE_PMA_SEQUENCE_DISB_CTRL1	0x010c
+-#define PCIE_DISB_RX_SDCAL_EN			BIT(0)
+-
+-#define REG_PCIE_PMA_CTRL_SEQUENCE_FORCE_CTRL1	0x0114
+-#define PCIE_FORCE_RX_SDCAL_EN			BIT(0)
+-
+-#define REG_PCIE_PMA_SS_RX_FREQ_DET1		0x014c
+-#define PCIE_PLL_FT_LOCK_CYCLECNT		GENMASK(15, 0)
+-#define PCIE_PLL_FT_UNLOCK_CYCLECNT		GENMASK(31, 16)
+-
+-#define REG_PCIE_PMA_SS_RX_FREQ_DET2		0x0150
+-#define PCIE_LOCK_TARGET_BEG			GENMASK(15, 0)
+-#define PCIE_LOCK_TARGET_END			GENMASK(31, 16)
+-
+-#define REG_PCIE_PMA_SS_RX_FREQ_DET3		0x0154
+-#define PCIE_UNLOCK_TARGET_BEG			GENMASK(15, 0)
+-#define PCIE_UNLOCK_TARGET_END			GENMASK(31, 16)
+-
+-#define REG_PCIE_PMA_SS_RX_FREQ_DET4		0x0158
+-#define PCIE_FREQLOCK_DET_EN			GENMASK(2, 0)
+-#define PCIE_LOCK_LOCKTH			GENMASK(11, 8)
+-#define PCIE_UNLOCK_LOCKTH			GENMASK(15, 12)
+-
+-#define REG_PCIE_PMA_SS_RX_CAL1			0x0160
+-#define REG_PCIE_PMA_SS_RX_CAL2			0x0164
+-#define PCIE_CAL_OUT_OS				GENMASK(11, 8)
+-
+-#define REG_PCIE_PMA_SS_RX_SIGDET0		0x0168
+-#define PCIE_SIGDET_WIN_NONVLD_TIMES		GENMASK(28, 24)
+-
+-#define REG_PCIE_PMA_TX_RESET			0x0260
+-#define PCIE_TX_TOP_RST				BIT(0)
+-#define PCIE_TX_CAL_RST				BIT(8)
+-
+-#define REG_PCIE_PMA_RX_FORCE_MODE0		0x0294
+-#define PCIE_FORCE_DA_XPON_RX_FE_GAIN_CTRL	GENMASK(1, 0)
+-
+-#define REG_PCIE_PMA_SS_DA_XPON_PWDB0		0x034c
+-#define PCIE_DA_XPON_CDR_PR_PWDB		BIT(8)
+-
+-#define REG_PCIE_PMA_SW_RESET			0x0460
+-#define PCIE_SW_RX_FIFO_RST			BIT(0)
+-#define PCIE_SW_RX_RST				BIT(1)
+-#define PCIE_SW_TX_RST				BIT(2)
+-#define PCIE_SW_PMA_RST				BIT(3)
+-#define PCIE_SW_ALLPCS_RST			BIT(4)
+-#define PCIE_SW_REF_RST				BIT(5)
+-#define PCIE_SW_TX_FIFO_RST			BIT(6)
+-#define PCIE_SW_XFI_TXPCS_RST			BIT(7)
+-#define PCIE_SW_XFI_RXPCS_RST			BIT(8)
+-#define PCIE_SW_XFI_RXPCS_BIST_RST		BIT(9)
+-#define PCIE_SW_HSG_TXPCS_RST			BIT(10)
+-#define PCIE_SW_HSG_RXPCS_RST			BIT(11)
+-#define PCIE_PMA_SW_RST				(PCIE_SW_RX_FIFO_RST | \
+-						 PCIE_SW_RX_RST | \
+-						 PCIE_SW_TX_RST | \
+-						 PCIE_SW_PMA_RST | \
+-						 PCIE_SW_ALLPCS_RST | \
+-						 PCIE_SW_REF_RST | \
+-						 PCIE_SW_TX_FIFO_RST | \
+-						 PCIE_SW_XFI_TXPCS_RST | \
+-						 PCIE_SW_XFI_RXPCS_RST | \
+-						 PCIE_SW_XFI_RXPCS_BIST_RST | \
+-						 PCIE_SW_HSG_TXPCS_RST | \
+-						 PCIE_SW_HSG_RXPCS_RST)
+-
+-#define REG_PCIE_PMA_RO_RX_FREQDET		0x0530
+-#define PCIE_RO_FBCK_LOCK			BIT(0)
+-#define PCIE_RO_FL_OUT				GENMASK(31, 16)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_IDAC	0x0794
+-#define PCIE_FORCE_DA_PXP_CDR_PR_IDAC		GENMASK(10, 0)
+-#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_IDAC	BIT(16)
+-#define PCIE_FORCE_SEL_DA_PXP_TXPLL_SDM_PCW	BIT(24)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_SDM_PCW	0x0798
+-#define PCIE_FORCE_DA_PXP_TXPLL_SDM_PCW		GENMASK(30, 0)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_VOS	0x079c
+-#define PCIE_FORCE_SEL_DA_PXP_JCPLL_SDM_PCW	BIT(16)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_JCPLL_SDM_PCW	0x0800
+-#define PCIE_FORCE_DA_PXP_JCPLL_SDM_PCW		GENMASK(30, 0)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PD_PWDB	0x081c
+-#define PCIE_FORCE_DA_PXP_CDR_PD_PWDB		BIT(0)
+-#define PCIE_FORCE_SEL_DA_PXP_CDR_PD_PWDB	BIT(8)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_LPF_C	0x0820
+-#define PCIE_FORCE_DA_PXP_CDR_PR_LPF_C_EN	BIT(0)
+-#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_C_EN	BIT(8)
+-#define PCIE_FORCE_DA_PXP_CDR_PR_LPF_R_EN	BIT(16)
+-#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_LPF_R_EN	BIT(24)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_CDR_PR_PIEYE_PWDB	0x0824
+-#define PCIE_FORCE_DA_PXP_CDR_PR_PWDB			BIT(16)
+-#define PCIE_FORCE_SEL_DA_PXP_CDR_PR_PWDB		BIT(24)
+-
+-#define REG_PCIE_PMA_FORCE_PXP_JCPLL_CKOUT	0x0828
+-#define PCIE_FORCE_DA_PXP_JCPLL_CKOUT_EN	BIT(0)
+-#define PCIE_FORCE_SEL_DA_PXP_JCPLL_CKOUT_EN	BIT(8)
+-#define PCIE_FORCE_DA_PXP_JCPLL_EN		BIT(16)
+-#define PCIE_FORCE_SEL_DA_PXP_JCPLL_EN		BIT(24)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_RX_SCAN_RST	0x0084c
+-#define PCIE_FORCE_DA_PXP_RX_SIGDET_PWDB	BIT(16)
+-#define PCIE_FORCE_SEL_DA_PXP_RX_SIGDET_PWDB	BIT(24)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_TXPLL_CKOUT	0x0854
+-#define PCIE_FORCE_DA_PXP_TXPLL_CKOUT_EN	BIT(0)
+-#define PCIE_FORCE_SEL_DA_PXP_TXPLL_CKOUT_EN	BIT(8)
+-#define PCIE_FORCE_DA_PXP_TXPLL_EN		BIT(16)
+-#define PCIE_FORCE_SEL_DA_PXP_TXPLL_EN		BIT(24)
+-
+-#define REG_PCIE_PMA_SCAN_MODE				0x0884
+-#define PCIE_FORCE_DA_PXP_JCPLL_KBAND_LOAD_EN		BIT(0)
+-#define PCIE_FORCE_SEL_DA_PXP_JCPLL_KBAND_LOAD_EN	BIT(8)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_13		0x08bc
+-#define PCIE_FLL_IDAC_PCIEG1			GENMASK(10, 0)
+-#define PCIE_FLL_IDAC_PCIEG2			GENMASK(26, 16)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_14		0x08c0
+-#define PCIE_FLL_IDAC_PCIEG3			GENMASK(10, 0)
+-#define PCIE_FLL_LOAD_EN			BIT(16)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_GAIN_CTRL	0x088c
+-#define PCIE_FORCE_DA_PXP_RX_FE_GAIN_CTRL		GENMASK(1, 0)
+-#define PCIE_FORCE_SEL_DA_PXP_RX_FE_GAIN_CTRL		BIT(8)
+-
+-#define REG_PCIE_PMA_FORCE_DA_PXP_RX_FE_PWDB	0x0894
+-#define PCIE_FORCE_DA_PXP_RX_FE_PWDB		BIT(0)
+-#define PCIE_FORCE_SEL_DA_PXP_RX_FE_PWDB	BIT(8)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_12		0x08b8
+-#define PCIE_FORCE_PMA_RX_SPEED			GENMASK(7, 4)
+-#define PCIE_FORCE_SEL_PMA_RX_SPEED		BIT(7)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_17		0x08e0
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_18		0x08e4
+-#define PCIE_PXP_RX_VTH_SEL_PCIE_G1		GENMASK(4, 0)
+-#define PCIE_PXP_RX_VTH_SEL_PCIE_G2		GENMASK(12, 8)
+-#define PCIE_PXP_RX_VTH_SEL_PCIE_G3		GENMASK(20, 16)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_19		0x08e8
+-#define PCIE_PCP_RX_REV0_PCIE_GEN1		GENMASK(31, 16)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_20		0x08ec
+-#define PCIE_PCP_RX_REV0_PCIE_GEN2		GENMASK(15, 0)
+-#define PCIE_PCP_RX_REV0_PCIE_GEN3		GENMASK(31, 16)
+-
+-#define REG_PCIE_PMA_DIG_RESERVE_21		0x08f0
+-#define REG_PCIE_PMA_DIG_RESERVE_22		0x08f4
+-#define REG_PCIE_PMA_DIG_RESERVE_27		0x0908
+-#define REG_PCIE_PMA_DIG_RESERVE_30		0x0914
+-
+-/* DTIME */
+-#define REG_PCIE_PEXTP_DIG_GLB44		0x00
+-#define PCIE_XTP_RXDET_VCM_OFF_STB_T_SEL	GENMASK(7, 0)
+-#define PCIE_XTP_RXDET_EN_STB_T_SEL		GENMASK(15, 8)
+-#define PCIE_XTP_RXDET_FINISH_STB_T_SEL		GENMASK(23, 16)
+-#define PCIE_XTP_TXPD_TX_DATA_EN_DLY		GENMASK(27, 24)
+-#define PCIE_XTP_TXPD_RXDET_DONE_CDT		BIT(28)
+-#define PCIE_XTP_RXDET_LATCH_STB_T_SEL		GENMASK(31, 29)
+-
+-/* RX AEQ */
+-#define REG_PCIE_PEXTP_DIG_LN_RX30_P0		0x0000
+-#define PCIE_XTP_LN_RX_PDOWN_L1P2_EXIT_WAIT	GENMASK(7, 0)
+-#define PCIE_XTP_LN_RX_PDOWN_T2RLB_DIG_EN	BIT(8)
+-#define PCIE_XTP_LN_RX_PDOWN_E0_AEQEN_WAIT	GENMASK(31, 16)
+-
+-#define REG_PCIE_PEXTP_DIG_LN_RX30_P1		0x0100
+-
+-#endif /* _PHY_AIROHA_PCIE_H */

--- a/target/linux/airoha/patches-6.6/602-04-phy-airoha-add-support-for-AN7583-PCIe-PHY-driver.patch
+++ b/target/linux/airoha/patches-6.6/602-04-phy-airoha-add-support-for-AN7583-PCIe-PHY-driver.patch
@@ -39,15 +39,12 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 #  AIROHA SPI SNFI DRIVER
 #  M:	Lorenzo Bianconi <lorenzo@kernel.org>
 #  M:	Ray Liu <ray.liu@airoha.com>
-diff --git a/drivers/phy/airoha/Kconfig b/drivers/phy/airoha/Kconfig
-index 08cc1fe4a11c..5fbfc94fd4b7 100644
 --- a/drivers/phy/airoha/Kconfig
 +++ b/drivers/phy/airoha/Kconfig
-@@ -11,6 +11,16 @@ config PHY_AIROHA_EN7581_PCIE
- 	  Say Y here to add support for Airoha EN7581 PCIe PHY driver.
+@@ -12,6 +12,16 @@ config PHY_AIROHA_EN7581_PCIE
  	  This driver create the basic PHY instance and provides initialize
  	  callback for PCIe GEN3 port.
-+
+ 
 +config PHY_AIROHA_AN7583_PCIE
 +	tristate "Airoha AN7583 PCIe-PHY Driver"
 +	depends on ARCH_AIROHA || COMPILE_TEST
@@ -57,20 +54,18 @@ index 08cc1fe4a11c..5fbfc94fd4b7 100644
 +	  Say Y here to add support for Airoha AN7583 PCIe PHY driver.
 +	  This driver create the basic PHY instance and provides initialize
 +	  callback for PCIe GEN3 port.
- 
++
  config PHY_AIROHA_USB
  	tristate "Airoha USB PHY Driver"
-diff --git a/drivers/phy/airoha/Makefile b/drivers/phy/airoha/Makefile
-index f8949a291486..3efb4438e8f2 100644
+ 	depends on ARCH_AIROHA || COMPILE_TEST
 --- a/drivers/phy/airoha/Makefile
 +++ b/drivers/phy/airoha/Makefile
-@@ -1,2 +1,3 @@
- # SPDX-License-Identifier: GPL-2.0-only
- obj-$(CONFIG_PHY_AIROHA_EN7581_PCIE)	+= phy-airoha-en7581-pcie.o
+@@ -1,4 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0
+ 
 +obj-$(CONFIG_PHY_AIROHA_AN7583_PCIE)	+= phy-airoha-an7583-pcie.o
-diff --git a/drivers/phy/airoha/phy-airoha-an7583-pcie-regs.h b/drivers/phy/airoha/phy-airoha-an7583-pcie-regs.h
-new file mode 100644
-index 000000000000..5a243fe4484c
+ obj-$(CONFIG_PHY_AIROHA_EN7581_PCIE)	+= phy-airoha-en7581-pcie.o
+ obj-$(CONFIG_PHY_AIROHA_USB)		+= phy-airoha-usb.o
 --- /dev/null
 +++ b/drivers/phy/airoha/phy-airoha-an7583-pcie-regs.h
 @@ -0,0 +1,550 @@
@@ -624,9 +619,6 @@ index 000000000000..5a243fe4484c
 +#define PCIE_XTP_LN_RX_PDOWN_L1P2_EXIT_WAIT	GENMASK(7, 0)
 +
 +#endif /* _PHY_AIROHA_PCIE_H */
-diff --git a/drivers/phy/airoha/phy-airoha-an7583-pcie.c b/drivers/phy/airoha/phy-airoha-an7583-pcie.c
-new file mode 100644
-index 000000000000..ebdab8db9262
 --- /dev/null
 +++ b/drivers/phy/airoha/phy-airoha-an7583-pcie.c
 @@ -0,0 +1,1069 @@
@@ -1699,6 +1691,3 @@ index 000000000000..ebdab8db9262
 +MODULE_DESCRIPTION("Airoha AN7583 PCIe PHY driver");
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_LICENSE("GPL");
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/603-01-PCI-mediatek-gen3-add-support-for-Airoha-AN7583-SoC.patch
+++ b/target/linux/airoha/patches-6.6/603-01-PCI-mediatek-gen3-add-support-for-Airoha-AN7583-SoC.patch
@@ -15,11 +15,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pci/controller/pcie-mediatek-gen3.c | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
-diff --git a/drivers/pci/controller/pcie-mediatek-gen3.c b/drivers/pci/controller/pcie-mediatek-gen3.c
-index b55f5973414c..84a95aedb39f 100644
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -1356,8 +1356,18 @@ static const struct mtk_gen3_pcie_pdata mtk_pcie_soc_en7581 = {
+@@ -1288,8 +1288,18 @@ static const struct mtk_gen3_pcie_pdata
  	.flags = SKIP_PCIE_RSTB,
  };
  
@@ -38,6 +36,3 @@ index b55f5973414c..84a95aedb39f 100644
  	{ .compatible = "mediatek,mt8192-pcie", .data = &mtk_pcie_soc_mt8192 },
  	{},
  };
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/603-02-PCI-mediatek-add-support-for-Airoha-AN7583-SoC.patch
+++ b/target/linux/airoha/patches-6.6/603-02-PCI-mediatek-add-support-for-Airoha-AN7583-SoC.patch
@@ -17,8 +17,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/pci/controller/pcie-mediatek.c | 84 +++++++++++++++++++-------
  1 file changed, 62 insertions(+), 22 deletions(-)
 
-diff --git a/drivers/pci/controller/pcie-mediatek.c b/drivers/pci/controller/pcie-mediatek.c
-index e1934aa06c8d..96c63956f584 100644
 --- a/drivers/pci/controller/pcie-mediatek.c
 +++ b/drivers/pci/controller/pcie-mediatek.c
 @@ -155,6 +155,7 @@ struct mtk_pcie_soc {
@@ -29,7 +27,7 @@ index e1934aa06c8d..96c63956f584 100644
  	unsigned int device_id;
  	struct pci_ops *ops;
  	int (*startup)(struct mtk_pcie_port *port);
-@@ -683,28 +684,30 @@ static int mtk_pcie_startup_port_v2(struct mtk_pcie_port *port)
+@@ -691,28 +692,30 @@ static int mtk_pcie_startup_port_v2(stru
  		regmap_update_bits(pcie->cfg, PCIE_SYS_CFG_V2, val, val);
  	}
  
@@ -82,7 +80,7 @@ index e1934aa06c8d..96c63956f584 100644
  
  	/* Set up vendor ID and class code */
  	if (soc->need_fix_class_id) {
-@@ -1109,6 +1112,33 @@ static int mtk_pcie_probe(struct platform_device *pdev)
+@@ -1122,6 +1125,33 @@ static int mtk_pcie_probe(struct platfor
  	if (err)
  		goto put_resources;
  
@@ -116,7 +114,7 @@ index e1934aa06c8d..96c63956f584 100644
  	return 0;
  
  put_resources:
-@@ -1209,6 +1239,15 @@ static const struct mtk_pcie_soc mtk_pcie_soc_mt7622 = {
+@@ -1222,6 +1252,15 @@ static const struct mtk_pcie_soc mtk_pci
  	.setup_irq = mtk_pcie_setup_irq,
  };
  
@@ -132,7 +130,7 @@ index e1934aa06c8d..96c63956f584 100644
  static const struct mtk_pcie_soc mtk_pcie_soc_mt7629 = {
  	.need_fix_class_id = true,
  	.need_fix_device_id = true,
-@@ -1219,6 +1258,7 @@ static const struct mtk_pcie_soc mtk_pcie_soc_mt7629 = {
+@@ -1232,6 +1271,7 @@ static const struct mtk_pcie_soc mtk_pci
  };
  
  static const struct of_device_id mtk_pcie_ids[] = {
@@ -140,6 +138,3 @@ index e1934aa06c8d..96c63956f584 100644
  	{ .compatible = "mediatek,mt2701-pcie", .data = &mtk_pcie_soc_v1 },
  	{ .compatible = "mediatek,mt7623-pcie", .data = &mtk_pcie_soc_v1 },
  	{ .compatible = "mediatek,mt2712-pcie", .data = &mtk_pcie_soc_mt2712 },
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/604-01-net-pcs-airoha-add-support-for-AN7583.patch
+++ b/target/linux/airoha/patches-6.6/604-01-net-pcs-airoha-add-support-for-AN7583.patch
@@ -17,8 +17,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  5 files changed, 2686 insertions(+), 3 deletions(-)
  create mode 100644 drivers/net/pcs/airoha/pcs-an7583.c
 
-diff --git a/drivers/net/pcs/airoha/Kconfig b/drivers/net/pcs/airoha/Kconfig
-index ba88cca278b1..c16efa1510e4 100644
 --- a/drivers/net/pcs/airoha/Kconfig
 +++ b/drivers/net/pcs/airoha/Kconfig
 @@ -9,3 +9,10 @@ config PCS_AIROHA_AN7581
@@ -32,8 +30,6 @@ index ba88cca278b1..c16efa1510e4 100644
 +	help
 +	  This module provides helper to phylink for managing the Airoha
 +	  AN7583 PCS for SoC Ethernet and PON SERDES.
-diff --git a/drivers/net/pcs/airoha/Makefile b/drivers/net/pcs/airoha/Makefile
-index 25cb8f090c21..69b8b0a0266b 100644
 --- a/drivers/net/pcs/airoha/Makefile
 +++ b/drivers/net/pcs/airoha/Makefile
 @@ -5,3 +5,6 @@ pcs-airoha-objs			:= pcs-airoha-common.o
@@ -43,8 +39,6 @@ index 25cb8f090c21..69b8b0a0266b 100644
 +ifdef CONFIG_PCS_AIROHA_AN7583
 +pcs-airoha-objs			+= pcs-an7583.o
 +endif
-diff --git a/drivers/net/pcs/airoha/pcs-airoha-common.c b/drivers/net/pcs/airoha/pcs-airoha-common.c
-index 916f03c259bd..f9ba4a47da1d 100644
 --- a/drivers/net/pcs/airoha/pcs-airoha-common.c
 +++ b/drivers/net/pcs/airoha/pcs-airoha-common.c
 @@ -19,6 +19,7 @@
@@ -55,7 +49,7 @@ index 916f03c259bd..f9ba4a47da1d 100644
  	u32 xsi_sel;
  
  	switch (interface) {
-@@ -36,6 +37,12 @@ static void airoha_pcs_setup_scu_eth(struct airoha_pcs_priv *priv,
+@@ -36,6 +37,12 @@ static void airoha_pcs_setup_scu_eth(str
  	regmap_update_bits(priv->scu, AIROHA_SCU_SSR3,
  			   AIROHA_SCU_ETH_XSI_SEL,
  			   xsi_sel);
@@ -68,7 +62,7 @@ index 916f03c259bd..f9ba4a47da1d 100644
  }
  
  static void airoha_pcs_setup_scu_pon(struct airoha_pcs_priv *priv,
-@@ -100,16 +107,24 @@ static int airoha_pcs_setup_scu(struct airoha_pcs_priv *priv,
+@@ -100,16 +107,24 @@ static int airoha_pcs_setup_scu(struct a
  
  static void airoha_pcs_init_usxgmii(struct airoha_pcs_priv *priv)
  {
@@ -96,7 +90,7 @@ index 916f03c259bd..f9ba4a47da1d 100644
  }
  
  static void airoha_pcs_init_hsgmii(struct airoha_pcs_priv *priv)
-@@ -434,6 +449,13 @@ static int airoha_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
+@@ -445,6 +460,13 @@ static int airoha_pcs_config(struct phyl
  					AIROHA_PCS_USXGMII_PCS_AN_CONTROL_7,
  					AIROHA_PCS_USXGMII_RATE_UPDATE_MODE);
  		}
@@ -110,7 +104,7 @@ index 916f03c259bd..f9ba4a47da1d 100644
  	}
  
  	/* Clear any force bit that my be set by bootloader */
-@@ -985,7 +1007,8 @@ static int airoha_pcs_probe(struct platform_device *pdev)
+@@ -1002,7 +1024,8 @@ static int airoha_pcs_probe(struct platf
  	 * manual rx calibration is needed. This is only limited to
  	 * any SoC revision before E2.
  	 */
@@ -120,7 +114,7 @@ index 916f03c259bd..f9ba4a47da1d 100644
  		u32 val;
  
  		ret = regmap_read(priv->scu, AIROHA_SCU_PDIDR, &val);
-@@ -1003,6 +1026,8 @@ static int airoha_pcs_probe(struct platform_device *pdev)
+@@ -1020,6 +1043,8 @@ static int airoha_pcs_probe(struct platf
  
  static const struct airoha_pcs_match_data an7581_pcs_eth = {
  	.port_type = AIROHA_PCS_ETH,
@@ -129,7 +123,7 @@ index 916f03c259bd..f9ba4a47da1d 100644
  	.bringup = an7581_pcs_bringup,
  	.link_up = an7581_pcs_phya_link_up,
  	.rxlock_workaround = an7581_pcs_rxlock_workaround,
-@@ -1008,13 +1032,33 @@ static const struct airoha_pcs_match_data an7581_pcs_eth = {
+@@ -1027,13 +1052,33 @@ static const struct airoha_pcs_match_dat
  
  static const struct airoha_pcs_match_data an7581_pcs_pon = {
  	.port_type = AIROHA_PCS_PON,
@@ -163,8 +157,6 @@ index 916f03c259bd..f9ba4a47da1d 100644
  	{ /* sentinel */ },
  };
  MODULE_DEVICE_TABLE(of, airoha_pcs_of_table);
-diff --git a/drivers/net/pcs/airoha/pcs-airoha.h b/drivers/net/pcs/airoha/pcs-airoha.h
-index 93ddec60d6dd..790adbe5179c 100644
 --- a/drivers/net/pcs/airoha/pcs-airoha.h
 +++ b/drivers/net/pcs/airoha/pcs-airoha.h
 @@ -14,6 +14,9 @@
@@ -785,7 +777,7 @@ index 93ddec60d6dd..790adbe5179c 100644
  	int (*bringup)(struct airoha_pcs_priv *priv,
  			phy_interface_t interface);
  	void (*link_up)(struct airoha_pcs_priv *priv);
-@@ -820,3 +1233,20 @@ static inline int an7581_pcs_rxlock_workaround(struct airoha_pcs_priv *priv)
+@@ -820,3 +1233,20 @@ static inline int an7581_pcs_rxlock_work
  	return 0;
  }
  #endif
@@ -806,9 +798,6 @@ index 93ddec60d6dd..790adbe5179c 100644
 +{
 +}
 +#endif
-diff --git a/drivers/net/pcs/airoha/pcs-an7583.c b/drivers/net/pcs/airoha/pcs-an7583.c
-new file mode 100644
-index 000000000000..8d8f79746d5b
 --- /dev/null
 +++ b/drivers/net/pcs/airoha/pcs-an7583.c
 @@ -0,0 +1,2199 @@
@@ -3011,6 +3000,3 @@ index 000000000000..8d8f79746d5b
 +	regmap_clear_bits(priv->xfi_pma, AIROHA_PCS_PMA_RX_CTRL_SEQUENCE_FORCE_CTRL_1,
 +			AIROHA_PCS_PMA_DISB_RX_RDY);
 +}
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
+++ b/target/linux/airoha/patches-6.6/604-02-net-ethernet-airoha-define-sport-value-for-GDM3.patch
@@ -12,11 +12,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/ethernet/airoha/airoha_eth.c | 3 +++
  1 file changed, 3 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 0c198ab6b30f..3cb4d35cd475 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -598,6 +598,9 @@ static int airoha_qdma_get_gdm_port(struct airoha_eth *eth,
+@@ -606,6 +606,9 @@ static int airoha_qdma_get_gdm_port(stru
  	case 0x18:
  		port = 3; /* GDM4 */
  		break;
@@ -26,6 +24,3 @@ index 0c198ab6b30f..3cb4d35cd475 100644
  	case 0x10 ... 0x14:
  		port = 0; /* GDM1 */
  		break;
--- 
-2.50.0
-

--- a/target/linux/airoha/patches-6.6/605-net-pcs-airoha-add-support-for-optional-xfi-reset-li.patch
+++ b/target/linux/airoha/patches-6.6/605-net-pcs-airoha-add-support-for-optional-xfi-reset-li.patch
@@ -16,11 +16,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/pcs/airoha/pcs-airoha.h        |  1 +
  2 files changed, 13 insertions(+)
 
-diff --git a/drivers/net/pcs/airoha/pcs-airoha-common.c b/drivers/net/pcs/airoha/pcs-airoha-common.c
-index f9ba4a47da1d..f9e845dceca2 100644
 --- a/drivers/net/pcs/airoha/pcs-airoha-common.c
 +++ b/drivers/net/pcs/airoha/pcs-airoha-common.c
-@@ -82,6 +82,10 @@ static int airoha_pcs_setup_scu(struct airoha_pcs_priv *priv,
+@@ -82,6 +82,10 @@ static int airoha_pcs_setup_scu(struct a
  	const struct airoha_pcs_match_data *data = priv->data;
  	int ret;
  
@@ -31,7 +29,7 @@ index f9ba4a47da1d..f9e845dceca2 100644
  	switch (data->port_type) {
  	case AIROHA_PCS_ETH:
  		airoha_pcs_setup_scu_eth(priv, interface);
-@@ -91,6 +95,10 @@ static int airoha_pcs_setup_scu(struct airoha_pcs_priv *priv,
+@@ -91,6 +95,10 @@ static int airoha_pcs_setup_scu(struct a
  		break;
  	}
  
@@ -42,7 +40,7 @@ index f9ba4a47da1d..f9e845dceca2 100644
  	/* TODO better handle reset from MAC */
  	ret = reset_control_bulk_assert(ARRAY_SIZE(priv->rsts),
  					priv->rsts);
-@@ -1001,6 +1009,10 @@ static int airoha_pcs_probe(struct platform_device *pdev)
+@@ -1020,6 +1028,10 @@ static int airoha_pcs_probe(struct platf
  	if (ret)
  		return dev_err_probe(dev, ret, "failed to get bulk reset lines\n");
  
@@ -53,8 +51,6 @@ index f9ba4a47da1d..f9e845dceca2 100644
  	/* For Ethernet PCS, read the AN7581 SoC revision to check if
  	 * manual rx calibration is needed. This is only limited to
  	 * any SoC revision before E2.
-diff --git a/drivers/net/pcs/airoha/pcs-airoha.h b/drivers/net/pcs/airoha/pcs-airoha.h
-index 790adbe5179c..c7041e2f7148 100644
 --- a/drivers/net/pcs/airoha/pcs-airoha.h
 +++ b/drivers/net/pcs/airoha/pcs-airoha.h
 @@ -1184,6 +1184,7 @@ struct airoha_pcs_priv {
@@ -65,6 +61,3 @@ index 790adbe5179c..c7041e2f7148 100644
  	struct reset_control_bulk_data rsts[AIROHA_PCS_MAX_NUM_RSTS];
  
  	bool manual_rx_calib;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/606-net-phy-mediatek-add-calibration-logic-for-AN7583.patch
+++ b/target/linux/airoha/patches-6.6/606-net-phy-mediatek-add-calibration-logic-for-AN7583.patch
@@ -23,20 +23,17 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  6 files changed, 263 insertions(+), 9 deletions(-)
  create mode 100644 drivers/net/phy/mediatek/an7583.c
 
-diff --git a/drivers/net/phy/mediatek/Makefile b/drivers/net/phy/mediatek/Makefile
-index 7c5c8f8158e5..c554343c84d4 100644
 --- a/drivers/net/phy/mediatek/Makefile
 +++ b/drivers/net/phy/mediatek/Makefile
-@@ -4,3 +4,3 @@ obj-$(CONFIG_MEDIATEK_GE_PHY)		+= mtk-ge.o
+@@ -3,4 +3,4 @@ obj-$(CONFIG_MTK_NET_PHYLIB)		+= mtk-phy
+ obj-$(CONFIG_MEDIATEK_GE_PHY)		+= mtk-ge.o
  obj-$(CONFIG_MEDIATEK_GE_SOC_PHY)	+= mtk-ge-soc.o
  mtk-ge-soc-objs				+= mtk-ge-soc.o
 -mtk-ge-soc-objs				+= airoha-phy-lib.o an7581.o
 +mtk-ge-soc-objs				+= airoha-phy-lib.o an7581.o an7583.o
-diff --git a/drivers/net/phy/mediatek/airoha-phy-lib.c b/drivers/net/phy/mediatek/airoha-phy-lib.c
-index 78783aac2d03..a28cf6b7f51e 100644
 --- a/drivers/net/phy/mediatek/airoha-phy-lib.c
 +++ b/drivers/net/phy/mediatek/airoha-phy-lib.c
-@@ -613,8 +613,9 @@ static int airoha_rx_offset_cal_sw(struct phy_device *phydev)
+@@ -612,8 +612,9 @@ static int airoha_rx_offset_cal_sw(struc
  	phy_clear_bits_mmd(phydev, MDIO_MMD_VEND1, 0x171,
  			   BIT(8) | BIT(7));
  
@@ -48,9 +45,6 @@ index 78783aac2d03..a28cf6b7f51e 100644
  
  	return 0;
  }
-diff --git a/drivers/net/phy/mediatek/an7583.c b/drivers/net/phy/mediatek/an7583.c
-new file mode 100644
-index 000000000000..5e8c02d0bdfb
 --- /dev/null
 +++ b/drivers/net/phy/mediatek/an7583.c
 @@ -0,0 +1,253 @@
@@ -307,11 +301,9 @@ index 000000000000..5e8c02d0bdfb
 +
 +	return 0;
 +}
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.c b/drivers/net/phy/mediatek/mtk-ge-soc.c
-index da08ee90948d..4ec1c394304b 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
-@@ -1147,12 +1147,6 @@ static int an7581_phy_led_polarity_set(struct phy_device *phydev, int index,
+@@ -1139,12 +1139,6 @@ static int an7581_phy_led_polarity_set(s
  			      MTK_PHY_LED_ON_POLARITY, val);
  }
  
@@ -324,7 +316,7 @@ index da08ee90948d..4ec1c394304b 100644
  static struct phy_driver mtk_socphy_driver[] = {
  	{
  		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981),
-@@ -1213,6 +1207,8 @@ static struct phy_driver mtk_socphy_driver[] = {
+@@ -1205,6 +1199,8 @@ static struct phy_driver mtk_socphy_driv
  		.led_hw_control_set = mt798x_phy_led_hw_control_set,
  		.led_hw_control_get = mt798x_phy_led_hw_control_get,
  		.led_polarity_set = an7581_phy_led_polarity_set,
@@ -333,19 +325,15 @@ index da08ee90948d..4ec1c394304b 100644
  	},
  };
  
-diff --git a/drivers/net/phy/mediatek/mtk-ge-soc.h b/drivers/net/phy/mediatek/mtk-ge-soc.h
-index db8e96c83a99..aed4be71deb2 100644
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.h
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.h
-@@ -412,5 +412,6 @@ int airoha_phy_auto_select_transformer(struct phy_device *phydev);
+@@ -412,5 +412,6 @@ int airoha_phy_auto_select_transformer(s
  int airoha_phy_tx_amp_compensation(struct phy_device *phydev);
  
  int an7581_phy_config_init(struct phy_device *phydev);
 +int an7583_phy_config_init(struct phy_device *phydev);
  
  #endif /* _MTK_GE_SOC_H_ */
-diff --git a/drivers/net/phy/mediatek/mtk.h b/drivers/net/phy/mediatek/mtk.h
-index f172f7d671c9..11f32a8f4b3a 100644
 --- a/drivers/net/phy/mediatek/mtk.h
 +++ b/drivers/net/phy/mediatek/mtk.h
 @@ -13,6 +13,7 @@
@@ -356,6 +344,3 @@ index f172f7d671c9..11f32a8f4b3a 100644
  #define MTK_PHY_PAGE_STANDARD			0x0000
  #define MTK_PHY_PAGE_EXTENDED_52B5		0x52b5
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/607-phy-airoha-Add-support-for-Airoha-AN7583-USB-PHY.patch
+++ b/target/linux/airoha/patches-6.6/607-phy-airoha-Add-support-for-Airoha-AN7583-USB-PHY.patch
@@ -19,11 +19,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  rename drivers/phy/airoha/{phy-airoha-usb.c => phy-airoha-an7581-usb.c} (100%)
  create mode 100644 drivers/phy/airoha/phy-airoha-an7583-usb.c
 
-diff --git a/drivers/phy/airoha/Kconfig b/drivers/phy/airoha/Kconfig
-index 0675d8f2f9d1..98859d41c4db 100644
 --- a/drivers/phy/airoha/Kconfig
 +++ b/drivers/phy/airoha/Kconfig
-@@ -12,12 +12,22 @@ config PHY_AIROHA_PCIE
+@@ -22,12 +22,22 @@ config PHY_AIROHA_AN7583_PCIE
  	  This driver create the basic PHY instance and provides initialize
  	  callback for PCIe GEN3 port.
  
@@ -49,24 +47,15 @@ index 0675d8f2f9d1..98859d41c4db 100644
 +	  Say 'Y' here to add support for Airoha AN7583 USB PHY driver.
  	  This driver create the basic PHY instance and provides initialize
  	  callback for USB port.
-diff --git a/drivers/phy/airoha/Makefile b/drivers/phy/airoha/Makefile
-index fd188d08c412..2424bf36872c 100644
 --- a/drivers/phy/airoha/Makefile
 +++ b/drivers/phy/airoha/Makefile
-@@ -1,4 +1,5 @@
+@@ -2,4 +2,5 @@
  
  obj-$(CONFIG_PHY_AIROHA_AN7583_PCIE)	+= phy-airoha-an7583-pcie.o
  obj-$(CONFIG_PHY_AIROHA_EN7581_PCIE)	+= phy-airoha-en7581-pcie.o
 -obj-$(CONFIG_PHY_AIROHA_USB)		+= phy-airoha-usb.o
 +obj-$(CONFIG_PHY_AIROHA_AN7581_USB)	+= phy-airoha-an7581-usb.o
 +obj-$(CONFIG_PHY_AIROHA_AN7583_USB)	+= phy-airoha-an7583-usb.o
-diff --git a/drivers/phy/airoha/phy-airoha-usb.c b/drivers/phy/airoha/phy-airoha-an7581-usb.c
-similarity index 100%
-rename from drivers/phy/airoha/phy-airoha-usb.c
-rename to drivers/phy/airoha/phy-airoha-an7581-usb.c
-diff --git a/drivers/phy/airoha/phy-airoha-an7583-usb.c b/drivers/phy/airoha/phy-airoha-an7583-usb.c
-new file mode 100644
-index 000000000000..3c948336c871
 --- /dev/null
 +++ b/drivers/phy/airoha/phy-airoha-an7583-usb.c
 @@ -0,0 +1,1310 @@
@@ -1380,6 +1369,1201 @@ index 000000000000..3c948336c871
 +MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
 +MODULE_LICENSE("GPL");
 +MODULE_DESCRIPTION("Airoha USB PHY driver");
--- 
-2.51.0
-
+--- /dev/null
++++ b/drivers/phy/airoha/phy-airoha-an7581-usb.c
+@@ -0,0 +1,596 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Author: Christian Marangi <ansuelsmth@gmail.com>
++ */
++
++#include <dt-bindings/phy/phy.h>
++#include <dt-bindings/soc/airoha,scu-ssr.h>
++#include <linux/bitfield.h>
++#include <linux/math.h>
++#include <linux/module.h>
++#include <linux/mfd/syscon.h>
++#include <linux/phy/phy.h>
++#include <linux/platform_device.h>
++#include <linux/regmap.h>
++
++/* SCU */
++#define AIROHA_SCU_SSTR				0x9c
++#define   AIROHA_SCU_SSTR_USB_PCIE_SEL		BIT(3)
++#define   AIROHA_SCU_SSTR_USB_PCIE_SEL_PCIE	FIELD_PREP_CONST(AIROHA_SCU_SSTR_USB_PCIE_SEL, 0x0)
++#define   AIROHA_SCU_SSTR_USB_PCIE_SEL_USB	FIELD_PREP_CONST(AIROHA_SCU_SSTR_USB_PCIE_SEL, 0x1)
++
++/* U2PHY */
++#define AIROHA_USB_PHY_FMCR0			0x100
++#define   AIROHA_USB_PHY_MONCLK_SEL		GENMASK(27, 26)
++#define   AIROHA_USB_PHY_MONCLK_SEL0		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x0)
++#define   AIROHA_USB_PHY_MONCLK_SEL1		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x1)
++#define   AIROHA_USB_PHY_MONCLK_SEL2		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x2)
++#define   AIROHA_USB_PHY_MONCLK_SEL3		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x3)
++#define   AIROHA_USB_PHY_FREQDET_EN		BIT(24)
++#define   AIROHA_USB_PHY_CYCLECNT		GENMASK(23, 0)
++#define AIROHA_USB_PHY_FMMONR0			0x10c
++#define   AIROHA_USB_PHY_USB_FM_OUT		GENMASK(31, 0)
++#define AIROHA_USB_PHY_FMMONR1			0x110
++#define   AIROHA_USB_PHY_FRCK_EN		BIT(8)
++
++#define AIROHA_USB_PHY_USBPHYACR4		0x310
++#define   AIROHA_USB_PHY_USB20_FS_CR		GENMASK(10, 8)
++#define   AIROHA_USB_PHY_USB20_FS_CR_MAX	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x0)
++#define   AIROHA_USB_PHY_USB20_FS_CR_NORMAL	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x2)
++#define   AIROHA_USB_PHY_USB20_FS_CR_SMALLER	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x4)
++#define   AIROHA_USB_PHY_USB20_FS_CR_MIN	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x6)
++#define   AIROHA_USB_PHY_USB20_FS_SR		GENMASK(2, 0)
++#define   AIROHA_USB_PHY_USB20_FS_SR_MAX	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x0)
++#define   AIROHA_USB_PHY_USB20_FS_SR_NORMAL	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x2)
++#define   AIROHA_USB_PHY_USB20_FS_SR_SMALLER	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x4)
++#define   AIROHA_USB_PHY_USB20_FS_SR_MIN	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x6)
++#define AIROHA_USB_PHY_USBPHYACR5		0x314
++#define   AIROHA_USB_PHY_USB20_HSTX_SRCAL_EN	BIT(15)
++#define   AIROHA_USB_PHY_USB20_HSTX_SRCTRL	GENMASK(14, 12)
++#define AIROHA_USB_PHY_USBPHYACR6		0x318
++#define   AIROHA_USB_PHY_USB20_BC11_SW_EN	BIT(23)
++#define   AIROHA_USB_PHY_USB20_DISCTH		GENMASK(7, 4)
++#define   AIROHA_USB_PHY_USB20_DISCTH_400	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x0)
++#define   AIROHA_USB_PHY_USB20_DISCTH_420	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x1)
++#define   AIROHA_USB_PHY_USB20_DISCTH_440	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x2)
++#define   AIROHA_USB_PHY_USB20_DISCTH_460	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x3)
++#define   AIROHA_USB_PHY_USB20_DISCTH_480	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x4)
++#define   AIROHA_USB_PHY_USB20_DISCTH_500	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x5)
++#define   AIROHA_USB_PHY_USB20_DISCTH_520	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x6)
++#define   AIROHA_USB_PHY_USB20_DISCTH_540	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x7)
++#define   AIROHA_USB_PHY_USB20_DISCTH_560	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x8)
++#define   AIROHA_USB_PHY_USB20_DISCTH_580	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x9)
++#define   AIROHA_USB_PHY_USB20_DISCTH_600	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xa)
++#define   AIROHA_USB_PHY_USB20_DISCTH_620	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xb)
++#define   AIROHA_USB_PHY_USB20_DISCTH_640	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xc)
++#define   AIROHA_USB_PHY_USB20_DISCTH_660	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xd)
++#define   AIROHA_USB_PHY_USB20_DISCTH_680	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xe)
++#define   AIROHA_USB_PHY_USB20_DISCTH_700	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xf)
++#define   AIROHA_USB_PHY_USB20_SQTH		GENMASK(3, 0)
++#define   AIROHA_USB_PHY_USB20_SQTH_85		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x0)
++#define   AIROHA_USB_PHY_USB20_SQTH_90		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x1)
++#define   AIROHA_USB_PHY_USB20_SQTH_95		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x2)
++#define   AIROHA_USB_PHY_USB20_SQTH_100		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x3)
++#define   AIROHA_USB_PHY_USB20_SQTH_105		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x4)
++#define   AIROHA_USB_PHY_USB20_SQTH_110		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x5)
++#define   AIROHA_USB_PHY_USB20_SQTH_115		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x6)
++#define   AIROHA_USB_PHY_USB20_SQTH_120		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x7)
++#define   AIROHA_USB_PHY_USB20_SQTH_125		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x8)
++#define   AIROHA_USB_PHY_USB20_SQTH_130		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x9)
++#define   AIROHA_USB_PHY_USB20_SQTH_135		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xa)
++#define   AIROHA_USB_PHY_USB20_SQTH_140		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xb)
++#define   AIROHA_USB_PHY_USB20_SQTH_145		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xc)
++#define   AIROHA_USB_PHY_USB20_SQTH_150		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xd)
++#define   AIROHA_USB_PHY_USB20_SQTH_155		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xe)
++#define   AIROHA_USB_PHY_USB20_SQTH_160		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xf)
++
++#define AIROHA_USB_PHY_U2PHYDTM1		0x36c
++#define   AIROHA_USB_PHY_FORCE_IDDIG		BIT(9)
++#define   AIROHA_USB_PHY_IDDIG			BIT(1)
++
++#define AIROHA_USB_PHY_GPIO_CTLD		0x80c
++#define   AIROHA_USB_PHY_C60802_GPIO_CTLD	GENMASK(31, 0)
++#define     AIROHA_USB_PHY_SSUSB_IP_SW_RST	BIT(31)
++#define     AIROHA_USB_PHY_MCU_BUS_CK_GATE_EN	BIT(30)
++#define     AIROHA_USB_PHY_FORCE_SSUSB_IP_SW_RST BIT(29)
++#define     AIROHA_USB_PHY_SSUSB_SW_RST		BIT(28)
++
++#define AIROHA_USB_PHY_U3_PHYA_REG0		0xb00
++#define   AIROHA_USB_PHY_SSUSB_BG_DIV		GENMASK(29, 28)
++#define   AIROHA_USB_PHY_SSUSB_BG_DIV_2		FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x0)
++#define   AIROHA_USB_PHY_SSUSB_BG_DIV_4		FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x1)
++#define   AIROHA_USB_PHY_SSUSB_BG_DIV_8		FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x2)
++#define   AIROHA_USB_PHY_SSUSB_BG_DIV_16	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x3)
++#define AIROHA_USB_PHY_U3_PHYA_REG1		0xb04
++#define   AIROHA_USB_PHY_SSUSB_XTAL_TOP_RESERVE	GENMASK(25, 10)
++#define AIROHA_USB_PHY_U3_PHYA_REG6		0xb18
++#define   AIROHA_USB_PHY_SSUSB_CDR_RESERVE	GENMASK(31, 24)
++#define AIROHA_USB_PHY_U3_PHYA_REG8		0xb20
++#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY	GENMASK(7, 6)
++#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_32	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x0)
++#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_64	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x1)
++#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_128	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x2)
++#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_216	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x3)
++
++#define AIROHA_USB_PHY_U3_PHYA_DA_REG19		0xc38
++#define   AIROHA_USB_PHY_SSUSB_PLL_SSC_DELTA1_U3 GENMASK(15, 0)
++
++#define AIROHA_USB_PHY_U2_FM_DET_CYCLE_CNT	1024
++#define AIROHA_USB_PHY_REF_CK			20
++#define AIROHA_USB_PHY_U2_SR_COEF		28
++#define AIROHA_USB_PHY_U2_SR_COEF_DIVISOR	1000
++
++#define AIROHA_USB_PHY_DEFAULT_SR_CALIBRATION	0x5
++#define AIROHA_USB_PHY_FREQDET_SLEEP		1000 /* 1ms */
++#define AIROHA_USB_PHY_FREQDET_TIMEOUT		(AIROHA_USB_PHY_FREQDET_SLEEP * 10)
++
++struct airoha_usb_phy_instance {
++	struct phy *phy;
++	u32 type;
++};
++
++enum airoha_usb_phy_instance_type {
++	AIROHA_PHY_USB2,
++	AIROHA_PHY_USB3,
++
++	AIROHA_PHY_USB_MAX,
++};
++
++struct airoha_usb_phy_priv {
++	struct device *dev;
++	struct regmap *regmap;
++	struct regmap *scu;
++
++	unsigned int monclk_sel;
++	unsigned int serdes_port;
++
++	struct airoha_usb_phy_instance *phys[AIROHA_PHY_USB_MAX];
++};
++
++static void airoha_usb_phy_u2_slew_rate_calibration(struct airoha_usb_phy_priv *priv)
++{
++	u32 fm_out;
++	u32 srctrl;
++
++	/* Enable HS TX SR calibration */
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR5,
++			AIROHA_USB_PHY_USB20_HSTX_SRCAL_EN);
++
++	usleep_range(1000, 1500);
++
++	/* Enable Free run clock */
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_FMMONR1,
++			AIROHA_USB_PHY_FRCK_EN);
++
++	/* Select Monitor Clock */
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
++			   AIROHA_USB_PHY_MONCLK_SEL,
++			   FIELD_PREP(AIROHA_USB_PHY_MONCLK_SEL,
++				      priv->monclk_sel));
++
++	/* Set cyclecnt */
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
++			   AIROHA_USB_PHY_CYCLECNT,
++			   FIELD_PREP(AIROHA_USB_PHY_CYCLECNT,
++				      AIROHA_USB_PHY_U2_FM_DET_CYCLE_CNT));
++
++	/* Enable Frequency meter */
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
++			AIROHA_USB_PHY_FREQDET_EN);
++
++	/* Timeout can happen and we will apply workaround at the end */
++	regmap_read_poll_timeout(priv->regmap, AIROHA_USB_PHY_FMMONR0, fm_out,
++				 fm_out, AIROHA_USB_PHY_FREQDET_SLEEP,
++				 AIROHA_USB_PHY_FREQDET_TIMEOUT);
++
++	/* Disable Frequency meter */
++	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
++			  AIROHA_USB_PHY_FREQDET_EN);
++
++	/* Disable Free run clock */
++	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_FMMONR1,
++			  AIROHA_USB_PHY_FRCK_EN);
++
++	/* Disable HS TX SR calibration */
++	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR5,
++			  AIROHA_USB_PHY_USB20_HSTX_SRCAL_EN);
++
++	usleep_range(1000, 1500);
++
++	/* Frequency was not detected, use default SR calibration value */
++	if (!fm_out) {
++		srctrl = AIROHA_USB_PHY_DEFAULT_SR_CALIBRATION;
++		dev_err(priv->dev, "Frequency not detected, using default SR calibration.\n");
++	} else {
++		/* (1024 / FM_OUT) * REF_CK * U2_SR_COEF (round to the nearest digits) */
++		srctrl = AIROHA_USB_PHY_REF_CK * AIROHA_USB_PHY_U2_SR_COEF;
++		srctrl = (srctrl * AIROHA_USB_PHY_U2_FM_DET_CYCLE_CNT) / fm_out;
++		srctrl = DIV_ROUND_CLOSEST(srctrl, AIROHA_USB_PHY_U2_SR_COEF_DIVISOR);
++		dev_dbg(priv->dev, "SR calibration applied: %x\n", srctrl);
++	}
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR5,
++			   AIROHA_USB_PHY_USB20_HSTX_SRCTRL,
++			   FIELD_PREP(AIROHA_USB_PHY_USB20_HSTX_SRCTRL, srctrl));
++}
++
++static void airoha_usb_phy_u2_init(struct airoha_usb_phy_priv *priv)
++{
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR4,
++			   AIROHA_USB_PHY_USB20_FS_CR,
++			   AIROHA_USB_PHY_USB20_FS_CR_MIN);
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR4,
++			   AIROHA_USB_PHY_USB20_FS_SR,
++			   AIROHA_USB_PHY_USB20_FS_SR_NORMAL);
++
++	/* FIXME: evaluate if needed */
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
++			   AIROHA_USB_PHY_USB20_SQTH,
++			   AIROHA_USB_PHY_USB20_SQTH_130);
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
++			   AIROHA_USB_PHY_USB20_DISCTH,
++			   AIROHA_USB_PHY_USB20_DISCTH_600);
++
++	/* Enable the USB port and then disable after calibration */
++	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
++			  AIROHA_USB_PHY_USB20_BC11_SW_EN);
++
++	airoha_usb_phy_u2_slew_rate_calibration(priv);
++
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
++			AIROHA_USB_PHY_USB20_BC11_SW_EN);
++
++	usleep_range(1000, 1500);
++}
++
++/*
++ * USB 3.0 mode can only work if USB serdes is correctly set.
++ * This is validated in xLate function.
++ */
++static void airoha_usb_phy_u3_init(struct airoha_usb_phy_priv *priv)
++{
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG8,
++			   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY,
++			   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_32);
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG6,
++			   AIROHA_USB_PHY_SSUSB_CDR_RESERVE,
++			   FIELD_PREP(AIROHA_USB_PHY_SSUSB_CDR_RESERVE, 0xe));
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG0,
++			   AIROHA_USB_PHY_SSUSB_BG_DIV,
++			   AIROHA_USB_PHY_SSUSB_BG_DIV_4);
++
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG1,
++			FIELD_PREP(AIROHA_USB_PHY_SSUSB_XTAL_TOP_RESERVE, 0x600));
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_DA_REG19,
++			   AIROHA_USB_PHY_SSUSB_PLL_SSC_DELTA1_U3,
++			   FIELD_PREP(AIROHA_USB_PHY_SSUSB_PLL_SSC_DELTA1_U3, 0x43));
++}
++
++static int airoha_usb_phy_init(struct phy *phy)
++{
++	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
++	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
++
++	switch (instance->type) {
++	case PHY_TYPE_USB2:
++		airoha_usb_phy_u2_init(priv);
++		break;
++	case PHY_TYPE_USB3:
++		if (phy_get_mode(phy) == PHY_MODE_PCIE)
++			return 0;
++
++		airoha_usb_phy_u3_init(priv);
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int airoha_usb_phy_u2_power_on(struct airoha_usb_phy_priv *priv)
++{
++	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
++			  AIROHA_USB_PHY_USB20_BC11_SW_EN);
++
++	usleep_range(1000, 1500);
++
++	return 0;
++}
++
++static int airoha_usb_phy_u3_power_on(struct airoha_usb_phy_priv *priv)
++{
++	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_GPIO_CTLD,
++			  AIROHA_USB_PHY_SSUSB_IP_SW_RST |
++			  AIROHA_USB_PHY_MCU_BUS_CK_GATE_EN |
++			  AIROHA_USB_PHY_FORCE_SSUSB_IP_SW_RST |
++			  AIROHA_USB_PHY_SSUSB_SW_RST);
++
++	usleep_range(1000, 1500);
++
++	return 0;
++}
++
++static int airoha_usb_phy_power_on(struct phy *phy)
++{
++	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
++	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
++
++	switch (instance->type) {
++	case PHY_TYPE_USB2:
++		airoha_usb_phy_u2_power_on(priv);
++		break;
++	case PHY_TYPE_USB3:
++		if (phy_get_mode(phy) == PHY_MODE_PCIE)
++			return 0;
++
++		airoha_usb_phy_u3_power_on(priv);
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int airoha_usb_phy_u2_power_off(struct airoha_usb_phy_priv *priv)
++{
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
++			AIROHA_USB_PHY_USB20_BC11_SW_EN);
++
++	usleep_range(1000, 1500);
++
++	return 0;
++}
++
++static int airoha_usb_phy_u3_power_off(struct airoha_usb_phy_priv *priv)
++{
++	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_GPIO_CTLD,
++			AIROHA_USB_PHY_SSUSB_IP_SW_RST |
++			AIROHA_USB_PHY_FORCE_SSUSB_IP_SW_RST);
++
++	usleep_range(1000, 1500);
++
++	return 0;
++}
++
++static int airoha_usb_phy_power_off(struct phy *phy)
++{
++	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
++	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
++
++	switch (instance->type) {
++	case PHY_TYPE_USB2:
++		airoha_usb_phy_u2_power_off(priv);
++		break;
++	case PHY_TYPE_USB3:
++		if (phy_get_mode(phy) == PHY_MODE_PCIE)
++			return 0;
++
++		airoha_usb_phy_u3_power_off(priv);
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int airoha_usb_phy_u2_set_mode(struct airoha_usb_phy_priv *priv,
++				      enum phy_mode mode)
++{
++	u32 val;
++
++	/*
++	 * For Device and Host mode, enable force IDDIG.
++	 * For Device set IDDIG, for Host clear IDDIG.
++	 * For OTG disable force and clear IDDIG bit while at it.
++	 */
++	switch (mode) {
++	case PHY_MODE_USB_DEVICE:
++		val = AIROHA_USB_PHY_IDDIG;
++		break;
++	case PHY_MODE_USB_HOST:
++		val = AIROHA_USB_PHY_FORCE_IDDIG |
++		      AIROHA_USB_PHY_FORCE_IDDIG;
++		break;
++	case PHY_MODE_USB_OTG:
++		val = 0;
++		break;
++	default:
++		return 0;
++	}
++
++	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U2PHYDTM1,
++			   AIROHA_USB_PHY_FORCE_IDDIG |
++			   AIROHA_USB_PHY_IDDIG, val);
++
++	return 0;
++}
++
++static int airoha_usb_phy_u3_set_mode(struct airoha_usb_phy_priv *priv,
++				      enum phy_mode mode)
++{
++	u32 sel;
++
++	/* Only USB2 supports PCIe mode */
++	if (mode == PHY_MODE_PCIE &&
++	    priv->serdes_port != AIROHA_SCU_SERDES_USB2)
++		return -EINVAL;
++
++	if (mode == PHY_MODE_PCIE)
++		sel = AIROHA_SCU_SSTR_USB_PCIE_SEL_PCIE;
++	else
++		sel = AIROHA_SCU_SSTR_USB_PCIE_SEL_USB;
++
++	regmap_update_bits(priv->scu, AIROHA_SCU_SSTR,
++			   AIROHA_SCU_SSTR_USB_PCIE_SEL, sel);
++
++	return 0;
++}
++
++static int airoha_usb_phy_set_mode(struct phy *phy, enum phy_mode mode, int submode)
++{
++	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
++	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
++
++	switch (instance->type) {
++	case PHY_TYPE_USB2:
++		return airoha_usb_phy_u2_set_mode(priv, mode);
++	case PHY_TYPE_USB3:
++		return airoha_usb_phy_u3_set_mode(priv, mode);
++	default:
++		return 0;
++	}
++}
++
++static struct phy *airoha_usb_phy_xlate(struct device *dev,
++					struct of_phandle_args *args)
++{
++	struct airoha_usb_phy_priv *priv = dev_get_drvdata(dev);
++	struct airoha_usb_phy_instance *instance = NULL;
++	unsigned int index, phy_type;
++
++	if (args->args_count != 1) {
++		dev_err(dev, "invalid number of cells in 'phy' property\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	phy_type = args->args[0];
++	if (!(phy_type == PHY_TYPE_USB2 || phy_type == PHY_TYPE_USB3)) {
++		dev_err(dev, "unsupported device type: %d\n", phy_type);
++		return ERR_PTR(-EINVAL);
++	}
++
++	for (index = 0; index < AIROHA_PHY_USB_MAX; index++)
++		if (priv->phys[index] &&
++		    phy_type == priv->phys[index]->type) {
++			instance = priv->phys[index];
++			break;
++		}
++
++	if (!instance) {
++		dev_err(dev, "failed to find appropriate phy\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	return instance->phy;
++}
++
++static const struct phy_ops airoha_phy = {
++	.init		= airoha_usb_phy_init,
++	.power_on	= airoha_usb_phy_power_on,
++	.power_off	= airoha_usb_phy_power_off,
++	.set_mode	= airoha_usb_phy_set_mode,
++	.owner		= THIS_MODULE,
++};
++
++static const struct regmap_config airoha_usb_phy_regmap_config = {
++	.reg_bits = 32,
++	.val_bits = 32,
++	.reg_stride = 4,
++};
++
++static int airoha_usb_phy_probe(struct platform_device *pdev)
++{
++	struct phy_provider *phy_provider;
++	struct airoha_usb_phy_priv *priv;
++	struct device *dev = &pdev->dev;
++	unsigned int index;
++	void *base;
++	int ret;
++
++	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->dev = dev;
++
++	ret = of_property_read_u32(dev->of_node, "airoha,usb2-monitor-clk-sel",
++				   &priv->monclk_sel);
++	if (ret)
++		return dev_err_probe(dev, ret, "Monitor clock selection is mandatory for USB PHY calibration.\n");
++
++	if (priv->monclk_sel > 3)
++		return dev_err_probe(dev, -EINVAL, "only 4 Monitor clock are selectable on the SoC.\n");
++
++	base = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(base))
++		return PTR_ERR(base);
++
++	priv->regmap = devm_regmap_init_mmio(dev, base, &airoha_usb_phy_regmap_config);
++	if (IS_ERR(priv->regmap))
++		return PTR_ERR(priv->regmap);
++
++	platform_set_drvdata(pdev, priv);
++
++	for (index = 0; index < AIROHA_PHY_USB_MAX; index++) {
++		enum airoha_usb_phy_instance_type phy_type;
++		struct airoha_usb_phy_instance *instance;
++
++		switch (index) {
++		case AIROHA_PHY_USB2:
++			phy_type = PHY_TYPE_USB2;
++			break;
++		case AIROHA_PHY_USB3:
++			phy_type = PHY_TYPE_USB3;
++			break;
++		}
++
++		/* Skip registering USB3 instance if not supported */
++		if (phy_type == PHY_TYPE_USB3) {
++			ret = of_property_read_u32(dev->of_node, "airoha,serdes-port",
++						   &priv->serdes_port);
++			if (ret)
++				continue;
++
++			/* With Serdes Port property, SCU is required */
++			priv->scu = syscon_regmap_lookup_by_phandle(dev->of_node,
++								    "airoha,scu");
++			if (IS_ERR(priv->scu))
++				return dev_err_probe(dev, PTR_ERR(priv->scu), "failed to get SCU syscon.\n");
++		}
++
++		instance = devm_kzalloc(dev, sizeof(*instance), GFP_KERNEL);
++		if (!instance)
++			return -ENOMEM;
++
++		instance->type = phy_type;
++		priv->phys[index] = instance;
++
++		instance->phy = devm_phy_create(dev, NULL, &airoha_phy);
++		if (IS_ERR(instance->phy))
++			return dev_err_probe(dev, PTR_ERR(instance->phy), "failed to create phy\n");
++
++		phy_set_drvdata(instance->phy, instance);
++	}
++
++	phy_provider = devm_of_phy_provider_register(&pdev->dev, airoha_usb_phy_xlate);
++
++	return PTR_ERR_OR_ZERO(phy_provider);
++}
++
++static const struct of_device_id airoha_phy_id_table[] = {
++	{ .compatible = "airoha,an7581-usb-phy" },
++	{ },
++};
++MODULE_DEVICE_TABLE(of, airoha_phy_id_table);
++
++static struct platform_driver airoha_usb_driver = {
++	.probe		= airoha_usb_phy_probe,
++	.driver		= {
++		.name	= "airoha-usb-phy",
++		.of_match_table = airoha_phy_id_table,
++	},
++};
++
++module_platform_driver(airoha_usb_driver);
++
++MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("Airoha USB PHY driver");
+--- a/drivers/phy/airoha/phy-airoha-usb.c
++++ /dev/null
+@@ -1,596 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0
+-/*
+- * Author: Christian Marangi <ansuelsmth@gmail.com>
+- */
+-
+-#include <dt-bindings/phy/phy.h>
+-#include <dt-bindings/soc/airoha,scu-ssr.h>
+-#include <linux/bitfield.h>
+-#include <linux/math.h>
+-#include <linux/module.h>
+-#include <linux/mfd/syscon.h>
+-#include <linux/phy/phy.h>
+-#include <linux/platform_device.h>
+-#include <linux/regmap.h>
+-
+-/* SCU */
+-#define AIROHA_SCU_SSTR				0x9c
+-#define   AIROHA_SCU_SSTR_USB_PCIE_SEL		BIT(3)
+-#define   AIROHA_SCU_SSTR_USB_PCIE_SEL_PCIE	FIELD_PREP_CONST(AIROHA_SCU_SSTR_USB_PCIE_SEL, 0x0)
+-#define   AIROHA_SCU_SSTR_USB_PCIE_SEL_USB	FIELD_PREP_CONST(AIROHA_SCU_SSTR_USB_PCIE_SEL, 0x1)
+-
+-/* U2PHY */
+-#define AIROHA_USB_PHY_FMCR0			0x100
+-#define   AIROHA_USB_PHY_MONCLK_SEL		GENMASK(27, 26)
+-#define   AIROHA_USB_PHY_MONCLK_SEL0		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x0)
+-#define   AIROHA_USB_PHY_MONCLK_SEL1		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x1)
+-#define   AIROHA_USB_PHY_MONCLK_SEL2		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x2)
+-#define   AIROHA_USB_PHY_MONCLK_SEL3		FIELD_PREP_CONST(AIROHA_USB_PHY_MONCLK_SEL, 0x3)
+-#define   AIROHA_USB_PHY_FREQDET_EN		BIT(24)
+-#define   AIROHA_USB_PHY_CYCLECNT		GENMASK(23, 0)
+-#define AIROHA_USB_PHY_FMMONR0			0x10c
+-#define   AIROHA_USB_PHY_USB_FM_OUT		GENMASK(31, 0)
+-#define AIROHA_USB_PHY_FMMONR1			0x110
+-#define   AIROHA_USB_PHY_FRCK_EN		BIT(8)
+-
+-#define AIROHA_USB_PHY_USBPHYACR4		0x310
+-#define   AIROHA_USB_PHY_USB20_FS_CR		GENMASK(10, 8)
+-#define   AIROHA_USB_PHY_USB20_FS_CR_MAX	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x0)
+-#define   AIROHA_USB_PHY_USB20_FS_CR_NORMAL	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x2)
+-#define   AIROHA_USB_PHY_USB20_FS_CR_SMALLER	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x4)
+-#define   AIROHA_USB_PHY_USB20_FS_CR_MIN	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_CR, 0x6)
+-#define   AIROHA_USB_PHY_USB20_FS_SR		GENMASK(2, 0)
+-#define   AIROHA_USB_PHY_USB20_FS_SR_MAX	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x0)
+-#define   AIROHA_USB_PHY_USB20_FS_SR_NORMAL	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x2)
+-#define   AIROHA_USB_PHY_USB20_FS_SR_SMALLER	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x4)
+-#define   AIROHA_USB_PHY_USB20_FS_SR_MIN	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_FS_SR, 0x6)
+-#define AIROHA_USB_PHY_USBPHYACR5		0x314
+-#define   AIROHA_USB_PHY_USB20_HSTX_SRCAL_EN	BIT(15)
+-#define   AIROHA_USB_PHY_USB20_HSTX_SRCTRL	GENMASK(14, 12)
+-#define AIROHA_USB_PHY_USBPHYACR6		0x318
+-#define   AIROHA_USB_PHY_USB20_BC11_SW_EN	BIT(23)
+-#define   AIROHA_USB_PHY_USB20_DISCTH		GENMASK(7, 4)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_400	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x0)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_420	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x1)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_440	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x2)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_460	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x3)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_480	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x4)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_500	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x5)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_520	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x6)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_540	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x7)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_560	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x8)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_580	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0x9)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_600	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xa)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_620	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xb)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_640	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xc)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_660	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xd)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_680	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xe)
+-#define   AIROHA_USB_PHY_USB20_DISCTH_700	FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_DISCTH, 0xf)
+-#define   AIROHA_USB_PHY_USB20_SQTH		GENMASK(3, 0)
+-#define   AIROHA_USB_PHY_USB20_SQTH_85		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x0)
+-#define   AIROHA_USB_PHY_USB20_SQTH_90		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x1)
+-#define   AIROHA_USB_PHY_USB20_SQTH_95		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x2)
+-#define   AIROHA_USB_PHY_USB20_SQTH_100		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x3)
+-#define   AIROHA_USB_PHY_USB20_SQTH_105		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x4)
+-#define   AIROHA_USB_PHY_USB20_SQTH_110		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x5)
+-#define   AIROHA_USB_PHY_USB20_SQTH_115		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x6)
+-#define   AIROHA_USB_PHY_USB20_SQTH_120		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x7)
+-#define   AIROHA_USB_PHY_USB20_SQTH_125		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x8)
+-#define   AIROHA_USB_PHY_USB20_SQTH_130		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0x9)
+-#define   AIROHA_USB_PHY_USB20_SQTH_135		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xa)
+-#define   AIROHA_USB_PHY_USB20_SQTH_140		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xb)
+-#define   AIROHA_USB_PHY_USB20_SQTH_145		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xc)
+-#define   AIROHA_USB_PHY_USB20_SQTH_150		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xd)
+-#define   AIROHA_USB_PHY_USB20_SQTH_155		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xe)
+-#define   AIROHA_USB_PHY_USB20_SQTH_160		FIELD_PREP_CONST(AIROHA_USB_PHY_USB20_SQTH, 0xf)
+-
+-#define AIROHA_USB_PHY_U2PHYDTM1		0x36c
+-#define   AIROHA_USB_PHY_FORCE_IDDIG		BIT(9)
+-#define   AIROHA_USB_PHY_IDDIG			BIT(1)
+-
+-#define AIROHA_USB_PHY_GPIO_CTLD		0x80c
+-#define   AIROHA_USB_PHY_C60802_GPIO_CTLD	GENMASK(31, 0)
+-#define     AIROHA_USB_PHY_SSUSB_IP_SW_RST	BIT(31)
+-#define     AIROHA_USB_PHY_MCU_BUS_CK_GATE_EN	BIT(30)
+-#define     AIROHA_USB_PHY_FORCE_SSUSB_IP_SW_RST BIT(29)
+-#define     AIROHA_USB_PHY_SSUSB_SW_RST		BIT(28)
+-
+-#define AIROHA_USB_PHY_U3_PHYA_REG0		0xb00
+-#define   AIROHA_USB_PHY_SSUSB_BG_DIV		GENMASK(29, 28)
+-#define   AIROHA_USB_PHY_SSUSB_BG_DIV_2		FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x0)
+-#define   AIROHA_USB_PHY_SSUSB_BG_DIV_4		FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x1)
+-#define   AIROHA_USB_PHY_SSUSB_BG_DIV_8		FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x2)
+-#define   AIROHA_USB_PHY_SSUSB_BG_DIV_16	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_BG_DIV, 0x3)
+-#define AIROHA_USB_PHY_U3_PHYA_REG1		0xb04
+-#define   AIROHA_USB_PHY_SSUSB_XTAL_TOP_RESERVE	GENMASK(25, 10)
+-#define AIROHA_USB_PHY_U3_PHYA_REG6		0xb18
+-#define   AIROHA_USB_PHY_SSUSB_CDR_RESERVE	GENMASK(31, 24)
+-#define AIROHA_USB_PHY_U3_PHYA_REG8		0xb20
+-#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY	GENMASK(7, 6)
+-#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_32	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x0)
+-#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_64	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x1)
+-#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_128	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x2)
+-#define   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_216	FIELD_PREP_CONST(AIROHA_USB_PHY_SSUSB_CDR_RST_DLY, 0x3)
+-
+-#define AIROHA_USB_PHY_U3_PHYA_DA_REG19		0xc38
+-#define   AIROHA_USB_PHY_SSUSB_PLL_SSC_DELTA1_U3 GENMASK(15, 0)
+-
+-#define AIROHA_USB_PHY_U2_FM_DET_CYCLE_CNT	1024
+-#define AIROHA_USB_PHY_REF_CK			20
+-#define AIROHA_USB_PHY_U2_SR_COEF		28
+-#define AIROHA_USB_PHY_U2_SR_COEF_DIVISOR	1000
+-
+-#define AIROHA_USB_PHY_DEFAULT_SR_CALIBRATION	0x5
+-#define AIROHA_USB_PHY_FREQDET_SLEEP		1000 /* 1ms */
+-#define AIROHA_USB_PHY_FREQDET_TIMEOUT		(AIROHA_USB_PHY_FREQDET_SLEEP * 10)
+-
+-struct airoha_usb_phy_instance {
+-	struct phy *phy;
+-	u32 type;
+-};
+-
+-enum airoha_usb_phy_instance_type {
+-	AIROHA_PHY_USB2,
+-	AIROHA_PHY_USB3,
+-
+-	AIROHA_PHY_USB_MAX,
+-};
+-
+-struct airoha_usb_phy_priv {
+-	struct device *dev;
+-	struct regmap *regmap;
+-	struct regmap *scu;
+-
+-	unsigned int monclk_sel;
+-	unsigned int serdes_port;
+-
+-	struct airoha_usb_phy_instance *phys[AIROHA_PHY_USB_MAX];
+-};
+-
+-static void airoha_usb_phy_u2_slew_rate_calibration(struct airoha_usb_phy_priv *priv)
+-{
+-	u32 fm_out;
+-	u32 srctrl;
+-
+-	/* Enable HS TX SR calibration */
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR5,
+-			AIROHA_USB_PHY_USB20_HSTX_SRCAL_EN);
+-
+-	usleep_range(1000, 1500);
+-
+-	/* Enable Free run clock */
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_FMMONR1,
+-			AIROHA_USB_PHY_FRCK_EN);
+-
+-	/* Select Monitor Clock */
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
+-			   AIROHA_USB_PHY_MONCLK_SEL,
+-			   FIELD_PREP(AIROHA_USB_PHY_MONCLK_SEL,
+-				      priv->monclk_sel));
+-
+-	/* Set cyclecnt */
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
+-			   AIROHA_USB_PHY_CYCLECNT,
+-			   FIELD_PREP(AIROHA_USB_PHY_CYCLECNT,
+-				      AIROHA_USB_PHY_U2_FM_DET_CYCLE_CNT));
+-
+-	/* Enable Frequency meter */
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
+-			AIROHA_USB_PHY_FREQDET_EN);
+-
+-	/* Timeout can happen and we will apply workaround at the end */
+-	regmap_read_poll_timeout(priv->regmap, AIROHA_USB_PHY_FMMONR0, fm_out,
+-				 fm_out, AIROHA_USB_PHY_FREQDET_SLEEP,
+-				 AIROHA_USB_PHY_FREQDET_TIMEOUT);
+-
+-	/* Disable Frequency meter */
+-	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_FMCR0,
+-			  AIROHA_USB_PHY_FREQDET_EN);
+-
+-	/* Disable Free run clock */
+-	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_FMMONR1,
+-			  AIROHA_USB_PHY_FRCK_EN);
+-
+-	/* Disable HS TX SR calibration */
+-	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR5,
+-			  AIROHA_USB_PHY_USB20_HSTX_SRCAL_EN);
+-
+-	usleep_range(1000, 1500);
+-
+-	/* Frequency was not detected, use default SR calibration value */
+-	if (!fm_out) {
+-		srctrl = AIROHA_USB_PHY_DEFAULT_SR_CALIBRATION;
+-		dev_err(priv->dev, "Frequency not detected, using default SR calibration.\n");
+-	} else {
+-		/* (1024 / FM_OUT) * REF_CK * U2_SR_COEF (round to the nearest digits) */
+-		srctrl = AIROHA_USB_PHY_REF_CK * AIROHA_USB_PHY_U2_SR_COEF;
+-		srctrl = (srctrl * AIROHA_USB_PHY_U2_FM_DET_CYCLE_CNT) / fm_out;
+-		srctrl = DIV_ROUND_CLOSEST(srctrl, AIROHA_USB_PHY_U2_SR_COEF_DIVISOR);
+-		dev_dbg(priv->dev, "SR calibration applied: %x\n", srctrl);
+-	}
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR5,
+-			   AIROHA_USB_PHY_USB20_HSTX_SRCTRL,
+-			   FIELD_PREP(AIROHA_USB_PHY_USB20_HSTX_SRCTRL, srctrl));
+-}
+-
+-static void airoha_usb_phy_u2_init(struct airoha_usb_phy_priv *priv)
+-{
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR4,
+-			   AIROHA_USB_PHY_USB20_FS_CR,
+-			   AIROHA_USB_PHY_USB20_FS_CR_MIN);
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR4,
+-			   AIROHA_USB_PHY_USB20_FS_SR,
+-			   AIROHA_USB_PHY_USB20_FS_SR_NORMAL);
+-
+-	/* FIXME: evaluate if needed */
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
+-			   AIROHA_USB_PHY_USB20_SQTH,
+-			   AIROHA_USB_PHY_USB20_SQTH_130);
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
+-			   AIROHA_USB_PHY_USB20_DISCTH,
+-			   AIROHA_USB_PHY_USB20_DISCTH_600);
+-
+-	/* Enable the USB port and then disable after calibration */
+-	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
+-			  AIROHA_USB_PHY_USB20_BC11_SW_EN);
+-
+-	airoha_usb_phy_u2_slew_rate_calibration(priv);
+-
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
+-			AIROHA_USB_PHY_USB20_BC11_SW_EN);
+-
+-	usleep_range(1000, 1500);
+-}
+-
+-/*
+- * USB 3.0 mode can only work if USB serdes is correctly set.
+- * This is validated in xLate function.
+- */
+-static void airoha_usb_phy_u3_init(struct airoha_usb_phy_priv *priv)
+-{
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG8,
+-			   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY,
+-			   AIROHA_USB_PHY_SSUSB_CDR_RST_DLY_32);
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG6,
+-			   AIROHA_USB_PHY_SSUSB_CDR_RESERVE,
+-			   FIELD_PREP(AIROHA_USB_PHY_SSUSB_CDR_RESERVE, 0xe));
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG0,
+-			   AIROHA_USB_PHY_SSUSB_BG_DIV,
+-			   AIROHA_USB_PHY_SSUSB_BG_DIV_4);
+-
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_REG1,
+-			FIELD_PREP(AIROHA_USB_PHY_SSUSB_XTAL_TOP_RESERVE, 0x600));
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U3_PHYA_DA_REG19,
+-			   AIROHA_USB_PHY_SSUSB_PLL_SSC_DELTA1_U3,
+-			   FIELD_PREP(AIROHA_USB_PHY_SSUSB_PLL_SSC_DELTA1_U3, 0x43));
+-}
+-
+-static int airoha_usb_phy_init(struct phy *phy)
+-{
+-	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
+-	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
+-
+-	switch (instance->type) {
+-	case PHY_TYPE_USB2:
+-		airoha_usb_phy_u2_init(priv);
+-		break;
+-	case PHY_TYPE_USB3:
+-		if (phy_get_mode(phy) == PHY_MODE_PCIE)
+-			return 0;
+-
+-		airoha_usb_phy_u3_init(priv);
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_u2_power_on(struct airoha_usb_phy_priv *priv)
+-{
+-	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
+-			  AIROHA_USB_PHY_USB20_BC11_SW_EN);
+-
+-	usleep_range(1000, 1500);
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_u3_power_on(struct airoha_usb_phy_priv *priv)
+-{
+-	regmap_clear_bits(priv->regmap, AIROHA_USB_PHY_GPIO_CTLD,
+-			  AIROHA_USB_PHY_SSUSB_IP_SW_RST |
+-			  AIROHA_USB_PHY_MCU_BUS_CK_GATE_EN |
+-			  AIROHA_USB_PHY_FORCE_SSUSB_IP_SW_RST |
+-			  AIROHA_USB_PHY_SSUSB_SW_RST);
+-
+-	usleep_range(1000, 1500);
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_power_on(struct phy *phy)
+-{
+-	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
+-	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
+-
+-	switch (instance->type) {
+-	case PHY_TYPE_USB2:
+-		airoha_usb_phy_u2_power_on(priv);
+-		break;
+-	case PHY_TYPE_USB3:
+-		if (phy_get_mode(phy) == PHY_MODE_PCIE)
+-			return 0;
+-
+-		airoha_usb_phy_u3_power_on(priv);
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_u2_power_off(struct airoha_usb_phy_priv *priv)
+-{
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_USBPHYACR6,
+-			AIROHA_USB_PHY_USB20_BC11_SW_EN);
+-
+-	usleep_range(1000, 1500);
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_u3_power_off(struct airoha_usb_phy_priv *priv)
+-{
+-	regmap_set_bits(priv->regmap, AIROHA_USB_PHY_GPIO_CTLD,
+-			AIROHA_USB_PHY_SSUSB_IP_SW_RST |
+-			AIROHA_USB_PHY_FORCE_SSUSB_IP_SW_RST);
+-
+-	usleep_range(1000, 1500);
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_power_off(struct phy *phy)
+-{
+-	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
+-	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
+-
+-	switch (instance->type) {
+-	case PHY_TYPE_USB2:
+-		airoha_usb_phy_u2_power_off(priv);
+-		break;
+-	case PHY_TYPE_USB3:
+-		if (phy_get_mode(phy) == PHY_MODE_PCIE)
+-			return 0;
+-
+-		airoha_usb_phy_u3_power_off(priv);
+-		break;
+-	default:
+-		return -EINVAL;
+-	}
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_u2_set_mode(struct airoha_usb_phy_priv *priv,
+-				      enum phy_mode mode)
+-{
+-	u32 val;
+-
+-	/*
+-	 * For Device and Host mode, enable force IDDIG.
+-	 * For Device set IDDIG, for Host clear IDDIG.
+-	 * For OTG disable force and clear IDDIG bit while at it.
+-	 */
+-	switch (mode) {
+-	case PHY_MODE_USB_DEVICE:
+-		val = AIROHA_USB_PHY_IDDIG;
+-		break;
+-	case PHY_MODE_USB_HOST:
+-		val = AIROHA_USB_PHY_FORCE_IDDIG |
+-		      AIROHA_USB_PHY_FORCE_IDDIG;
+-		break;
+-	case PHY_MODE_USB_OTG:
+-		val = 0;
+-		break;
+-	default:
+-		return 0;
+-	}
+-
+-	regmap_update_bits(priv->regmap, AIROHA_USB_PHY_U2PHYDTM1,
+-			   AIROHA_USB_PHY_FORCE_IDDIG |
+-			   AIROHA_USB_PHY_IDDIG, val);
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_u3_set_mode(struct airoha_usb_phy_priv *priv,
+-				      enum phy_mode mode)
+-{
+-	u32 sel;
+-
+-	/* Only USB2 supports PCIe mode */
+-	if (mode == PHY_MODE_PCIE &&
+-	    priv->serdes_port != AIROHA_SCU_SERDES_USB2)
+-		return -EINVAL;
+-
+-	if (mode == PHY_MODE_PCIE)
+-		sel = AIROHA_SCU_SSTR_USB_PCIE_SEL_PCIE;
+-	else
+-		sel = AIROHA_SCU_SSTR_USB_PCIE_SEL_USB;
+-
+-	regmap_update_bits(priv->scu, AIROHA_SCU_SSTR,
+-			   AIROHA_SCU_SSTR_USB_PCIE_SEL, sel);
+-
+-	return 0;
+-}
+-
+-static int airoha_usb_phy_set_mode(struct phy *phy, enum phy_mode mode, int submode)
+-{
+-	struct airoha_usb_phy_instance *instance = phy_get_drvdata(phy);
+-	struct airoha_usb_phy_priv *priv = dev_get_drvdata(phy->dev.parent);
+-
+-	switch (instance->type) {
+-	case PHY_TYPE_USB2:
+-		return airoha_usb_phy_u2_set_mode(priv, mode);
+-	case PHY_TYPE_USB3:
+-		return airoha_usb_phy_u3_set_mode(priv, mode);
+-	default:
+-		return 0;
+-	}
+-}
+-
+-static struct phy *airoha_usb_phy_xlate(struct device *dev,
+-					struct of_phandle_args *args)
+-{
+-	struct airoha_usb_phy_priv *priv = dev_get_drvdata(dev);
+-	struct airoha_usb_phy_instance *instance = NULL;
+-	unsigned int index, phy_type;
+-
+-	if (args->args_count != 1) {
+-		dev_err(dev, "invalid number of cells in 'phy' property\n");
+-		return ERR_PTR(-EINVAL);
+-	}
+-
+-	phy_type = args->args[0];
+-	if (!(phy_type == PHY_TYPE_USB2 || phy_type == PHY_TYPE_USB3)) {
+-		dev_err(dev, "unsupported device type: %d\n", phy_type);
+-		return ERR_PTR(-EINVAL);
+-	}
+-
+-	for (index = 0; index < AIROHA_PHY_USB_MAX; index++)
+-		if (priv->phys[index] &&
+-		    phy_type == priv->phys[index]->type) {
+-			instance = priv->phys[index];
+-			break;
+-		}
+-
+-	if (!instance) {
+-		dev_err(dev, "failed to find appropriate phy\n");
+-		return ERR_PTR(-EINVAL);
+-	}
+-
+-	return instance->phy;
+-}
+-
+-static const struct phy_ops airoha_phy = {
+-	.init		= airoha_usb_phy_init,
+-	.power_on	= airoha_usb_phy_power_on,
+-	.power_off	= airoha_usb_phy_power_off,
+-	.set_mode	= airoha_usb_phy_set_mode,
+-	.owner		= THIS_MODULE,
+-};
+-
+-static const struct regmap_config airoha_usb_phy_regmap_config = {
+-	.reg_bits = 32,
+-	.val_bits = 32,
+-	.reg_stride = 4,
+-};
+-
+-static int airoha_usb_phy_probe(struct platform_device *pdev)
+-{
+-	struct phy_provider *phy_provider;
+-	struct airoha_usb_phy_priv *priv;
+-	struct device *dev = &pdev->dev;
+-	unsigned int index;
+-	void *base;
+-	int ret;
+-
+-	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+-	if (!priv)
+-		return -ENOMEM;
+-
+-	priv->dev = dev;
+-
+-	ret = of_property_read_u32(dev->of_node, "airoha,usb2-monitor-clk-sel",
+-				   &priv->monclk_sel);
+-	if (ret)
+-		return dev_err_probe(dev, ret, "Monitor clock selection is mandatory for USB PHY calibration.\n");
+-
+-	if (priv->monclk_sel > 3)
+-		return dev_err_probe(dev, -EINVAL, "only 4 Monitor clock are selectable on the SoC.\n");
+-
+-	base = devm_platform_ioremap_resource(pdev, 0);
+-	if (IS_ERR(base))
+-		return PTR_ERR(base);
+-
+-	priv->regmap = devm_regmap_init_mmio(dev, base, &airoha_usb_phy_regmap_config);
+-	if (IS_ERR(priv->regmap))
+-		return PTR_ERR(priv->regmap);
+-
+-	platform_set_drvdata(pdev, priv);
+-
+-	for (index = 0; index < AIROHA_PHY_USB_MAX; index++) {
+-		enum airoha_usb_phy_instance_type phy_type;
+-		struct airoha_usb_phy_instance *instance;
+-
+-		switch (index) {
+-		case AIROHA_PHY_USB2:
+-			phy_type = PHY_TYPE_USB2;
+-			break;
+-		case AIROHA_PHY_USB3:
+-			phy_type = PHY_TYPE_USB3;
+-			break;
+-		}
+-
+-		/* Skip registering USB3 instance if not supported */
+-		if (phy_type == PHY_TYPE_USB3) {
+-			ret = of_property_read_u32(dev->of_node, "airoha,serdes-port",
+-						   &priv->serdes_port);
+-			if (ret)
+-				continue;
+-
+-			/* With Serdes Port property, SCU is required */
+-			priv->scu = syscon_regmap_lookup_by_phandle(dev->of_node,
+-								    "airoha,scu");
+-			if (IS_ERR(priv->scu))
+-				return dev_err_probe(dev, PTR_ERR(priv->scu), "failed to get SCU syscon.\n");
+-		}
+-
+-		instance = devm_kzalloc(dev, sizeof(*instance), GFP_KERNEL);
+-		if (!instance)
+-			return -ENOMEM;
+-
+-		instance->type = phy_type;
+-		priv->phys[index] = instance;
+-
+-		instance->phy = devm_phy_create(dev, NULL, &airoha_phy);
+-		if (IS_ERR(instance->phy))
+-			return dev_err_probe(dev, PTR_ERR(instance->phy), "failed to create phy\n");
+-
+-		phy_set_drvdata(instance->phy, instance);
+-	}
+-
+-	phy_provider = devm_of_phy_provider_register(&pdev->dev, airoha_usb_phy_xlate);
+-
+-	return PTR_ERR_OR_ZERO(phy_provider);
+-}
+-
+-static const struct of_device_id airoha_phy_id_table[] = {
+-	{ .compatible = "airoha,an7581-usb-phy" },
+-	{ },
+-};
+-MODULE_DEVICE_TABLE(of, airoha_phy_id_table);
+-
+-static struct platform_driver airoha_usb_driver = {
+-	.probe		= airoha_usb_phy_probe,
+-	.driver		= {
+-		.name	= "airoha-usb-phy",
+-		.of_match_table = airoha_phy_id_table,
+-	},
+-};
+-
+-module_platform_driver(airoha_usb_driver);
+-
+-MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
+-MODULE_LICENSE("GPL");
+-MODULE_DESCRIPTION("Airoha USB PHY driver");

--- a/target/linux/airoha/patches-6.6/700-clk-en7523-Permit-to-probe-child-for-EN7581-clock.patch
+++ b/target/linux/airoha/patches-6.6/700-clk-en7523-Permit-to-probe-child-for-EN7581-clock.patch
@@ -15,11 +15,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index b3c57aac8480..c2addcf9ad8b 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
-@@ -1179,6 +1179,7 @@ static const struct en_clk_soc_data en7523_data = {
+@@ -1180,6 +1180,7 @@ static const struct en_clk_soc_data en75
  };
  
  static const struct en_clk_soc_data en7581_data = {
@@ -27,6 +25,3 @@ index b3c57aac8480..c2addcf9ad8b 100644
  	.base_clks = en7581_base_clks,
  	/* We increment num_clocks by 1 to account for additional PCIe clock */
  	.num_clocks = ARRAY_SIZE(en7581_base_clks) + 1,
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/701-01-dt-bindings-clock-Define-ID-for-Switch-MDC-clock-for.patch
+++ b/target/linux/airoha/patches-6.6/701-01-dt-bindings-clock-Define-ID-for-Switch-MDC-clock-for.patch
@@ -12,8 +12,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  include/dt-bindings/clock/en7523-clk.h | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/include/dt-bindings/clock/en7523-clk.h b/include/dt-bindings/clock/en7523-clk.h
-index 0fbbcb7b1b25..d1163807c0b7 100644
 --- a/include/dt-bindings/clock/en7523-clk.h
 +++ b/include/dt-bindings/clock/en7523-clk.h
 @@ -17,4 +17,6 @@
@@ -23,6 +21,3 @@ index 0fbbcb7b1b25..d1163807c0b7 100644
 +#define EN7581_CLK_SWITCH_MDC	9
 +
  #endif /* _DT_BINDINGS_CLOCK_AIROHA_EN7523_H_ */
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/701-02-clk-en7523-add-support-for-Switch-MDC-clock-for-EN75.patch
+++ b/target/linux/airoha/patches-6.6/701-02-clk-en7523-add-support-for-Switch-MDC-clock-for-EN75.patch
@@ -12,11 +12,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/clk/clk-en7523.c | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
-diff --git a/drivers/clk/clk-en7523.c b/drivers/clk/clk-en7523.c
-index b3c57aac8480..61285e92bea4 100644
 --- a/drivers/clk/clk-en7523.c
 +++ b/drivers/clk/clk-en7523.c
-@@ -312,6 +312,19 @@ static const struct en_clk_desc en7581_base_clks[] = {
+@@ -312,6 +312,19 @@ static const struct en_clk_desc en7581_b
  		.base_shift = 12,
  		.base_values = emmc7581_base,
  		.n_base_values = ARRAY_SIZE(emmc7581_base),
@@ -36,6 +34,3 @@ index b3c57aac8480..61285e92bea4 100644
  	}
  };
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/701-03-net-dsa-mt7530-add-support-for-configuring-MDIO-cloc.patch
+++ b/target/linux/airoha/patches-6.6/701-03-net-dsa-mt7530-add-support-for-configuring-MDIO-cloc.patch
@@ -15,8 +15,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/dsa/mt7530.h |  1 +
  2 files changed, 24 insertions(+)
 
-diff --git a/drivers/net/dsa/mt7530.c b/drivers/net/dsa/mt7530.c
-index d70399bce5b9..f0dc884c86a2 100644
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
 @@ -3,6 +3,7 @@
@@ -27,7 +25,7 @@ index d70399bce5b9..f0dc884c86a2 100644
  #include <linux/etherdevice.h>
  #include <linux/if_bridge.h>
  #include <linux/iopoll.h>
-@@ -2158,6 +2159,7 @@ mt7530_setup_mdio(struct mt7530_priv *priv)
+@@ -2423,6 +2424,7 @@ mt7530_setup_mdio(struct mt7530_priv *pr
  	struct dsa_switch *ds = priv->ds;
  	struct device *dev = priv->dev;
  	struct mii_bus *bus;
@@ -35,7 +33,7 @@ index d70399bce5b9..f0dc884c86a2 100644
  	static int idx;
  	int ret = 0;
  
-@@ -2195,6 +2197,21 @@ mt7530_setup_mdio(struct mt7530_priv *priv)
+@@ -2460,6 +2462,21 @@ mt7530_setup_mdio(struct mt7530_priv *pr
  			mt7530_free_mdio_irq(priv);
  	}
  
@@ -57,9 +55,9 @@ index d70399bce5b9..f0dc884c86a2 100644
  out:
  	of_node_put(mnp);
  	return ret;
-@@ -2991,6 +3008,9 @@ mt753x_setup(struct dsa_switch *ds)
- 	if (ret && priv->irq_domain)
- 		mt7530_free_mdio_irq(priv);
+@@ -3226,6 +3243,9 @@ mt753x_setup(struct dsa_switch *ds)
+ 			mt7530_free_irq(priv);
+ 	}
  
 +	if (ret && priv->mdio_clk)
 +		clk_disable_unprepare(priv->mdio_clk);
@@ -67,9 +65,9 @@ index d70399bce5b9..f0dc884c86a2 100644
  	return ret;
  }
  
-@@ -3236,6 +3256,9 @@ mt7530_remove_common(struct mt7530_priv *priv)
- 	if (priv->irq_domain)
- 		mt7530_free_mdio_irq(priv);
+@@ -3466,6 +3486,9 @@ mt7530_remove_common(struct mt7530_priv
+ 	if (priv->irq)
+ 		mt7530_free_irq(priv);
  
 +	if (priv->mdio_clk)
 +		clk_disable_unprepare(priv->mdio_clk);
@@ -77,11 +75,9 @@ index d70399bce5b9..f0dc884c86a2 100644
  	dsa_unregister_switch(priv->ds);
  
  	mutex_destroy(&priv->reg_mutex);
-diff --git a/drivers/net/dsa/mt7530.h b/drivers/net/dsa/mt7530.h
-index c3ea403d7acf..ff5fecc0e21e 100644
 --- a/drivers/net/dsa/mt7530.h
 +++ b/drivers/net/dsa/mt7530.h
-@@ -833,6 +833,7 @@ struct mt7530_priv {
+@@ -875,6 +875,7 @@ struct mt7530_priv {
  	struct regulator	*core_pwr;
  	struct regulator	*io_pwr;
  	struct gpio_desc	*reset;
@@ -89,6 +85,3 @@ index c3ea403d7acf..ff5fecc0e21e 100644
  	const struct mt753x_info *info;
  	unsigned int		id;
  	bool			mcm;
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/801-01-net-phy-add-PHY_DETACH_NO_HW_RESET-PHY-flag.patch
+++ b/target/linux/airoha/patches-6.6/801-01-net-phy-add-PHY_DETACH_NO_HW_RESET-PHY-flag.patch
@@ -23,11 +23,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  include/linux/phy.h          |  1 +
  3 files changed, 13 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 92697f43087d..0e6f6e1985f4 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -964,6 +964,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -965,6 +965,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -35,7 +33,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21011PB1),
-@@ -976,6 +977,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -977,6 +978,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -43,7 +41,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21010PB1),
-@@ -988,6 +990,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -989,6 +991,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -51,7 +49,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21010JB1),
-@@ -1000,6 +1003,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1001,6 +1004,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -59,7 +57,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21210PB1),
-@@ -1012,6 +1016,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1013,6 +1017,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -67,7 +65,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21510JB1),
-@@ -1024,6 +1029,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1025,6 +1030,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -75,7 +73,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21510PB1),
-@@ -1036,6 +1042,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1037,6 +1043,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -83,7 +81,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21511JB1),
-@@ -1048,6 +1055,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1049,6 +1056,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -91,7 +89,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21210JB1),
-@@ -1060,6 +1068,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1061,6 +1069,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -99,7 +97,7 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21511PB1),
-@@ -1072,6 +1081,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1073,6 +1082,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -107,11 +105,9 @@ index 92697f43087d..0e6f6e1985f4 100644
  	},
  };
  module_phy_driver(as21xxx_drivers);
-diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
-index 73f9cb2e2844..1dc7a8dd7fae 100644
 --- a/drivers/net/phy/phy_device.c
 +++ b/drivers/net/phy/phy_device.c
-@@ -1797,7 +1797,8 @@ void phy_detach(struct phy_device *phydev)
+@@ -1968,7 +1968,8 @@ void phy_detach(struct phy_device *phyde
  		device_release_driver(&phydev->mdio.dev);
  
  	/* Assert the reset signal */
@@ -121,11 +117,9 @@ index 73f9cb2e2844..1dc7a8dd7fae 100644
  
  	/*
  	 * The phydev might go away on the put_device() below, so avoid
-diff --git a/include/linux/phy.h b/include/linux/phy.h
-index e194dad1623d..5a7f18cc7eec 100644
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
-@@ -64,6 +64,7 @@ extern const int phy_basic_ports_array[3];
+@@ -87,6 +87,7 @@ extern const int phy_10gbit_features_arr
  #define PHY_RST_AFTER_CLK_EN	0x00000002
  #define PHY_POLL_CABLE_TEST	0x00000004
  #define PHY_ALWAYS_CALL_SUSPEND	0x00000008
@@ -133,6 +127,3 @@ index e194dad1623d..5a7f18cc7eec 100644
  #define MDIO_DEVICE_IS_PHY	0x80000000
  
  /**
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/801-02-net-phy-as21xxx-add-flag-PHY_DETACH_NO_HW_RESET.patch
+++ b/target/linux/airoha/patches-6.6/801-02-net-phy-as21xxx-add-flag-PHY_DETACH_NO_HW_RESET.patch
@@ -14,11 +14,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 20 ++++++++++----------
  1 file changed, 10 insertions(+), 10 deletions(-)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 0e6f6e1985f4..bccbc07b48ce 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -964,7 +964,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -965,7 +965,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -27,7 +25,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21011PB1),
-@@ -977,7 +977,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -978,7 +978,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -36,7 +34,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21010PB1),
-@@ -990,7 +990,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -991,7 +991,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -45,7 +43,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21010JB1),
-@@ -1003,7 +1003,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1004,7 +1004,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -54,7 +52,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21210PB1),
-@@ -1016,7 +1016,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1017,7 +1017,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -63,7 +61,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21510JB1),
-@@ -1029,7 +1029,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1030,7 +1030,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -72,7 +70,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21510PB1),
-@@ -1042,7 +1042,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1043,7 +1043,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -81,7 +79,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21511JB1),
-@@ -1055,7 +1055,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1056,7 +1056,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -90,7 +88,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21210JB1),
-@@ -1068,7 +1068,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1069,7 +1069,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -99,7 +97,7 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  	{
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21511PB1),
-@@ -1081,7 +1081,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1082,7 +1082,7 @@ static struct phy_driver as21xxx_drivers
  		.led_hw_control_set = as21xxx_led_hw_control_set,
  		.led_hw_control_get = as21xxx_led_hw_control_get,
  		.led_polarity_set = as21xxx_led_polarity_set,
@@ -108,6 +106,3 @@ index 0e6f6e1985f4..bccbc07b48ce 100644
  	},
  };
  module_phy_driver(as21xxx_drivers);
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/802-01-net-phy-as21xxx-handle-corner-case-with-link-and-aut.patch
+++ b/target/linux/airoha/patches-6.6/802-01-net-phy-as21xxx-handle-corner-case-with-link-and-aut.patch
@@ -13,11 +13,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 7 +++++++
  1 file changed, 7 insertions(+)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 92697f43087d..ce190d5b0497 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -658,6 +658,13 @@ static int as21xxx_read_link(struct phy_device *phydev, int *bmcr)
+@@ -658,6 +658,13 @@ static int as21xxx_read_link(struct phy_
  		return status;
  
  	phydev->link = !!(status & MDIO_STAT1_LSTATUS);
@@ -31,6 +29,3 @@ index 92697f43087d..ce190d5b0497 100644
  
  	return 0;
  }
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/802-02-net-phy-as21xxx-fix-read_status-speed-handling.patch
+++ b/target/linux/airoha/patches-6.6/802-02-net-phy-as21xxx-fix-read_status-speed-handling.patch
@@ -19,11 +19,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 96 +++++++++++++++++++++------------------
  1 file changed, 53 insertions(+), 43 deletions(-)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index ce190d5b0497..3550937c6c7a 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -671,7 +671,7 @@ static int as21xxx_read_link(struct phy_device *phydev, int *bmcr)
+@@ -671,7 +671,7 @@ static int as21xxx_read_link(struct phy_
  
  static int as21xxx_read_c22_lpa(struct phy_device *phydev)
  {
@@ -32,7 +30,7 @@ index ce190d5b0497..3550937c6c7a 100644
  
  	/* MII_STAT1000 are only filled in the mapped C22
  	 * in C45, use that to fill lpagb values and check.
-@@ -698,12 +698,20 @@ static int as21xxx_read_c22_lpa(struct phy_device *phydev)
+@@ -698,12 +698,20 @@ static int as21xxx_read_c22_lpa(struct p
  	mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising,
  					lpagb);
  
@@ -53,7 +51,7 @@ index ce190d5b0497..3550937c6c7a 100644
  	int ret;
  
  	ret = as21xxx_read_link(phydev, &bmcr);
-@@ -720,58 +728,60 @@ static int as21xxx_read_status(struct phy_device *phydev)
+@@ -720,58 +728,60 @@ static int as21xxx_read_status(struct ph
  	phydev->asym_pause = 0;
  
  	if (phydev->autoneg == AUTONEG_ENABLE) {
@@ -86,25 +84,6 @@ index ce190d5b0497..3550937c6c7a 100644
 -		switch (speed & VEND1_SPEED_STATUS) {
 -		case VEND1_SPEED_10000:
 -			phydev->speed = SPEED_10000;
--			phydev->duplex = DUPLEX_FULL;
--			break;
--		case VEND1_SPEED_5000:
--			phydev->speed = SPEED_5000;
--			phydev->duplex = DUPLEX_FULL;
--			break;
--		case VEND1_SPEED_2500:
--			phydev->speed = SPEED_2500;
--			phydev->duplex = DUPLEX_FULL;
--			break;
--		case VEND1_SPEED_1000:
--			phydev->speed = SPEED_1000;
--			if (bmcr & BMCR_FULLDPLX)
--				phydev->duplex = DUPLEX_FULL;
--			else
--				phydev->duplex = DUPLEX_HALF;
--			break;
--		case VEND1_SPEED_100:
--			phydev->speed = SPEED_100;
 +	speed = phy_read_mmd(phydev, MDIO_MMD_VEND1,
 +			     VEND1_SPEED_STATUS);
 +	if (speed < 0)
@@ -127,6 +106,25 @@ index ce190d5b0497..3550937c6c7a 100644
 +		phydev->speed = SPEED_1000;
 +		if (bmcr & BMCR_FULLDPLX)
  			phydev->duplex = DUPLEX_FULL;
+-			break;
+-		case VEND1_SPEED_5000:
+-			phydev->speed = SPEED_5000;
+-			phydev->duplex = DUPLEX_FULL;
+-			break;
+-		case VEND1_SPEED_2500:
+-			phydev->speed = SPEED_2500;
+-			phydev->duplex = DUPLEX_FULL;
+-			break;
+-		case VEND1_SPEED_1000:
+-			phydev->speed = SPEED_1000;
+-			if (bmcr & BMCR_FULLDPLX)
+-				phydev->duplex = DUPLEX_FULL;
+-			else
+-				phydev->duplex = DUPLEX_HALF;
+-			break;
+-		case VEND1_SPEED_100:
+-			phydev->speed = SPEED_100;
+-			phydev->duplex = DUPLEX_FULL;
 -			break;
 -		case VEND1_SPEED_10:
 -			phydev->speed = SPEED_10;
@@ -156,6 +154,3 @@ index ce190d5b0497..3550937c6c7a 100644
  	return 0;
  }
  
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/802-03-net-phy-as21xxx-force-C45-OPs-for-AUTONEG.patch
+++ b/target/linux/airoha/patches-6.6/802-03-net-phy-as21xxx-force-C45-OPs-for-AUTONEG.patch
@@ -16,11 +16,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 7 +++++++
  1 file changed, 7 insertions(+)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 3550937c6c7a..cbcc70937fea 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -616,6 +616,13 @@ static int as21xxx_probe(struct phy_device *phydev)
+@@ -616,6 +616,13 @@ static int as21xxx_probe(struct phy_devi
  	if (ret)
  		return ret;
  
@@ -34,6 +32,3 @@ index 3550937c6c7a..cbcc70937fea 100644
  	ret = aeon_ipc_sync_parity(phydev, priv);
  	if (ret)
  		return ret;
--- 
-2.48.1
-

--- a/target/linux/airoha/patches-6.6/803-net-phy-as21xxx-fill-in-inband-caps-and-better-handl.patch
+++ b/target/linux/airoha/patches-6.6/803-net-phy-as21xxx-fill-in-inband-caps-and-better-handl.patch
@@ -20,11 +20,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 43 +++++++++++++++++++++++++++++++++------
  1 file changed, 37 insertions(+), 6 deletions(-)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 005277360656..2dd808186642 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -625,12 +625,8 @@ static int as21xxx_probe(struct phy_device *phydev)
+@@ -632,12 +632,8 @@ static int as21xxx_probe(struct phy_devi
  		return ret;
  
  	/* Enable PTP clk if not already Enabled */
@@ -39,7 +37,7 @@ index 005277360656..2dd808186642 100644
  }
  
  static int as21xxx_read_link(struct phy_device *phydev, int *bmcr)
-@@ -943,6 +939,21 @@ static int as21xxx_match_phy_device(struct phy_device *phydev,
+@@ -967,6 +963,21 @@ out:
  	return ret;
  }
  
@@ -61,7 +59,7 @@ index 005277360656..2dd808186642 100644
  static struct phy_driver as21xxx_drivers[] = {
  	{
  		/* PHY expose in C45 as 0x7500 0x9410
-@@ -958,6 +969,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -982,6 +993,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21011JB1),
  		.name		= "Aeonsemi AS21011JB1",
  		.probe		= as21xxx_probe,
@@ -70,7 +68,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -970,6 +983,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -995,6 +1008,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21011PB1),
  		.name		= "Aeonsemi AS21011PB1",
  		.probe		= as21xxx_probe,
@@ -79,7 +77,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -982,6 +997,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1008,6 +1023,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21010PB1),
  		.name		= "Aeonsemi AS21010PB1",
  		.probe		= as21xxx_probe,
@@ -88,7 +86,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -994,6 +1011,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1021,6 +1038,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21010JB1),
  		.name		= "Aeonsemi AS21010JB1",
  		.probe		= as21xxx_probe,
@@ -97,7 +95,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -1006,6 +1025,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1034,6 +1053,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21210PB1),
  		.name		= "Aeonsemi AS21210PB1",
  		.probe		= as21xxx_probe,
@@ -106,7 +104,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -1018,6 +1039,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1047,6 +1068,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21510JB1),
  		.name		= "Aeonsemi AS21510JB1",
  		.probe		= as21xxx_probe,
@@ -115,7 +113,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -1030,6 +1053,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1060,6 +1083,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21510PB1),
  		.name		= "Aeonsemi AS21510PB1",
  		.probe		= as21xxx_probe,
@@ -124,7 +122,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -1042,6 +1067,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1073,6 +1098,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21511JB1),
  		.name		= "Aeonsemi AS21511JB1",
  		.probe		= as21xxx_probe,
@@ -133,7 +131,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -1054,6 +1081,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1086,6 +1113,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21210JB1),
  		.name		= "Aeonsemi AS21210JB1",
  		.probe		= as21xxx_probe,
@@ -142,7 +140,7 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
-@@ -1066,6 +1095,8 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1099,6 +1128,8 @@ static struct phy_driver as21xxx_drivers
  		PHY_ID_MATCH_EXACT(PHY_ID_AS21511PB1),
  		.name		= "Aeonsemi AS21511PB1",
  		.probe		= as21xxx_probe,
@@ -151,6 +149,3 @@ index 005277360656..2dd808186642 100644
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
  		.led_brightness_set = as21xxx_led_brightness_set,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/804-net-phy-as21xxx-implement-read-workaround-for-C45-re.patch
+++ b/target/linux/airoha/patches-6.6/804-net-phy-as21xxx-implement-read-workaround-for-C45-re.patch
@@ -26,11 +26,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  drivers/net/phy/as21xxx.c | 25 +++++++++++++++++++++++++
  1 file changed, 25 insertions(+)
 
-diff --git a/drivers/net/phy/as21xxx.c b/drivers/net/phy/as21xxx.c
-index 2dd808186642..dff7e7b41c3c 100644
 --- a/drivers/net/phy/as21xxx.c
 +++ b/drivers/net/phy/as21xxx.c
-@@ -954,6 +954,21 @@ static int as21xxx_config_inband(struct phy_device *phydev,
+@@ -978,6 +978,21 @@ static int as21xxx_config_inband(struct
  	return 0;
  }
  
@@ -52,7 +50,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  static struct phy_driver as21xxx_drivers[] = {
  	{
  		/* PHY expose in C45 as 0x7500 0x9410
-@@ -973,6 +988,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -997,6 +1012,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -60,7 +58,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -987,6 +1003,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1012,6 +1028,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -68,7 +66,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1001,6 +1018,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1027,6 +1044,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -76,7 +74,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1015,6 +1033,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1042,6 +1060,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -84,7 +82,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1029,6 +1048,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1057,6 +1076,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -92,7 +90,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1043,6 +1063,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1072,6 +1092,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -100,7 +98,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1057,6 +1078,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1087,6 +1108,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -108,7 +106,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1071,6 +1093,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1102,6 +1124,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -116,7 +114,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1085,6 +1108,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1117,6 +1140,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -124,7 +122,7 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
-@@ -1099,6 +1123,7 @@ static struct phy_driver as21xxx_drivers[] = {
+@@ -1132,6 +1156,7 @@ static struct phy_driver as21xxx_drivers
  		.config_inband	= as21xxx_config_inband,
  		.match_phy_device = as21xxx_match_phy_device,
  		.read_status	= as21xxx_read_status,
@@ -132,6 +130,3 @@ index 2dd808186642..dff7e7b41c3c 100644
  		.led_brightness_set = as21xxx_led_brightness_set,
  		.led_hw_is_supported = as21xxx_led_hw_is_supported,
  		.led_hw_control_set = as21xxx_led_hw_control_set,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/902-01-v6.13-net-phylink-move-manual-flow-control-setting.patch
+++ b/target/linux/airoha/patches-6.6/902-01-v6.13-net-phylink-move-manual-flow-control-setting.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 5 +++--
  1 file changed, 3 insertions(+), 2 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 6ca7ea970f51..65e81ef2225d 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1467,7 +1467,6 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1475,7 +1475,6 @@ static void phylink_resolve(struct work_
  		switch (pl->cur_link_an_mode) {
  		case MLO_AN_PHY:
  			link_state = pl->phy_state;
@@ -26,7 +24,7 @@ index 6ca7ea970f51..65e81ef2225d 100644
  			mac_config = link_state.link;
  			break;
  
-@@ -1528,11 +1527,13 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1536,11 +1535,13 @@ static void phylink_resolve(struct work_
  				link_state.pause = pl->phy_state.pause;
  				mac_config = true;
  			}
@@ -41,6 +39,3 @@ index 6ca7ea970f51..65e81ef2225d 100644
  	if (mac_config) {
  		if (link_state.interface != pl->link_config.interface) {
  			/* The interface has changed, force the link down and
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/902-02-v6.13-net-phylink-move-MLO_AN_FIXED-resolve-handling-to-if.patch
+++ b/target/linux/airoha/patches-6.6/902-02-v6.13-net-phylink-move-MLO_AN_FIXED-resolve-handling-to-if.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 8 +++-----
  1 file changed, 3 insertions(+), 5 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 65e81ef2225d..bb20ae5674e5 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1463,6 +1463,9 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1471,6 +1471,9 @@ static void phylink_resolve(struct work_
  	} else if (pl->mac_link_dropped) {
  		link_state.link = false;
  		retrigger = true;
@@ -30,7 +28,7 @@ index 65e81ef2225d..bb20ae5674e5 100644
  	} else {
  		switch (pl->cur_link_an_mode) {
  		case MLO_AN_PHY:
-@@ -1470,11 +1473,6 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1478,11 +1481,6 @@ static void phylink_resolve(struct work_
  			mac_config = link_state.link;
  			break;
  
@@ -42,6 +40,3 @@ index 65e81ef2225d..bb20ae5674e5 100644
  		case MLO_AN_INBAND:
  			phylink_mac_pcs_get_state(pl, &link_state);
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/902-03-v6.13-net-phylink-move-MLO_AN_PHY-resolve-handling-to-if-s.patch
+++ b/target/linux/airoha/patches-6.6/902-03-v6.13-net-phylink-move-MLO_AN_PHY-resolve-handling-to-if-s.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 8 +++-----
  1 file changed, 3 insertions(+), 5 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index bb20ae5674e5..3af6368a9fbf 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1466,13 +1466,11 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1474,13 +1474,11 @@ static void phylink_resolve(struct work_
  	} else if (pl->cur_link_an_mode == MLO_AN_FIXED) {
  		phylink_get_fixed_state(pl, &link_state);
  		mac_config = link_state.link;
@@ -37,6 +35,3 @@ index bb20ae5674e5..3af6368a9fbf 100644
  		case MLO_AN_INBAND:
  			phylink_mac_pcs_get_state(pl, &link_state);
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/902-04-v6.13-net-phylink-remove-switch-statement-in-resolve-handl.patch
+++ b/target/linux/airoha/patches-6.6/902-04-v6.13-net-phylink-remove-switch-statement-in-resolve-handl.patch
@@ -17,11 +17,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 94 +++++++++++++++++++--------------------
  1 file changed, 45 insertions(+), 49 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 3af6368a9fbf..aaeb8b11e758 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1470,60 +1470,56 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1478,60 +1478,56 @@ static void phylink_resolve(struct work_
  		link_state = pl->phy_state;
  		mac_config = link_state.link;
  	} else {
@@ -127,6 +125,3 @@ index 3af6368a9fbf..aaeb8b11e758 100644
  		}
  	}
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/902-05-v6.13-net-phylink-clean-up-phylink_resolve.patch
+++ b/target/linux/airoha/patches-6.6/902-05-v6.13-net-phylink-clean-up-phylink_resolve.patch
@@ -13,11 +13,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 35 ++++++++++++++++-------------------
  1 file changed, 16 insertions(+), 19 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index aaeb8b11e758..b1e828a4286d 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1472,51 +1472,48 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1480,51 +1480,48 @@ static void phylink_resolve(struct work_
  	} else {
  		phylink_mac_pcs_get_state(pl, &link_state);
  
@@ -85,6 +83,3 @@ index aaeb8b11e758..b1e828a4286d 100644
  			 */
  			link_state.pause = pl->phy_state.pause;
  			mac_config = true;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/902-v6.8-net-phylink-move-phylink_pcs_neg_mode-into-phylink.c.patch
+++ b/target/linux/airoha/patches-6.6/902-v6.8-net-phylink-move-phylink_pcs_neg_mode-into-phylink.c.patch
@@ -14,11 +14,9 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  include/linux/phylink.h   | 66 ---------------------------------------
  2 files changed, 66 insertions(+), 66 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 3d25a4a6212b..a816391add12 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1074,6 +1074,72 @@ static void phylink_pcs_an_restart(struct phylink *pl)
+@@ -1156,6 +1156,72 @@ static void phylink_pcs_an_restart(struc
  		pl->pcs->ops->pcs_an_restart(pl->pcs);
  }
  
@@ -91,15 +89,12 @@ index 3d25a4a6212b..a816391add12 100644
  static void phylink_major_config(struct phylink *pl, bool restart,
  				  const struct phylink_link_state *state)
  {
-diff --git a/include/linux/phylink.h b/include/linux/phylink.h
-index 875439ab45de..d589f89c612c 100644
 --- a/include/linux/phylink.h
 +++ b/include/linux/phylink.h
-@@ -98,72 +98,6 @@ static inline bool phylink_autoneg_inband(unsigned int mode)
- 	return mode == MLO_AN_INBAND;
+@@ -99,72 +99,6 @@ static inline bool phylink_autoneg_inban
  }
  
--/**
+ /**
 - * phylink_pcs_neg_mode() - helper to determine PCS inband mode
 - * @mode: one of %MLO_AN_FIXED, %MLO_AN_PHY, %MLO_AN_INBAND.
 - * @interface: interface mode to be used
@@ -165,9 +160,7 @@ index 875439ab45de..d589f89c612c 100644
 -	return neg_mode;
 -}
 -
- /**
+-/**
   * struct phylink_link_state - link state structure
   * @advertising: ethtool bitmask containing advertised link modes
--- 
-2.51.0
-
+  * @lp_advertising: ethtool bitmask containing link partner advertised link

--- a/target/linux/airoha/patches-6.6/903-01-v6.14-net-phylink-pass-phylink-and-pcs-into-phylink_pcs_ne.patch
+++ b/target/linux/airoha/patches-6.6/903-01-v6.14-net-phylink-pass-phylink-and-pcs-into-phylink_pcs_ne.patch
@@ -22,11 +22,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 26 +++++++++++++-------------
  1 file changed, 13 insertions(+), 13 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 30a654e98352..daee679f33b3 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -1085,7 +1085,8 @@ static void phylink_pcs_an_restart(struct phylink *pl)
+@@ -1158,7 +1158,8 @@ static void phylink_pcs_an_restart(struc
  
  /**
   * phylink_pcs_neg_mode() - helper to determine PCS inband mode
@@ -36,7 +34,7 @@ index 30a654e98352..daee679f33b3 100644
   * @interface: interface mode to be used
   * @advertising: adertisement ethtool link mode mask
   *
-@@ -1102,11 +1103,13 @@ static void phylink_pcs_an_restart(struct phylink *pl)
+@@ -1175,11 +1176,13 @@ static void phylink_pcs_an_restart(struc
   * Note: this is for cases where the PCS itself is involved in negotiation
   * (e.g. Clause 37, SGMII and similar) not Clause 73.
   */
@@ -54,7 +52,7 @@ index 30a654e98352..daee679f33b3 100644
  
  	switch (interface) {
  	case PHY_INTERFACE_MODE_SGMII:
-@@ -1147,7 +1150,7 @@ static unsigned int phylink_pcs_neg_mode(unsigned int mode,
+@@ -1219,7 +1222,7 @@ static unsigned int phylink_pcs_neg_mode
  		break;
  	}
  
@@ -63,7 +61,7 @@ index 30a654e98352..daee679f33b3 100644
  }
  
  static void phylink_major_config(struct phylink *pl, bool restart,
-@@ -1161,10 +1164,6 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1233,10 +1236,6 @@ static void phylink_major_config(struct
  
  	phylink_dbg(pl, "major config %s\n", phy_modes(state->interface));
  
@@ -74,8 +72,8 @@ index 30a654e98352..daee679f33b3 100644
  	if (pl->using_mac_select_pcs) {
  		pcs = pl->mac_ops->mac_select_pcs(pl->config, state->interface);
  		if (IS_ERR(pcs)) {
-@@ -1177,6 +1176,8 @@ static void phylink_major_config(struct phylink *pl, bool restart,
- 		pcs_changed = pl->pcs != pcs;
+@@ -1249,6 +1248,8 @@ static void phylink_major_config(struct
+ 		pcs_changed = pcs && pl->pcs != pcs;
  	}
  
 +	phylink_pcs_neg_mode(pl, pcs, state->interface, state->advertising);
@@ -83,7 +81,7 @@ index 30a654e98352..daee679f33b3 100644
  	phylink_pcs_poll_stop(pl);
  
  	if (pl->mac_ops->mac_prepare) {
-@@ -1267,9 +1268,8 @@ static int phylink_change_inband_advert(struct phylink *pl)
+@@ -1339,9 +1340,8 @@ static int phylink_change_inband_advert(
  		    pl->link_config.pause);
  
  	/* Recompute the PCS neg mode */
@@ -95,6 +93,3 @@ index 30a654e98352..daee679f33b3 100644
  
  	neg_mode = pl->cur_link_an_mode;
  	if (pl->pcs->neg_mode)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-02-v6.14-net-phylink-split-cur_link_an_mode-into-requested-an.patch
+++ b/target/linux/airoha/patches-6.6/903-02-v6.14-net-phylink-split-cur_link_an_mode-into-requested-an.patch
@@ -30,8 +30,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 60 ++++++++++++++++++++-------------------
  1 file changed, 31 insertions(+), 29 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index daee679f33b3..098021f1ab49 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
 @@ -56,7 +56,8 @@ struct phylink {
@@ -44,7 +42,7 @@ index daee679f33b3..098021f1ab49 100644
  	u8 link_port;			/* The current non-phy ethtool port */
  	__ETHTOOL_DECLARE_LINK_MODE_MASK(supported);
  
-@@ -1065,13 +1066,13 @@ static void phylink_mac_config(struct phylink *pl,
+@@ -1138,13 +1139,13 @@ static void phylink_mac_config(struct ph
  
  	phylink_dbg(pl,
  		    "%s: mode=%s/%s/%s adv=%*pb pause=%02x\n",
@@ -60,7 +58,7 @@ index daee679f33b3..098021f1ab49 100644
  }
  
  static void phylink_pcs_an_restart(struct phylink *pl)
-@@ -1079,7 +1080,7 @@ static void phylink_pcs_an_restart(struct phylink *pl)
+@@ -1152,7 +1153,7 @@ static void phylink_pcs_an_restart(struc
  	if (pl->pcs && linkmode_test_bit(ETHTOOL_LINK_MODE_Autoneg_BIT,
  					 pl->link_config.advertising) &&
  	    phy_interface_mode_is_8023z(pl->link_config.interface) &&
@@ -69,7 +67,7 @@ index daee679f33b3..098021f1ab49 100644
  		pl->pcs->ops->pcs_an_restart(pl->pcs);
  }
  
-@@ -1109,7 +1110,7 @@ static void phylink_pcs_neg_mode(struct phylink *pl, struct phylink_pcs *pcs,
+@@ -1182,7 +1183,7 @@ static void phylink_pcs_neg_mode(struct
  {
  	unsigned int neg_mode, mode;
  
@@ -78,7 +76,7 @@ index daee679f33b3..098021f1ab49 100644
  
  	switch (interface) {
  	case PHY_INTERFACE_MODE_SGMII:
-@@ -1151,6 +1152,7 @@ static void phylink_pcs_neg_mode(struct phylink *pl, struct phylink_pcs *pcs,
+@@ -1223,6 +1224,7 @@ static void phylink_pcs_neg_mode(struct
  	}
  
  	pl->pcs_neg_mode = neg_mode;
@@ -86,7 +84,7 @@ index daee679f33b3..098021f1ab49 100644
  }
  
  static void phylink_major_config(struct phylink *pl, bool restart,
-@@ -1181,7 +1183,7 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1253,7 +1255,7 @@ static void phylink_major_config(struct
  	phylink_pcs_poll_stop(pl);
  
  	if (pl->mac_ops->mac_prepare) {
@@ -95,7 +93,7 @@ index daee679f33b3..098021f1ab49 100644
  					       state->interface);
  		if (err < 0) {
  			phylink_err(pl, "mac_prepare failed: %pe\n",
-@@ -1215,7 +1217,7 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1287,7 +1289,7 @@ static void phylink_major_config(struct
  	if (pl->pcs_state == PCS_STATE_STARTING || pcs_changed)
  		phylink_pcs_enable(pl->pcs);
  
@@ -104,7 +102,7 @@ index daee679f33b3..098021f1ab49 100644
  	if (pl->pcs && pl->pcs->neg_mode)
  		neg_mode = pl->pcs_neg_mode;
  
-@@ -1231,7 +1233,7 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1303,7 +1305,7 @@ static void phylink_major_config(struct
  		phylink_pcs_an_restart(pl);
  
  	if (pl->mac_ops->mac_finish) {
@@ -113,7 +111,7 @@ index daee679f33b3..098021f1ab49 100644
  					      state->interface);
  		if (err < 0)
  			phylink_err(pl, "mac_finish failed: %pe\n",
-@@ -1262,7 +1264,7 @@ static int phylink_change_inband_advert(struct phylink *pl)
+@@ -1334,7 +1336,7 @@ static int phylink_change_inband_advert(
  		return 0;
  
  	phylink_dbg(pl, "%s: mode=%s/%s adv=%*pb pause=%02x\n", __func__,
@@ -122,7 +120,7 @@ index daee679f33b3..098021f1ab49 100644
  		    phy_modes(pl->link_config.interface),
  		    __ETHTOOL_LINK_MODE_MASK_NBITS, pl->link_config.advertising,
  		    pl->link_config.pause);
-@@ -1271,7 +1273,7 @@ static int phylink_change_inband_advert(struct phylink *pl)
+@@ -1343,7 +1345,7 @@ static int phylink_change_inband_advert(
  	phylink_pcs_neg_mode(pl, pl->pcs, pl->link_config.interface,
  			     pl->link_config.advertising);
  
@@ -131,7 +129,7 @@ index daee679f33b3..098021f1ab49 100644
  	if (pl->pcs->neg_mode)
  		neg_mode = pl->pcs_neg_mode;
  
-@@ -1336,7 +1338,7 @@ static void phylink_mac_initial_config(struct phylink *pl, bool force_restart)
+@@ -1408,7 +1410,7 @@ static void phylink_mac_initial_config(s
  {
  	struct phylink_link_state link_state;
  
@@ -140,7 +138,7 @@ index daee679f33b3..098021f1ab49 100644
  	case MLO_AN_PHY:
  		link_state = pl->phy_state;
  		break;
-@@ -1410,14 +1412,14 @@ static void phylink_link_up(struct phylink *pl,
+@@ -1482,14 +1484,14 @@ static void phylink_link_up(struct phyli
  
  	pl->cur_interface = link_state.interface;
  
@@ -157,7 +155,7 @@ index daee679f33b3..098021f1ab49 100644
  				 pl->cur_interface, speed, duplex,
  				 !!(link_state.pause & MLO_PAUSE_TX), rx_pause);
  
-@@ -1437,7 +1439,7 @@ static void phylink_link_down(struct phylink *pl)
+@@ -1511,7 +1513,7 @@ static void phylink_link_down(struct phy
  		netif_carrier_off(ndev);
  	phylink_pcs_link_down(pl->pcs);
  
@@ -166,8 +164,8 @@ index daee679f33b3..098021f1ab49 100644
  				   pl->cur_interface);
  	phylink_info(pl, "Link is Down\n");
  }
-@@ -1463,10 +1465,10 @@ static void phylink_resolve(struct work_struct *w)
- 	} else if (pl->link_failed) {
+@@ -1537,10 +1539,10 @@ static void phylink_resolve(struct work_
+ 	} else if (pl->mac_link_dropped) {
  		link_state.link = false;
  		retrigger = true;
 -	} else if (pl->cur_link_an_mode == MLO_AN_FIXED) {
@@ -179,7 +177,7 @@ index daee679f33b3..098021f1ab49 100644
  		link_state = pl->phy_state;
  		mac_config = link_state.link;
  	} else {
-@@ -1520,7 +1522,7 @@ static void phylink_resolve(struct work_struct *w)
+@@ -1594,7 +1596,7 @@ static void phylink_resolve(struct work_
  		}
  	}
  
@@ -188,7 +186,7 @@ index daee679f33b3..098021f1ab49 100644
  		phylink_apply_manual_flow(pl, &link_state);
  
  	if (mac_config) {
-@@ -1732,7 +1734,7 @@ struct phylink *phylink_create(struct phylink_config *config,
+@@ -1771,7 +1773,7 @@ struct phylink *phylink_create(struct ph
  		}
  	}
  
@@ -197,7 +195,7 @@ index daee679f33b3..098021f1ab49 100644
  
  	ret = phylink_register_sfp(pl, fwnode);
  	if (ret < 0) {
-@@ -2189,7 +2191,7 @@ void phylink_start(struct phylink *pl)
+@@ -2234,7 +2236,7 @@ void phylink_start(struct phylink *pl)
  	ASSERT_RTNL();
  
  	phylink_info(pl, "configuring for %s/%s link mode\n",
@@ -206,7 +204,7 @@ index daee679f33b3..098021f1ab49 100644
  		     phy_modes(pl->link_config.interface));
  
  	/* Always set the carrier off */
-@@ -2474,7 +2476,7 @@ int phylink_ethtool_ksettings_get(struct phylink *pl,
+@@ -2493,7 +2495,7 @@ int phylink_ethtool_ksettings_get(struct
  
  	linkmode_copy(kset->link_modes.supported, pl->supported);
  
@@ -215,7 +213,7 @@ index daee679f33b3..098021f1ab49 100644
  	case MLO_AN_FIXED:
  		/* We are using fixed settings. Report these as the
  		 * current link settings - and note that these also
-@@ -2566,7 +2568,7 @@ int phylink_ethtool_ksettings_set(struct phylink *pl,
+@@ -2585,7 +2587,7 @@ int phylink_ethtool_ksettings_set(struct
  		/* If we have a fixed link, refuse to change link parameters.
  		 * If the link parameters match, accept them but do nothing.
  		 */
@@ -224,7 +222,7 @@ index daee679f33b3..098021f1ab49 100644
  			if (s->speed != pl->link_config.speed ||
  			    s->duplex != pl->link_config.duplex)
  				return -EINVAL;
-@@ -2582,7 +2584,7 @@ int phylink_ethtool_ksettings_set(struct phylink *pl,
+@@ -2601,7 +2603,7 @@ int phylink_ethtool_ksettings_set(struct
  		 * is our default case) but do not allow the advertisement to
  		 * be changed. If the advertisement matches, simply return.
  		 */
@@ -233,7 +231,7 @@ index daee679f33b3..098021f1ab49 100644
  			if (!linkmode_equal(config.advertising,
  					    pl->link_config.advertising))
  				return -EINVAL;
-@@ -2617,7 +2619,7 @@ int phylink_ethtool_ksettings_set(struct phylink *pl,
+@@ -2641,7 +2643,7 @@ int phylink_ethtool_ksettings_set(struct
  		linkmode_copy(support, pl->supported);
  		if (phylink_validate(pl, support, &config)) {
  			phylink_err(pl, "validation of %s/%s with support %*pb failed\n",
@@ -242,7 +240,7 @@ index daee679f33b3..098021f1ab49 100644
  				    phy_modes(config.interface),
  				    __ETHTOOL_LINK_MODE_MASK_NBITS, support);
  			return -EINVAL;
-@@ -2717,7 +2719,7 @@ int phylink_ethtool_set_pauseparam(struct phylink *pl,
+@@ -2741,7 +2743,7 @@ int phylink_ethtool_set_pauseparam(struc
  
  	ASSERT_RTNL();
  
@@ -251,7 +249,7 @@ index daee679f33b3..098021f1ab49 100644
  		return -EOPNOTSUPP;
  
  	if (!phylink_test(pl->supported, Pause) &&
-@@ -2981,7 +2983,7 @@ static int phylink_mii_read(struct phylink *pl, unsigned int phy_id,
+@@ -3005,7 +3007,7 @@ static int phylink_mii_read(struct phyli
  	struct phylink_link_state state;
  	int val = 0xffff;
  
@@ -260,7 +258,7 @@ index daee679f33b3..098021f1ab49 100644
  	case MLO_AN_FIXED:
  		if (phy_id == 0) {
  			phylink_get_fixed_state(pl, &state);
-@@ -3006,7 +3008,7 @@ static int phylink_mii_read(struct phylink *pl, unsigned int phy_id,
+@@ -3030,7 +3032,7 @@ static int phylink_mii_read(struct phyli
  static int phylink_mii_write(struct phylink *pl, unsigned int phy_id,
  			     unsigned int reg, unsigned int val)
  {
@@ -269,7 +267,7 @@ index daee679f33b3..098021f1ab49 100644
  	case MLO_AN_FIXED:
  		break;
  
-@@ -3196,9 +3198,9 @@ static void phylink_sfp_set_config(struct phylink *pl, u8 mode,
+@@ -3220,9 +3222,9 @@ static void phylink_sfp_set_config(struc
  		changed = true;
  	}
  
@@ -281,6 +279,3 @@ index daee679f33b3..098021f1ab49 100644
  		pl->link_config.interface = state->interface;
  
  		changed = true;
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-03-v6.14-net-phylink-add-debug-for-phylink_major_config.patch
+++ b/target/linux/airoha/patches-6.6/903-03-v6.14-net-phylink-add-debug-for-phylink_major_config.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 27 ++++++++++++++++++++++++++-
  1 file changed, 26 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 098021f1ab49..fda53dd58285 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -175,6 +175,24 @@ static const char *phylink_an_mode_str(unsigned int mode)
+@@ -176,6 +176,24 @@ static const char *phylink_an_mode_str(u
  	return mode < ARRAY_SIZE(modestr) ? modestr[mode] : "unknown";
  }
  
@@ -43,7 +41,7 @@ index 098021f1ab49..fda53dd58285 100644
  static unsigned int phylink_interface_signal_rate(phy_interface_t interface)
  {
  	switch (interface) {
-@@ -1164,7 +1182,9 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1236,7 +1254,9 @@ static void phylink_major_config(struct
  	unsigned int neg_mode;
  	int err;
  
@@ -52,9 +50,9 @@ index 098021f1ab49..fda53dd58285 100644
 +		    phylink_an_mode_str(pl->req_link_an_mode),
 +		    phy_modes(state->interface));
  
- 	if (pl->mac_ops->mac_select_pcs) {
+ 	if (pl->using_mac_select_pcs) {
  		pcs = pl->mac_ops->mac_select_pcs(pl->config, state->interface);
-@@ -1180,6 +1200,11 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1252,6 +1272,11 @@ static void phylink_major_config(struct
  
  	phylink_pcs_neg_mode(pl, pcs, state->interface, state->advertising);
  
@@ -66,6 +64,3 @@ index 098021f1ab49..fda53dd58285 100644
  	phylink_pcs_poll_stop(pl);
  
  	if (pl->mac_ops->mac_prepare) {
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-04-v6.14-net-phy-add-phy_inband_caps.patch
+++ b/target/linux/airoha/patches-6.6/903-04-v6.14-net-phy-add-phy_inband_caps.patch
@@ -35,15 +35,12 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  include/linux/phy.h   | 28 ++++++++++++++++++++++++++++
  2 files changed, 49 insertions(+)
 
-diff --git a/drivers/net/phy/phy.c b/drivers/net/phy/phy.c
-index 0d20b534122b..f42cd6584841 100644
 --- a/drivers/net/phy/phy.c
 +++ b/drivers/net/phy/phy.c
-@@ -1005,6 +1005,27 @@ static int phy_check_link_status(struct phy_device *phydev)
- 	return 0;
+@@ -973,6 +973,27 @@ static int phy_check_link_status(struct
  }
  
-+/**
+ /**
 + * phy_inband_caps - query which in-band signalling modes are supported
 + * @phydev: a pointer to a &struct phy_device
 + * @interface: the interface mode for the PHY
@@ -64,18 +61,16 @@ index 0d20b534122b..f42cd6584841 100644
 +}
 +EXPORT_SYMBOL_GPL(phy_inband_caps);
 +
- /**
++/**
   * _phy_start_aneg - start auto-negotiation for this PHY device
   * @phydev: the phy_device struct
-diff --git a/include/linux/phy.h b/include/linux/phy.h
-index 563c46205685..ccb93d892da9 100644
+  *
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
-@@ -817,6 +817,24 @@ struct phy_tdr_config {
- };
+@@ -801,6 +801,24 @@ struct phy_tdr_config {
  #define PHY_PAIR_ALL -1
  
-+/**
+ /**
 + * enum link_inband_signalling - in-band signalling modes that are supported
 + *
 + * @LINK_INBAND_DISABLE: in-band signalling can be disabled
@@ -93,14 +88,14 @@ index 563c46205685..ccb93d892da9 100644
 +	LINK_INBAND_BYPASS		= BIT(2),
 +};
 +
- /**
++/**
   * struct phy_plca_cfg - Configuration of the PLCA (Physical Layer Collision
   * Avoidance) Reconciliation Sublayer.
-@@ -956,6 +974,14 @@ struct phy_driver {
- 	 */
+  *
+@@ -940,6 +958,14 @@ struct phy_driver {
  	int (*get_features)(struct phy_device *phydev);
  
-+	/**
+ 	/**
 +	 * @inband_caps: query whether in-band is supported for the given PHY
 +	 * interface mode. Returns a bitmask of bits defined by enum
 +	 * link_inband_signalling.
@@ -108,11 +103,12 @@ index 563c46205685..ccb93d892da9 100644
 +	unsigned int (*inband_caps)(struct phy_device *phydev,
 +				    phy_interface_t interface);
 +
- 	/**
++	/**
  	 * @get_rate_matching: Get the supported type of rate matching for a
  	 * particular phy interface. This is used by phy consumers to determine
-@@ -1818,6 +1844,8 @@ int phy_config_aneg(struct phy_device *phydev);
- int _phy_start_aneg(struct phy_device *phydev);
+ 	 * whether to advertise lower-speed modes for that interface. It is
+@@ -1793,6 +1819,8 @@ void phy_stop(struct phy_device *phydev)
+ int phy_config_aneg(struct phy_device *phydev);
  int phy_start_aneg(struct phy_device *phydev);
  int phy_aneg_done(struct phy_device *phydev);
 +unsigned int phy_inband_caps(struct phy_device *phydev,
@@ -120,6 +116,3 @@ index 563c46205685..ccb93d892da9 100644
  int phy_speed_down(struct phy_device *phydev, bool sync);
  int phy_speed_up(struct phy_device *phydev);
  bool phy_check_valid(int speed, int duplex, unsigned long *features);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-05-v6.14-net-phy-bcm84881-implement-phy_inband_caps-method.patch
+++ b/target/linux/airoha/patches-6.6/903-05-v6.14-net-phy-bcm84881-implement-phy_inband_caps-method.patch
@@ -15,11 +15,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/bcm84881.c | 10 ++++++++++
  1 file changed, 10 insertions(+)
 
-diff --git a/drivers/net/phy/bcm84881.c b/drivers/net/phy/bcm84881.c
-index 97da3aee4942..47405bded677 100644
 --- a/drivers/net/phy/bcm84881.c
 +++ b/drivers/net/phy/bcm84881.c
-@@ -235,11 +235,21 @@ static int bcm84881_read_status(struct phy_device *phydev)
+@@ -223,11 +223,21 @@ static int bcm84881_read_status(struct p
  	return genphy_c45_read_mdix(phydev);
  }
  
@@ -41,6 +39,3 @@ index 97da3aee4942..47405bded677 100644
  		.config_init	= bcm84881_config_init,
  		.probe		= bcm84881_probe,
  		.get_features	= bcm84881_get_features,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-06-v6.14-net-phy-marvell-implement-phy_inband_caps-method.patch
+++ b/target/linux/airoha/patches-6.6/903-06-v6.14-net-phy-marvell-implement-phy_inband_caps-method.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/marvell.c | 17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
-diff --git a/drivers/net/phy/marvell.c b/drivers/net/phy/marvell.c
-index cd50cd6a7f75..3075ebc3f964 100644
 --- a/drivers/net/phy/marvell.c
 +++ b/drivers/net/phy/marvell.c
-@@ -717,6 +717,20 @@ static int marvell_config_aneg_fiber(struct phy_device *phydev)
+@@ -673,6 +673,20 @@ static int marvell_config_aneg_fiber(str
  	return genphy_check_and_restart_aneg(phydev, changed);
  }
  
@@ -39,7 +37,7 @@ index cd50cd6a7f75..3075ebc3f964 100644
  static int m88e1111_config_aneg(struct phy_device *phydev)
  {
  	int extsr = phy_read(phydev, MII_M1111_PHY_EXT_SR);
-@@ -3677,6 +3691,7 @@ static struct phy_driver marvell_drivers[] = {
+@@ -3292,6 +3306,7 @@ static struct phy_driver marvell_drivers
  		.name = "Marvell 88E1112",
  		/* PHY_GBIT_FEATURES */
  		.probe = marvell_probe,
@@ -47,15 +45,15 @@ index cd50cd6a7f75..3075ebc3f964 100644
  		.config_init = m88e1112_config_init,
  		.config_aneg = marvell_config_aneg,
  		.config_intr = marvell_config_intr,
-@@ -3698,6 +3713,7 @@ static struct phy_driver marvell_drivers[] = {
+@@ -3312,6 +3327,7 @@ static struct phy_driver marvell_drivers
+ 		.name = "Marvell 88E1111",
  		/* PHY_GBIT_FEATURES */
- 		.flags = PHY_POLL_CABLE_TEST,
  		.probe = marvell_probe,
 +		.inband_caps = m88e1111_inband_caps,
  		.config_init = m88e1111gbe_config_init,
  		.config_aneg = m88e1111_config_aneg,
  		.read_status = marvell_read_status,
-@@ -3721,6 +3737,7 @@ static struct phy_driver marvell_drivers[] = {
+@@ -3333,6 +3349,7 @@ static struct phy_driver marvell_drivers
  		.name = "Marvell 88E1111 (Finisar)",
  		/* PHY_GBIT_FEATURES */
  		.probe = marvell_probe,
@@ -63,6 +61,3 @@ index cd50cd6a7f75..3075ebc3f964 100644
  		.config_init = m88e1111gbe_config_init,
  		.config_aneg = m88e1111_config_aneg,
  		.read_status = marvell_read_status,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-07-v6.14-net-phy-add-phy_config_inband.patch
+++ b/target/linux/airoha/patches-6.6/903-07-v6.14-net-phy-add-phy_config_inband.patch
@@ -14,15 +14,12 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  include/linux/phy.h   |  6 ++++++
  2 files changed, 38 insertions(+)
 
-diff --git a/drivers/net/phy/phy.c b/drivers/net/phy/phy.c
-index f42cd6584841..0c228aa18019 100644
 --- a/drivers/net/phy/phy.c
 +++ b/drivers/net/phy/phy.c
-@@ -1026,6 +1026,38 @@ unsigned int phy_inband_caps(struct phy_device *phydev,
- }
+@@ -994,6 +994,38 @@ unsigned int phy_inband_caps(struct phy_
  EXPORT_SYMBOL_GPL(phy_inband_caps);
  
-+/**
+ /**
 + * phy_config_inband - configure the desired PHY in-band mode
 + * @phydev: the phy_device struct
 + * @modes: in-band modes to configure
@@ -54,26 +51,25 @@ index f42cd6584841..0c228aa18019 100644
 +}
 +EXPORT_SYMBOL(phy_config_inband);
 +
- /**
++/**
   * _phy_start_aneg - start auto-negotiation for this PHY device
   * @phydev: the phy_device struct
-diff --git a/include/linux/phy.h b/include/linux/phy.h
-index ccb93d892da9..61a1bc81f597 100644
+  *
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
-@@ -982,6 +982,11 @@ struct phy_driver {
- 	unsigned int (*inband_caps)(struct phy_device *phydev,
+@@ -966,6 +966,11 @@ struct phy_driver {
  				    phy_interface_t interface);
  
-+	/**
+ 	/**
 +	 * @config_inband: configure in-band mode for the PHY
 +	 */
 +	int (*config_inband)(struct phy_device *phydev, unsigned int modes);
 +
- 	/**
++	/**
  	 * @get_rate_matching: Get the supported type of rate matching for a
  	 * particular phy interface. This is used by phy consumers to determine
-@@ -1846,6 +1851,7 @@ int phy_start_aneg(struct phy_device *phydev);
+ 	 * whether to advertise lower-speed modes for that interface. It is
+@@ -1821,6 +1826,7 @@ int phy_start_aneg(struct phy_device *ph
  int phy_aneg_done(struct phy_device *phydev);
  unsigned int phy_inband_caps(struct phy_device *phydev,
  			     phy_interface_t interface);
@@ -81,6 +77,3 @@ index ccb93d892da9..61a1bc81f597 100644
  int phy_speed_down(struct phy_device *phydev, bool sync);
  int phy_speed_up(struct phy_device *phydev);
  bool phy_check_valid(int speed, int duplex, unsigned long *features);
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-08-v6.14-net-phy-marvell-implement-config_inband-method.patch
+++ b/target/linux/airoha/patches-6.6/903-08-v6.14-net-phy-marvell-implement-config_inband-method.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/marvell.c | 31 +++++++++++++++++++++++++++++++
  1 file changed, 31 insertions(+)
 
-diff --git a/drivers/net/phy/marvell.c b/drivers/net/phy/marvell.c
-index 3075ebc3f964..b885bc0fe6e0 100644
 --- a/drivers/net/phy/marvell.c
 +++ b/drivers/net/phy/marvell.c
-@@ -731,6 +731,34 @@ static unsigned int m88e1111_inband_caps(struct phy_device *phydev,
+@@ -687,6 +687,34 @@ static unsigned int m88e1111_inband_caps
  	return 0;
  }
  
@@ -53,7 +51,7 @@ index 3075ebc3f964..b885bc0fe6e0 100644
  static int m88e1111_config_aneg(struct phy_device *phydev)
  {
  	int extsr = phy_read(phydev, MII_M1111_PHY_EXT_SR);
-@@ -3692,6 +3720,7 @@ static struct phy_driver marvell_drivers[] = {
+@@ -3307,6 +3335,7 @@ static struct phy_driver marvell_drivers
  		/* PHY_GBIT_FEATURES */
  		.probe = marvell_probe,
  		.inband_caps = m88e1111_inband_caps,
@@ -61,15 +59,7 @@ index 3075ebc3f964..b885bc0fe6e0 100644
  		.config_init = m88e1112_config_init,
  		.config_aneg = marvell_config_aneg,
  		.config_intr = marvell_config_intr,
-@@ -3714,6 +3743,7 @@ static struct phy_driver marvell_drivers[] = {
- 		.flags = PHY_POLL_CABLE_TEST,
- 		.probe = marvell_probe,
- 		.inband_caps = m88e1111_inband_caps,
-+		.config_inband = m88e1111_config_inband,
- 		.config_init = m88e1111gbe_config_init,
- 		.config_aneg = m88e1111_config_aneg,
- 		.read_status = marvell_read_status,
-@@ -3738,6 +3768,7 @@ static struct phy_driver marvell_drivers[] = {
+@@ -3328,6 +3357,7 @@ static struct phy_driver marvell_drivers
  		/* PHY_GBIT_FEATURES */
  		.probe = marvell_probe,
  		.inband_caps = m88e1111_inband_caps,
@@ -77,6 +67,11 @@ index 3075ebc3f964..b885bc0fe6e0 100644
  		.config_init = m88e1111gbe_config_init,
  		.config_aneg = m88e1111_config_aneg,
  		.read_status = marvell_read_status,
--- 
-2.51.0
-
+@@ -3350,6 +3380,7 @@ static struct phy_driver marvell_drivers
+ 		/* PHY_GBIT_FEATURES */
+ 		.probe = marvell_probe,
+ 		.inband_caps = m88e1111_inband_caps,
++		.config_inband = m88e1111_config_inband,
+ 		.config_init = m88e1111gbe_config_init,
+ 		.config_aneg = m88e1111_config_aneg,
+ 		.read_status = marvell_read_status,

--- a/target/linux/airoha/patches-6.6/903-09-v6.14-net-phylink-add-pcs_inband_caps-method.patch
+++ b/target/linux/airoha/patches-6.6/903-09-v6.14-net-phylink-add-pcs_inband_caps-method.patch
@@ -20,11 +20,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  include/linux/phylink.h   | 17 +++++++++++
  2 files changed, 77 insertions(+)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index fda53dd58285..42f3c7ccbf38 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -990,6 +990,15 @@ static void phylink_resolve_an_pause(struct phylink_link_state *state)
+@@ -1072,6 +1072,15 @@ static void phylink_resolve_an_pause(str
  	}
  }
  
@@ -40,8 +38,8 @@ index fda53dd58285..42f3c7ccbf38 100644
  static void phylink_pcs_pre_config(struct phylink_pcs *pcs,
  				   phy_interface_t interface)
  {
-@@ -1043,6 +1052,24 @@ static void phylink_pcs_link_up(struct phylink_pcs *pcs, unsigned int neg_mode,
- 		pcs->ops->pcs_link_up(pcs, neg_mode, interface, speed, duplex);
+@@ -1131,6 +1140,24 @@ static void phylink_pcs_link_down(struct
+ 		pcs->ops->pcs_link_down(pcs);
  }
  
 +/* Query inband for a specific interface mode, asking the MAC for the
@@ -65,7 +63,7 @@ index fda53dd58285..42f3c7ccbf38 100644
  static void phylink_pcs_poll_stop(struct phylink *pl)
  {
  	if (pl->cfg_link_an_mode == MLO_AN_INBAND)
-@@ -2532,6 +2559,26 @@ int phylink_ethtool_ksettings_get(struct phylink *pl,
+@@ -2551,6 +2578,26 @@ int phylink_ethtool_ksettings_get(struct
  }
  EXPORT_SYMBOL_GPL(phylink_ethtool_ksettings_get);
  
@@ -92,7 +90,7 @@ index fda53dd58285..42f3c7ccbf38 100644
  /**
   * phylink_ethtool_ksettings_set() - set the link settings
   * @pl: a pointer to a &struct phylink returned from phylink_create()
-@@ -2662,6 +2709,13 @@ int phylink_ethtool_ksettings_set(struct phylink *pl,
+@@ -2686,6 +2733,13 @@ int phylink_ethtool_ksettings_set(struct
  	    phylink_is_empty_linkmode(config.advertising))
  		return -EINVAL;
  
@@ -106,7 +104,7 @@ index fda53dd58285..42f3c7ccbf38 100644
  	mutex_lock(&pl->state_mutex);
  	pl->link_config.speed = config.speed;
  	pl->link_config.duplex = config.duplex;
-@@ -3341,6 +3395,12 @@ static int phylink_sfp_config_optical(struct phylink *pl)
+@@ -3370,6 +3424,12 @@ static int phylink_sfp_config_optical(st
  	phylink_dbg(pl, "optical SFP: chosen %s interface\n",
  		    phy_modes(interface));
  
@@ -119,11 +117,9 @@ index fda53dd58285..42f3c7ccbf38 100644
  	config.interface = interface;
  
  	/* Ignore errors if we're expecting a PHY to attach later */
-diff --git a/include/linux/phylink.h b/include/linux/phylink.h
-index 5c01048860c4..5462cc6a37dc 100644
 --- a/include/linux/phylink.h
 +++ b/include/linux/phylink.h
-@@ -419,6 +419,7 @@ struct phylink_pcs {
+@@ -432,6 +432,7 @@ struct phylink_pcs {
  /**
   * struct phylink_pcs_ops - MAC PCS operations structure.
   * @pcs_validate: validate the link configuration.
@@ -131,7 +127,7 @@ index 5c01048860c4..5462cc6a37dc 100644
   * @pcs_enable: enable the PCS.
   * @pcs_disable: disable the PCS.
   * @pcs_pre_config: pre-mac_config method (for errata)
-@@ -434,6 +435,8 @@ struct phylink_pcs {
+@@ -446,6 +447,8 @@ struct phylink_pcs {
  struct phylink_pcs_ops {
  	int (*pcs_validate)(struct phylink_pcs *pcs, unsigned long *supported,
  			    const struct phylink_link_state *state);
@@ -140,11 +136,10 @@ index 5c01048860c4..5462cc6a37dc 100644
  	int (*pcs_enable)(struct phylink_pcs *pcs);
  	void (*pcs_disable)(struct phylink_pcs *pcs);
  	void (*pcs_pre_config)(struct phylink_pcs *pcs,
-@@ -470,6 +473,20 @@ struct phylink_pcs_ops {
- int pcs_validate(struct phylink_pcs *pcs, unsigned long *supported,
+@@ -483,6 +486,20 @@ int pcs_validate(struct phylink_pcs *pcs
  		 const struct phylink_link_state *state);
  
-+/**
+ /**
 + * pcs_inband_caps - query PCS in-band capabilities for interface mode.
 + * @pcs: a pointer to a &struct phylink_pcs.
 + * @interface: interface mode to be queried
@@ -158,9 +153,7 @@ index 5c01048860c4..5462cc6a37dc 100644
 +unsigned int pcs_inband_caps(struct phylink_pcs *pcs,
 +			     phy_interface_t interface);
 +
- /**
++/**
   * pcs_enable() - enable the PCS.
   * @pcs: a pointer to a &struct phylink_pcs.
--- 
-2.51.0
-
+  */

--- a/target/linux/airoha/patches-6.6/903-10-v6.14-net-mvneta-implement-pcs_inband_caps-method.patch
+++ b/target/linux/airoha/patches-6.6/903-10-v6.14-net-mvneta-implement-pcs_inband_caps-method.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/ethernet/marvell/mvneta.c | 27 +++++++++++++++++----------
  1 file changed, 17 insertions(+), 10 deletions(-)
 
-diff --git a/drivers/net/ethernet/marvell/mvneta.c b/drivers/net/ethernet/marvell/mvneta.c
-index 1fb285fa0bdb..fe6261b81540 100644
 --- a/drivers/net/ethernet/marvell/mvneta.c
 +++ b/drivers/net/ethernet/marvell/mvneta.c
-@@ -3960,20 +3960,27 @@ static struct mvneta_port *mvneta_pcs_to_port(struct phylink_pcs *pcs)
+@@ -3959,20 +3959,27 @@ static struct mvneta_port *mvneta_pcs_to
  	return container_of(pcs, struct mvneta_port, phylink_pcs);
  }
  
@@ -55,7 +53,7 @@ index 1fb285fa0bdb..fe6261b81540 100644
  }
  
  static void mvneta_pcs_get_state(struct phylink_pcs *pcs,
-@@ -4071,7 +4078,7 @@ static void mvneta_pcs_an_restart(struct phylink_pcs *pcs)
+@@ -4070,7 +4077,7 @@ static void mvneta_pcs_an_restart(struct
  }
  
  static const struct phylink_pcs_ops mvneta_phylink_pcs_ops = {
@@ -64,6 +62,3 @@ index 1fb285fa0bdb..fe6261b81540 100644
  	.pcs_get_state = mvneta_pcs_get_state,
  	.pcs_config = mvneta_pcs_config,
  	.pcs_an_restart = mvneta_pcs_an_restart,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-11-v6.14-net-mvpp2-implement-pcs_inband_caps-method.patch
+++ b/target/linux/airoha/patches-6.6/903-11-v6.14-net-mvpp2-implement-pcs_inband_caps-method.patch
@@ -14,11 +14,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  .../net/ethernet/marvell/mvpp2/mvpp2_main.c   | 25 ++++++++++++-------
  1 file changed, 16 insertions(+), 9 deletions(-)
 
-diff --git a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
-index 571631a30320..f85229a30844 100644
 --- a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
 +++ b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
-@@ -6224,19 +6224,26 @@ static const struct phylink_pcs_ops mvpp2_phylink_xlg_pcs_ops = {
+@@ -6214,19 +6214,26 @@ static const struct phylink_pcs_ops mvpp
  	.pcs_config = mvpp2_xlg_pcs_config,
  };
  
@@ -53,7 +51,7 @@ index 571631a30320..f85229a30844 100644
  }
  
  static void mvpp2_gmac_pcs_get_state(struct phylink_pcs *pcs,
-@@ -6343,7 +6350,7 @@ static void mvpp2_gmac_pcs_an_restart(struct phylink_pcs *pcs)
+@@ -6333,7 +6340,7 @@ static void mvpp2_gmac_pcs_an_restart(st
  }
  
  static const struct phylink_pcs_ops mvpp2_phylink_gmac_pcs_ops = {
@@ -62,6 +60,3 @@ index 571631a30320..f85229a30844 100644
  	.pcs_get_state = mvpp2_gmac_pcs_get_state,
  	.pcs_config = mvpp2_gmac_pcs_config,
  	.pcs_an_restart = mvpp2_gmac_pcs_an_restart,
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-12-v6.14-net-phylink-add-negotiation-of-in-band-capabilities.patch
+++ b/target/linux/airoha/patches-6.6/903-12-v6.14-net-phylink-add-negotiation-of-in-band-capabilities.patch
@@ -25,8 +25,6 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 154 +++++++++++++++++++++++++++++++++++---
  1 file changed, 144 insertions(+), 10 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index 42f3c7ccbf38..b0881fa9c72e 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
 @@ -75,6 +75,7 @@ struct phylink {
@@ -37,7 +35,7 @@ index 42f3c7ccbf38..b0881fa9c72e 100644
  	struct work_struct resolve;
  	unsigned int pcs_neg_mode;
  	unsigned int pcs_state;
-@@ -1153,10 +1154,18 @@ static void phylink_pcs_neg_mode(struct phylink *pl, struct phylink_pcs *pcs,
+@@ -1226,10 +1227,18 @@ static void phylink_pcs_neg_mode(struct
  				 phy_interface_t interface,
  				 const unsigned long *advertising)
  {
@@ -56,7 +54,7 @@ index 42f3c7ccbf38..b0881fa9c72e 100644
  	switch (interface) {
  	case PHY_INTERFACE_MODE_SGMII:
  	case PHY_INTERFACE_MODE_QSGMII:
-@@ -1168,10 +1177,7 @@ static void phylink_pcs_neg_mode(struct phylink *pl, struct phylink_pcs *pcs,
+@@ -1240,10 +1249,7 @@ static void phylink_pcs_neg_mode(struct
  		 * inband communication. Note: there exist PHYs that run
  		 * with SGMII but do not send the inband data.
  		 */
@@ -68,7 +66,7 @@ index 42f3c7ccbf38..b0881fa9c72e 100644
  		break;
  
  	case PHY_INTERFACE_MODE_1000BASEX:
-@@ -1182,18 +1188,139 @@ static void phylink_pcs_neg_mode(struct phylink *pl, struct phylink_pcs *pcs,
+@@ -1254,18 +1260,139 @@ static void phylink_pcs_neg_mode(struct
  		 * as well, but drivers may not support this, so may
  		 * need to override this.
  		 */
@@ -214,7 +212,7 @@ index 42f3c7ccbf38..b0881fa9c72e 100644
  	}
  
  	pl->pcs_neg_mode = neg_mode;
-@@ -1292,6 +1419,13 @@ static void phylink_major_config(struct phylink *pl, bool restart,
+@@ -1364,6 +1491,13 @@ static void phylink_major_config(struct
  				    ERR_PTR(err));
  	}
  
@@ -228,6 +226,3 @@ index 42f3c7ccbf38..b0881fa9c72e 100644
  	if (pl->sfp_bus) {
  		rate_kbd = phylink_interface_signal_rate(state->interface);
  		if (rate_kbd)
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/903-13-v6.14-net-phylink-remove-phylink_phy_no_inband.patch
+++ b/target/linux/airoha/patches-6.6/903-13-v6.14-net-phylink-remove-phylink_phy_no_inband.patch
@@ -16,11 +16,9 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  drivers/net/phy/phylink.c | 27 ++++++---------------------
  1 file changed, 6 insertions(+), 21 deletions(-)
 
-diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
-index b0881fa9c72e..95fbc363f9a6 100644
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -3391,10 +3391,11 @@ static phy_interface_t phylink_choose_sfp_interface(struct phylink *pl,
+@@ -3415,10 +3415,11 @@ static phy_interface_t phylink_choose_sf
  	return interface;
  }
  
@@ -33,7 +31,7 @@ index b0881fa9c72e..95fbc363f9a6 100644
  	bool changed = false;
  
  	phylink_dbg(pl, "requesting link mode %s/%s with support %*pb\n",
-@@ -3428,8 +3429,7 @@ static void phylink_sfp_set_config(struct phylink *pl, u8 mode,
+@@ -3452,8 +3453,7 @@ static void phylink_sfp_set_config(struc
  		phylink_mac_initial_config(pl, false);
  }
  
@@ -41,9 +39,9 @@ index b0881fa9c72e..95fbc363f9a6 100644
 -				  struct phy_device *phy)
 +static int phylink_sfp_config_phy(struct phylink *pl, struct phy_device *phy)
  {
+ 	__ETHTOOL_DECLARE_LINK_MODE_MASK(support1);
  	__ETHTOOL_DECLARE_LINK_MODE_MASK(support);
- 	struct phylink_link_state config;
-@@ -3473,7 +3473,7 @@ static int phylink_sfp_config_phy(struct phylink *pl, u8 mode,
+@@ -3493,7 +3493,7 @@ static int phylink_sfp_config_phy(struct
  	if (ret) {
  		phylink_err(pl,
  			    "validation of %s/%s with support %*pb failed: %pe\n",
@@ -52,7 +50,7 @@ index b0881fa9c72e..95fbc363f9a6 100644
  			    phy_modes(config.interface),
  			    __ETHTOOL_LINK_MODE_MASK_NBITS, support,
  			    ERR_PTR(ret));
-@@ -3473,7 +3473,7 @@ static int phylink_sfp_config_phy(struct phylink *pl, u8 mode,
+@@ -3502,7 +3502,7 @@ static int phylink_sfp_config_phy(struct
  
  	pl->link_port = pl->sfp_port;
  
@@ -61,7 +59,7 @@ index b0881fa9c72e..95fbc363f9a6 100644
  
  	return 0;
  }
-@@ -3548,7 +3548,7 @@ static int phylink_sfp_config_optical(struct phylink *pl)
+@@ -3577,7 +3577,7 @@ static int phylink_sfp_config_optical(st
  
  	pl->link_port = pl->sfp_port;
  
@@ -70,7 +68,7 @@ index b0881fa9c72e..95fbc363f9a6 100644
  
  	return 0;
  }
-@@ -3619,20 +3619,10 @@ static void phylink_sfp_link_up(void *upstream)
+@@ -3648,20 +3648,10 @@ static void phylink_sfp_link_up(void *up
  	phylink_enable_and_run_resolve(pl, PHYLINK_DISABLE_LINK);
  }
  
@@ -86,12 +84,12 @@ index b0881fa9c72e..95fbc363f9a6 100644
  static int phylink_sfp_connect_phy(void *upstream, struct phy_device *phy)
  {
  	struct phylink *pl = upstream;
-	phy_interface_t interface;
+ 	phy_interface_t interface;
 -	u8 mode;
  	int ret;
  
  	/*
-@@ -3642,17 +3632,12 @@ static int phylink_sfp_connect_phy(void *upstream, struct phy_device *phy)
+@@ -3673,17 +3663,12 @@ static int phylink_sfp_connect_phy(void
  	 */
  	phy_support_asym_pause(phy);
  
@@ -110,6 +108,3 @@ index b0881fa9c72e..95fbc363f9a6 100644
  	if (ret < 0)
  		return ret;
  
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/999-16-netfilter-nft_flow_offload-Add-flow-mark-to-flowtabl.patch
+++ b/target/linux/airoha/patches-6.6/999-16-netfilter-nft_flow_offload-Add-flow-mark-to-flowtabl.patch
@@ -60,11 +60,11 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static bool nft_flow_offload_skip(struct sk_buff *skb, int family)
  {
  	if (skb_sec_path(skb))
-@@ -354,6 +364,7 @@ static void nft_flow_offload_eval(const
+@@ -363,6 +373,7 @@ static void nft_flow_offload_eval(const
  	if (!flow)
  		goto err_flow_alloc;
  
 +	nft_flow_set_priority(pkt, flow, dir);
  	flow_offload_route_init(flow, &route);
- 
- 	if (tcph) {
+ 	if (tcph)
+ 		flow_offload_ct_tcp(ct);

--- a/target/linux/airoha/patches-6.6/999-17-net-airoha-Integrate-QoS-support-for-traffic-acceler.patch
+++ b/target/linux/airoha/patches-6.6/999-17-net-airoha-Integrate-QoS-support-for-traffic-acceler.patch
@@ -14,8 +14,8 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -200,7 +200,7 @@ static int airoha_get_dsa_port(struct ne
- static int airoha_ppe_foe_entry_prepare(struct airoha_foe_entry *hwe,
+@@ -274,7 +274,7 @@ static int airoha_ppe_foe_entry_prepare(
+ 					struct airoha_foe_entry *hwe,
  					struct net_device *dev, int type,
  					struct airoha_flow_data *data,
 -					int l4proto)
@@ -23,7 +23,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  {
  	u32 qdata = FIELD_PREP(AIROHA_FOE_SHAPER_ID, 0x7f), ports_pad, val;
  	int wlan_etype = -EINVAL, dsa_port = airoha_get_dsa_port(&dev);
-@@ -228,12 +228,15 @@ static int airoha_ppe_foe_entry_prepare(
+@@ -301,12 +301,15 @@ static int airoha_ppe_foe_entry_prepare(
  			       FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT,
  					  FE_PSE_PORT_CDM4);
  			qdata |= FIELD_PREP(AIROHA_FOE_ACTDP, info.bss);
@@ -31,8 +31,8 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +			wlan_etype = FIELD_PREP(AIROHA_FOE_MAC_WDMA_QOS,
 +						priority) |
 +				     FIELD_PREP(AIROHA_FOE_MAC_WDMA_BAND,
-						info.idx) |
-				     FIELD_PREP(AIROHA_FOE_MAC_WDMA_WCID,
+ 						info.idx) |
+ 				     FIELD_PREP(AIROHA_FOE_MAC_WDMA_WCID,
  						info.wcid);
  		} else {
  			struct airoha_gdm_port *port = netdev_priv(dev);
@@ -40,7 +40,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			u8 pse_port;
  
  			if (!airoha_is_valid_gdm_port(eth, port))
-@@ -240,6 +240,14 @@ static int airoha_ppe_foe_entry_prepare(
+@@ -322,6 +325,14 @@ static int airoha_ppe_foe_entry_prepare(
  
  			val |= FIELD_PREP(AIROHA_FOE_IB2_PSE_PORT, pse_port) |
  			       AIROHA_FOE_IB2_PSE_QOS;
@@ -55,7 +55,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			/* For downlink traffic consume SRAM memory for hw
  			 * forwarding descriptors queue.
  			 */
-@@ -544,6 +550,7 @@ static int airoha_ppe_flow_offload_repla
+@@ -1015,6 +1026,7 @@ static int airoha_ppe_flow_offload_repla
  	struct airoha_foe_entry hwe;
  	int err, i, offload_type;
  	u16 addr_type = 0;
@@ -63,9 +63,9 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	u8 l4proto = 0;
  
  	if (rhashtable_lookup(&eth->flow_table, &f->cookie,
-@@ -621,6 +628,9 @@ static int airoha_ppe_flow_offload_repla
- 			break;
- 		case FLOW_ACTION_PPPOE_PUSH:
+@@ -1100,6 +1112,9 @@ static int airoha_ppe_flow_offload_repla
+ 			data.pppoe.sid = act->pppoe.sid;
+ 			data.pppoe.num++;
  			break;
 +		case FLOW_ACTION_PRIORITY:
 +			priority = act->priority;
@@ -73,7 +73,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		default:
  			return -EOPNOTSUPP;
  		}
-@@ -631,7 +641,7 @@ static int airoha_ppe_flow_offload_repla
+@@ -1110,7 +1125,7 @@ static int airoha_ppe_flow_offload_repla
  		return -EINVAL;
  
  	err = airoha_ppe_foe_entry_prepare(eth, &hwe, odev, offload_type,

--- a/target/linux/airoha/patches-6.6/999-18-airoha-eth-debugfs.patch
+++ b/target/linux/airoha/patches-6.6/999-18-airoha-eth-debugfs.patch
@@ -1,7 +1,7 @@
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2432,6 +2432,129 @@ static void airoha_metadata_dst_free(str
- 	}
+@@ -2986,6 +2986,129 @@ static int airoha_setup_phylink(struct n
+ 	return 0;
  }
  
 +static int airoha_xmit_rings_show(struct seq_file *s, void *data)
@@ -130,7 +130,7 @@
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
  				 struct device_node *np, int index)
  {
-@@ -2509,6 +2632,10 @@ static int airoha_alloc_gdm_port(struct
+@@ -3074,6 +3197,10 @@ static int airoha_register_gdm_ports(str
  		if (!port)
  			continue;
  
@@ -141,7 +141,7 @@
  		err = airoha_setup_phylink(port->dev);
  		if (err)
  			return err;
-@@ -2568,6 +2695,7 @@ static int airoha_probe(struct platform_
+@@ -3152,6 +3279,7 @@ static int airoha_probe(struct platform_
  	strscpy(eth->napi_dev->name, "qdma_eth", sizeof(eth->napi_dev->name));
  	platform_set_drvdata(pdev, eth);
  
@@ -149,7 +149,7 @@
  	err = airoha_hw_init(pdev, eth);
  	if (err)
  		goto error_hw_cleanup;
-@@ -2596,6 +2724,7 @@ error_napi_stop:
+@@ -3184,6 +3312,7 @@ error_napi_stop:
  	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
  		airoha_qdma_stop_napi(&eth->qdma[i]);
  error_hw_cleanup:
@@ -157,7 +157,7 @@
  	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
  		airoha_hw_cleanup(&eth->qdma[i]);
  
-@@ -2636,6 +2765,7 @@ static void airoha_remove(struct platfor
+@@ -3233,6 +3362,7 @@ static void airoha_remove(struct platfor
  	free_netdev(eth->napi_dev);
  
  	airoha_ppe_deinit(eth);
@@ -167,7 +167,7 @@
  
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -149,6 +149,7 @@ enum trtcm_param {
+@@ -152,6 +152,7 @@ enum trtcm_param {
  #define MAX_TOKEN_SIZE_OFFSET			17
  #define TRTCM_TOKEN_RATE_MASK			GENMASK(23, 6)
  #define TRTCM_TOKEN_RATE_FRACTION_MASK		GENMASK(5, 0)
@@ -175,7 +175,7 @@
  
  struct airoha_queue_entry {
  	union {
-@@ -503,6 +504,8 @@ struct airoha_eth {
+@@ -579,6 +580,8 @@ struct airoha_eth {
  
  	struct airoha_qdma qdma[AIROHA_MAX_NUM_QDMA];
  	struct airoha_gdm_port *ports[AIROHA_MAX_NUM_GDM_PORTS];
@@ -186,15 +186,15 @@
  u32 airoha_rr(void __iomem *base, u32 offset);
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -913,5 +913,4 @@ void airoha_ppe_deinit(struct airoha_eth
- 	rcu_read_unlock();
+@@ -1577,5 +1577,4 @@ void airoha_ppe_deinit(struct airoha_eth
  
+ 	rhashtable_destroy(&eth->ppe->l2_flows);
  	rhashtable_destroy(&eth->flow_table);
 -	debugfs_remove(eth->ppe->debugfs_dir);
  }
 --- a/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe_debugfs.c
-@@ -171,10 +171,13 @@ DEFINE_SHOW_ATTRIBUTE(airoha_ppe_debugfs
+@@ -177,10 +177,13 @@ DEFINE_SHOW_ATTRIBUTE(airoha_ppe_debugfs
  
  int airoha_ppe_debugfs_init(struct airoha_ppe *ppe)
  {

--- a/target/linux/airoha/patches-6.6/999-26-net-airoha-take-into-account-all-possible-GDM-combin.patch
+++ b/target/linux/airoha/patches-6.6/999-26-net-airoha-take-into-account-all-possible-GDM-combin.patch
@@ -12,7 +12,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.h
 +++ b/drivers/net/ethernet/airoha/airoha_eth.h
-@@ -621,13 +621,26 @@ u32 airoha_rmw(void __iomem *base, u32 o
+@@ -610,13 +610,26 @@ u32 airoha_rmw(void __iomem *base, u32 o
  #define airoha_qdma_clear(qdma, offset, val)			\
  	airoha_rmw((qdma)->regs, (offset), (val), 0)
  
@@ -43,7 +43,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static inline bool airoha_is_7581(struct airoha_eth *eth)
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -83,8 +83,8 @@ static void airoha_set_macaddr(struct ai
+@@ -82,8 +82,8 @@ static void airoha_set_macaddr(struct ai
  	struct airoha_eth *eth = port->qdma->eth;
  	u32 val, reg;
  
@@ -54,7 +54,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	val = (addr[0] << 16) | (addr[1] << 8) | addr[2];
  	airoha_fe_wr(eth, reg, val);
  
-@@ -3286,11 +3286,10 @@ static int airoha_register_port_debugfs(
+@@ -3110,11 +3110,10 @@ static int airoha_register_port_debugfs(
  }
  
  static int airoha_alloc_gdm_port(struct airoha_eth *eth,
@@ -67,7 +67,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	struct net_device *dev;
  	int err, p;
  	u32 id;
-@@ -3321,7 +3320,6 @@ static int airoha_alloc_gdm_port(struct
+@@ -3145,7 +3144,6 @@ static int airoha_alloc_gdm_port(struct
  		return -ENOMEM;
  	}
  
@@ -75,23 +75,23 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	dev->netdev_ops = &airoha_netdev_ops;
  	dev->ethtool_ops = &airoha_ethtool_ops;
  	dev->max_mtu = AIROHA_MAX_MTU;
-@@ -3330,7 +3328,6 @@ static int airoha_alloc_gdm_port(struct
- 	dev->features |= AIROHA_HW_FEATURES;
- 	dev->vlan_features = AIROHA_HW_FEATURES;
+@@ -3157,7 +3155,6 @@ static int airoha_alloc_gdm_port(struct
+ 	dev->features |= dev->hw_features;
+ 	dev->vlan_features = dev->hw_features;
  	dev->dev.of_node = np;
 -	dev->irq = qdma->irq_banks[0].irq;
  	SET_NETDEV_DEV(dev, eth->dev);
  
  	/* reserve hw queues for HTB offloading */
-@@ -3351,7 +3348,6 @@ static int airoha_alloc_gdm_port(struct
+@@ -3178,7 +3175,6 @@ static int airoha_alloc_gdm_port(struct
  	port = netdev_priv(dev);
  	u64_stats_init(&port->stats.syncp);
  	spin_lock_init(&port->stats.lock);
 -	port->qdma = qdma;
  	port->dev = dev;
  	port->id = id;
- 	port->np = np;
-@@ -3351,11 +3348,17 @@ static int airoha_alloc_gdm_port(struct
+ 	eth->ports[p] = port;
+@@ -3192,11 +3188,17 @@ static int airoha_register_gdm_ports(str
  
  	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
  		struct airoha_gdm_port *port = eth->ports[i];
@@ -110,7 +110,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		err = airoha_register_port_debugfs(port);
  		if (err)
  			return err;
-@@ -3456,7 +3465,6 @@ static int airoha_probe(struct platform_
+@@ -3287,7 +3289,6 @@ static int airoha_probe(struct platform_
  	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
  		airoha_qdma_start_napi(&eth->qdma[i]);
  
@@ -118,7 +118,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	for_each_child_of_node(pdev->dev.of_node, np) {
  		if (!of_device_is_compatible(np, "airoha,eth-mac"))
  			continue;
-@@ -3464,7 +3472,7 @@ static int airoha_probe(struct platform_
+@@ -3295,7 +3296,7 @@ static int airoha_probe(struct platform_
  		if (!of_device_is_available(np))
  			continue;
  
@@ -129,7 +129,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			goto error_napi_stop;
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -316,7 +316,7 @@ static int airoha_ppe_foe_entry_prepare(
+@@ -315,7 +315,7 @@ static int airoha_ppe_foe_entry_prepare(
  			if (!airoha_is_valid_gdm_port(eth, port))
  				return -EINVAL;
  
@@ -138,7 +138,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  				pse_port = port->id == 4 ? FE_PSE_PORT_GDM4
  							 : port->id;
  			else
-@@ -337,7 +337,7 @@ static int airoha_ppe_foe_entry_prepare(
+@@ -336,7 +336,7 @@ static int airoha_ppe_foe_entry_prepare(
  			/* For downlink traffic consume SRAM memory for hw
  			 * forwarding descriptors queue.
  			 */

--- a/target/linux/airoha/patches-6.6/999-51-lro.patch
+++ b/target/linux/airoha/patches-6.6/999-51-lro.patch
@@ -205,7 +205,7 @@
  		if (err)
  			return err;
  	}
-@@ -1927,6 +2050,47 @@ static int airoha_get_fe_port(struct air
+@@ -1925,6 +2048,47 @@ static int airoha_get_fe_port(struct air
  	}
  }
  
@@ -253,7 +253,7 @@
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
-@@ -2838,6 +3002,7 @@ static const struct net_device_ops airoh
+@@ -2808,6 +2972,7 @@ static const struct net_device_ops airoh
  	.ndo_stop		= airoha_dev_stop,
  	.ndo_change_mtu		= airoha_dev_change_mtu,
  	.ndo_select_queue	= airoha_dev_select_queue,
@@ -261,7 +261,7 @@
  	.ndo_start_xmit		= airoha_dev_xmit,
  	.ndo_get_stats64        = airoha_dev_get_stats64,
  	.ndo_set_mac_address	= airoha_dev_set_macaddr,
-@@ -3056,6 +3221,31 @@ static int airoha_xmit_rings_show(struct
+@@ -3023,6 +3188,31 @@ static int airoha_xmit_rings_show(struct
  }
  DEFINE_SHOW_ATTRIBUTE(airoha_xmit_rings);
  
@@ -293,7 +293,7 @@
  static int airoha_tx_meter_show(struct seq_file *s, void *data)
  {
  	struct airoha_gdm_port *port = s->private;
-@@ -3138,6 +3328,8 @@ static int airoha_register_port_debugfs(
+@@ -3105,6 +3295,8 @@ static int airoha_register_port_debugfs(
  			    &airoha_tx_meter_fops);
  	debugfs_create_file("xmit-rings", 0400, root, port,
  			    &airoha_xmit_rings_fops);
@@ -302,7 +302,7 @@
  
  	return 0;
  }
-@@ -3181,12 +3373,9 @@ static int airoha_alloc_gdm_port(struct
+@@ -3148,12 +3340,9 @@ static int airoha_alloc_gdm_port(struct
  	dev->ethtool_ops = &airoha_ethtool_ops;
  	dev->max_mtu = AIROHA_MAX_MTU;
  	dev->watchdog_timeo = 5 * HZ;

--- a/target/linux/airoha/patches-6.6/999-57-airoha-8021p-dscp-mark.patch
+++ b/target/linux/airoha/patches-6.6/999-57-airoha-8021p-dscp-mark.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -267,7 +267,8 @@ static int airoha_ppe_foe_entry_prepare(
+@@ -292,7 +292,8 @@ static int airoha_ppe_foe_entry_prepare(
  	      AIROHA_FOE_IB1_BIND_TTL;
  	hwe->ib1 = val;
  
@@ -10,7 +10,7 @@
  	if (dev) {
  		struct airoha_wdma_info info = {};
  
-@@ -365,9 +366,11 @@ static int airoha_ppe_foe_entry_prepare(
+@@ -390,9 +391,11 @@ static int airoha_ppe_foe_entry_prepare(
  	}
  
  	if (data->vlan.num) {

--- a/target/linux/airoha/patches-6.6/999-61-net-airoha-Add-missing-stats-to-ethtool_eth_mac_stat.patch
+++ b/target/linux/airoha/patches-6.6/999-61-net-airoha-Add-missing-stats-to-ethtool_eth_mac_stat.patch
@@ -16,11 +16,9 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 4 ++++
  1 file changed, 4 insertions(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 81ea01a652b9..fb8cc35ebcd6 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2020,8 +2020,12 @@ static void airoha_ethtool_get_mac_stats(struct net_device *dev,
+@@ -2238,8 +2238,12 @@ static void airoha_ethtool_get_mac_stats
  	airoha_update_hw_stats(port);
  	do {
  		start = u64_stats_fetch_begin(&port->stats.syncp);
@@ -33,6 +31,3 @@ index 81ea01a652b9..fb8cc35ebcd6 100644
  		stats->BroadcastFramesReceivedOK = port->stats.rx_broadcast;
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
--- 
-2.51.0
-

--- a/target/linux/airoha/patches-6.6/999-62-net-airoha-Add-get_link-ethtool-callback.patch
+++ b/target/linux/airoha/patches-6.6/999-62-net-airoha-Add-get_link-ethtool-callback.patch
@@ -13,18 +13,13 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index fb8cc35ebcd6..b7868003c2e6 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2768,6 +2768,7 @@ static const struct ethtool_ops airoha_ethtool_ops = {
+@@ -2987,6 +2987,7 @@ static const struct ethtool_ops airoha_e
  	.get_drvinfo		= airoha_ethtool_get_drvinfo,
  	.get_eth_mac_stats      = airoha_ethtool_get_mac_stats,
  	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
 +	.get_link		= ethtool_op_get_link,
  };
  
- static int airoha_metadata_dst_alloc(struct airoha_gdm_port *port)
--- 
-2.51.0
-
+ static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,

--- a/target/linux/airoha/patches-6.6/999-63-airoha-ethtool-link.patch
+++ b/target/linux/airoha/patches-6.6/999-63-airoha-ethtool-link.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2292,6 +2292,30 @@ airoha_ethtool_get_rmon_stats(struct net
+@@ -2289,6 +2289,30 @@ airoha_ethtool_get_rmon_stats(struct net
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
  
@@ -31,7 +31,7 @@
  static int airoha_qdma_set_chan_tx_sched(struct airoha_gdm_port *port,
  					 int channel, enum tx_sched_mode mode,
  					 const u16 *weights, u8 n_weights)
-@@ -2991,6 +3015,8 @@ static const struct ethtool_ops airoha_e
+@@ -2988,6 +3012,8 @@ static const struct ethtool_ops airoha_e
  	.get_eth_mac_stats      = airoha_ethtool_get_mac_stats,
  	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
  	.get_link		= ethtool_op_get_link,

--- a/target/linux/airoha/patches-6.6/999-64-net-airoha-Take-into-account-out-of-order-tx-complet.patch
+++ b/target/linux/airoha/patches-6.6/999-64-net-airoha-Take-into-account-out-of-order-tx-complet.patch
@@ -18,12 +18,10 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  drivers/net/ethernet/airoha/airoha_eth.c | 16 +++++++++++++++-
  1 file changed, 15 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/ethernet/airoha/airoha_eth.c b/drivers/net/ethernet/airoha/airoha_eth.c
-index 833dd911980b..9d513c62fefd 100644
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1873,6 +1873,20 @@ static u32 airoha_get_dsa_tag(struct sk_buff *skb, struct net_device *dev)
- #endif
+@@ -2089,6 +2089,20 @@ static int airoha_dev_set_features(struc
+ 	return 0;
  }
  
 +static bool airoha_dev_tx_queue_busy(struct airoha_queue *q, u32 nr_frags)
@@ -43,7 +41,7 @@ index 833dd911980b..9d513c62fefd 100644
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
-@@ -1926,7 +1940,7 @@ static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
+@@ -2142,7 +2156,7 @@ static netdev_tx_t airoha_dev_xmit(struc
  	txq = netdev_get_tx_queue(dev, qid);
  	nr_frags = 1 + skb_shinfo(skb)->nr_frags;
  
@@ -52,6 +50,3 @@ index 833dd911980b..9d513c62fefd 100644
  		/* not enough space in the queue */
  		netif_tx_stop_queue(txq);
  		spin_unlock_bh(&q->lock);
--- 
-2.51.0
-

--- a/target/linux/generic/backport-6.6/705-v6.12-netdevice-add-netdev_tx_reset_subqueue-shorthand.patch
+++ b/target/linux/generic/backport-6.6/705-v6.12-netdevice-add-netdev_tx_reset_subqueue-shorthand.patch
@@ -16,7 +16,7 @@ Signed-off-by: Tony Nguyen <anthony.l.nguyen@intel.com>
 
 --- a/include/linux/netdevice.h
 +++ b/include/linux/netdevice.h
-@@ -3616,6 +3616,17 @@ static inline void netdev_tx_reset_queue
+@@ -3614,6 +3614,17 @@ static inline void netdev_tx_reset_queue
  }
  
  /**
@@ -34,7 +34,7 @@ Signed-off-by: Tony Nguyen <anthony.l.nguyen@intel.com>
   * 	netdev_reset_queue - reset the packets and bytes count of a network device
   * 	@dev_queue: network device
   *
-@@ -3624,7 +3635,7 @@ static inline void netdev_tx_reset_queue
+@@ -3622,7 +3633,7 @@ static inline void netdev_tx_reset_queue
   */
  static inline void netdev_reset_queue(struct net_device *dev_queue)
  {


### PR DESCRIPTION
linux:
* generic & airoha: refresh linux patches
* airoha: spi: snfi driver fixes & improvements
* airoha: spi: remove snfi driver dirty hack

u-boot:
* refresh patches to apply cleanly
* speed up spinand flash operations using dma
* snfi: remove dirty hack required for both u-boot & linux
* snfi: other fixes
* eth: GDM support cleanups
* eth: fix mdio for embedded switch and link it with GDM1
* configs: minor fixes
* dts: minor fixes
* do not use get_ram_size() to get an actual ram size
* ATF related fixes