### PR TITLE
airoha: add missing def_cport for dynamic lan/wan switching

### DIFF
--- a/target/linux/airoha/patches-6.12/920-16-net-airoha-Add-ethtool-priv_flags-callbacks.patch
+++ b/target/linux/airoha/patches-6.12/920-16-net-airoha-Add-ethtool-priv_flags-callbacks.patch
@@ -32,13 +32,16 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	netif_tx_start_all_queues(netdev);
  	err = airoha_set_vip_for_gdm_port(dev, true);
  	if (err)
-@@ -1792,6 +1797,58 @@ static int airhoha_enable_gdm2_loopback(
+@@ -1792,36 +1797,102 @@ static int airhoha_enable_gdm2_loopback(
  	return 0;
  }
  
+-static int airoha_dev_init(struct net_device *netdev)
 +static void airhoha_disable_gdm2_loopback(struct airoha_gdm_dev *dev)
-+{
-+	struct airoha_eth *eth = dev->eth;
+ {
+-	struct airoha_gdm_dev *dev = netdev_priv(netdev);
+-	struct airoha_gdm_port *port = dev->port;
+ 	struct airoha_eth *eth = dev->eth;
 +	u32 pse_port, len;
 +
 +	airoha_set_gdm_port_fwd_cfg(eth, REG_GDM_FWD_CFG(AIROHA_GDM2_IDX),
@@ -63,8 +66,9 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +static struct airoha_gdm_dev *
 +airhoa_get_wan_gdm_dev(struct airoha_eth *eth)
 +{
-+	int i;
-+
+ 	int i;
+ 
+-	airoha_set_macaddr(dev, netdev->dev_addr);
 +	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
 +		struct airoha_gdm_port *port = eth->ports[i];
 +		int j;
@@ -88,24 +92,36 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +	return NULL;
 +}
 +
- static int airoha_dev_init(struct net_device *netdev)
- {
- 	struct airoha_gdm_dev *dev = netdev_priv(netdev);
-@@ -1799,18 +1856,21 @@ static int airoha_dev_init(struct net_de
- 	struct airoha_eth *eth = dev->eth;
- 	int i;
++static void airoha_dev_set_qdma(struct airoha_gdm_dev *dev)
++{
++	struct airoha_eth *eth = dev->eth;
++	int i;
++
++	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
++	dev->qdma = &eth->qdma[!airhoa_is_lan_gdm_dev(dev)];
++	dev->dev->irq = dev->qdma->irq_banks[0].irq;
++
++	for (i = 0; i < eth->soc->num_ppe; i++)
++		airoha_ppe_set_def_cport(dev, i);
++}
++
++static int airoha_dev_init(struct net_device *netdev)
++{
++	struct airoha_gdm_dev *dev = netdev_priv(netdev);
++	struct airoha_gdm_port *port = dev->port;
  
--	airoha_set_macaddr(dev, netdev->dev_addr);
--
  	switch (port->id) {
 +	case AIROHA_GDM2_IDX:
 +		/* GDM2 is always used as wan */
 +		dev->flags |= PRIV_FLAG_WAN;
 +		break;
  	case AIROHA_GDM3_IDX:
- 	case AIROHA_GDM4_IDX:
+-	case AIROHA_GDM4_IDX:
 -		/* If GDM2 is active we can't enable loopback */
 -		if (!eth->ports[1]) {
++	case AIROHA_GDM4_IDX: {
++		struct airoha_eth *eth = dev->eth;
++
 +		if (!eth->ports[1] && !airhoa_get_wan_gdm_dev(eth)) {
  			int err;
  
@@ -116,16 +132,22 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +			dev->flags |= PRIV_FLAG_WAN;
  		}
  		break;
++	}
  	default:
-@@ -1820,6 +1880,7 @@ static int airoha_dev_init(struct net_de
- 	dev->qdma = &eth->qdma[!airhoa_is_lan_gdm_dev(dev)];
- 	dev->dev->irq = dev->qdma->irq_banks[0].irq;
+ 		break;
+ 	}
+-	/* QDMA0 is used for lan ports while QDMA1 is used for WAN ports */
+-	dev->qdma = &eth->qdma[!airhoa_is_lan_gdm_dev(dev)];
+-	dev->dev->irq = dev->qdma->irq_banks[0].irq;
  
+-	for (i = 0; i < eth->soc->num_ppe; i++)
+-		airoha_ppe_set_def_cport(dev, i);
 +	airoha_set_macaddr(dev, netdev->dev_addr);
- 	for (i = 0; i < eth->soc->num_ppe; i++)
- 		airoha_ppe_set_def_cport(dev, i);
++	airoha_dev_set_qdma(dev);
  
-@@ -2083,6 +2144,73 @@ error:
+ 	return 0;
+ }
+@@ -2083,6 +2154,73 @@ error:
  	return NETDEV_TX_OK;
  }
  
@@ -185,8 +207,8 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 +		}
 +		dev->flags &= ~PRIV_FLAG_WAN;
 +	}
-+	/* If the device is used as WAN is always using QDMA1 */
-+	dev->qdma = &eth->qdma[!airhoa_is_lan_gdm_dev(dev)];
++
++	airoha_dev_set_qdma(dev);
 +
 +	return 0;
 +}
@@ -199,7 +221,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static void airoha_ethtool_get_drvinfo(struct net_device *netdev,
  				       struct ethtool_drvinfo *info)
  {
-@@ -2091,6 +2219,7 @@ static void airoha_ethtool_get_drvinfo(s
+@@ -2091,6 +2229,7 @@ static void airoha_ethtool_get_drvinfo(s
  
  	strscpy(info->driver, eth->dev->driver->name, sizeof(info->driver));
  	strscpy(info->bus_info, dev_name(eth->dev), sizeof(info->bus_info));
@@ -207,7 +229,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  }
  
  static void airoha_ethtool_get_mac_stats(struct net_device *netdev,
-@@ -2155,6 +2284,56 @@ airoha_ethtool_get_rmon_stats(struct net
+@@ -2155,6 +2294,56 @@ airoha_ethtool_get_rmon_stats(struct net
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
  
@@ -264,9 +286,9 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  static int airoha_qdma_set_chan_tx_sched(struct airoha_gdm_dev *dev,
  					 int channel, enum tx_sched_mode mode,
  					 const u16 *weights, u8 n_weights)
-@@ -2861,6 +3040,10 @@ static const struct ethtool_ops airoha_e
+@@ -2860,6 +3049,10 @@ static const struct ethtool_ops airoha_e
+ 	.get_eth_mac_stats      = airoha_ethtool_get_mac_stats,
  	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
- 	.get_link_ksettings	= phy_ethtool_get_link_ksettings,
  	.get_link		= ethtool_op_get_link,
 +	.set_priv_flags		= airoha_ethtool_set_priv_flags,
 +	.get_priv_flags		= airoha_ethtool_get_priv_flags,

--- a/target/linux/airoha/patches-6.12/920-17-move-phy-in-dev.patch
+++ b/target/linux/airoha/patches-6.12/920-17-move-phy-in-dev.patch
@@ -29,7 +29,7 @@
  	}
  #endif
  
-@@ -3050,10 +3050,10 @@ static const struct ethtool_ops airoha_e
+@@ -3059,10 +3059,10 @@ static const struct ethtool_ops airoha_e
  static struct phylink_pcs *airoha_phylink_mac_select_pcs(struct phylink_config *config,
  							 phy_interface_t interface)
  {
@@ -43,7 +43,7 @@
  }
  
  static void airoha_mac_config(struct phylink_config *config, unsigned int mode,
-@@ -3119,9 +3119,10 @@ static void airoha_mac_link_up(struct ph
+@@ -3128,9 +3128,10 @@ static void airoha_mac_link_up(struct ph
  			       unsigned int mode, phy_interface_t interface,
  			       int speed, int duplex, bool tx_pause, bool rx_pause)
  {
@@ -57,7 +57,7 @@
  	struct airoha_eth *eth = qdma->eth;
  	u32 frag_size_tx, frag_size_rx;
  
-@@ -3162,48 +3163,47 @@ static const struct phylink_mac_ops airo
+@@ -3171,48 +3172,47 @@ static const struct phylink_mac_ops airo
  	.mac_link_down = airoha_mac_link_down,
  };
  
@@ -123,7 +123,7 @@
  
  	return 0;
  }
-@@ -3272,6 +3272,14 @@ static int airoha_alloc_gdm_device(struc
+@@ -3281,6 +3281,14 @@ static int airoha_alloc_gdm_device(struc
  	dev->nbq = nbq;
  	port->devs[index] = dev;
  
@@ -138,7 +138,7 @@
  	return 0;
  }
  
-@@ -3315,14 +3323,6 @@ static int airoha_alloc_gdm_port(struct
+@@ -3324,14 +3332,6 @@ static int airoha_alloc_gdm_port(struct
  	if (err)
  		return err;
  
@@ -153,7 +153,7 @@
  	for_each_child_of_node(np, node) {
  		/* Multiple external serdes connected to the FE GDM port via an
  		 * external arbiter.
-@@ -3491,19 +3491,19 @@ error_hw_cleanup:
+@@ -3500,19 +3500,19 @@ error_hw_cleanup:
  			continue;
  
  		airoha_metadata_dst_free(port);
@@ -180,7 +180,7 @@
  			if (dev->dev->reg_state == NETREG_REGISTERED)
  				unregister_netdev(dev->dev);
  		}
-@@ -3533,18 +3533,19 @@ static void airoha_remove(struct platfor
+@@ -3542,18 +3542,19 @@ static void airoha_remove(struct platfor
  
  		airoha_metadata_dst_free(port);
  

--- a/target/linux/airoha/patches-6.12/921-net-airoha-npu-Dump-fw-version-during-probe.patch
+++ b/target/linux/airoha/patches-6.12/921-net-airoha-npu-Dump-fw-version-during-probe.patch
@@ -13,7 +13,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_npu.c
 +++ b/drivers/net/ethernet/airoha/airoha_npu.c
-@@ -663,6 +663,7 @@ static int airoha_npu_probe(struct platf
+@@ -698,6 +698,7 @@ static int airoha_npu_probe(struct platf
  	struct device_node *np;
  	void __iomem *base;
  	int i, irq, err;
@@ -21,7 +21,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  
  	base = devm_platform_ioremap_resource(pdev, 0);
  	if (IS_ERR(base))
-@@ -762,6 +763,11 @@ static int airoha_npu_probe(struct platf
+@@ -797,6 +798,11 @@ static int airoha_npu_probe(struct platf
  	regmap_write(npu->regmap, REG_CR_BOOT_TRIGGER, 0x1);
  	msleep(100);
  

--- a/target/linux/airoha/patches-6.12/922-net-airoha-Fix-schedule-while-atomic-issue-in-airoha.patch
+++ b/target/linux/airoha/patches-6.12/922-net-airoha-Fix-schedule-while-atomic-issue-in-airoha.patch
@@ -16,7 +16,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_ppe.c
 +++ b/drivers/net/ethernet/airoha/airoha_ppe.c
-@@ -1548,13 +1548,16 @@ void airoha_ppe_deinit(struct airoha_eth
+@@ -1578,13 +1578,16 @@ void airoha_ppe_deinit(struct airoha_eth
  {
  	struct airoha_npu *npu;
  

--- a/target/linux/airoha/patches-6.12/923-net-airoha-better-handle-MIB-for-GDM-with-multiple-p.patch
+++ b/target/linux/airoha/patches-6.12/923-net-airoha-better-handle-MIB-for-GDM-with-multiple-p.patch
@@ -231,7 +231,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  }
  
  static int airoha_dev_open(struct net_device *netdev)
-@@ -1872,6 +1880,10 @@ static int airoha_dev_init(struct net_de
+@@ -1885,6 +1893,10 @@ static int airoha_dev_init(struct net_de
  
  			dev->flags |= PRIV_FLAG_WAN;
  		}
@@ -240,9 +240,9 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +			      FE_GDM_TX_MIB_SPLIT_EN_MASK |
 +			      FE_GDM_RX_MIB_SPLIT_EN_MASK);
  		break;
+ 	}
  	default:
- 		break;
-@@ -1891,23 +1903,22 @@ static void airoha_dev_get_stats64(struc
+@@ -1901,23 +1913,22 @@ static void airoha_dev_get_stats64(struc
  				   struct rtnl_link_stats64 *storage)
  {
  	struct airoha_gdm_dev *dev = netdev_priv(netdev);
@@ -278,7 +278,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  }
  
  static int airoha_dev_change_mtu(struct net_device *netdev, int mtu)
-@@ -2226,20 +2237,19 @@ static void airoha_ethtool_get_mac_stats
+@@ -2236,20 +2247,19 @@ static void airoha_ethtool_get_mac_stats
  					 struct ethtool_eth_mac_stats *stats)
  {
  	struct airoha_gdm_dev *dev = netdev_priv(netdev);
@@ -308,7 +308,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  }
  
  static const struct ethtool_rmon_hist_range airoha_ethtool_rmon_ranges[] = {
-@@ -2259,8 +2269,7 @@ airoha_ethtool_get_rmon_stats(struct net
+@@ -2269,8 +2279,7 @@ airoha_ethtool_get_rmon_stats(struct net
  			      const struct ethtool_rmon_hist_range **ranges)
  {
  	struct airoha_gdm_dev *dev = netdev_priv(netdev);
@@ -318,7 +318,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	unsigned int start;
  
  	BUILD_BUG_ON(ARRAY_SIZE(airoha_ethtool_rmon_ranges) !=
-@@ -2273,7 +2282,7 @@ airoha_ethtool_get_rmon_stats(struct net
+@@ -2283,7 +2292,7 @@ airoha_ethtool_get_rmon_stats(struct net
  	do {
  		int i;
  
@@ -327,7 +327,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		stats->fragments = hw_stats->rx_fragment;
  		stats->jabbers = hw_stats->rx_jabber;
  		for (i = 0; i < ARRAY_SIZE(airoha_ethtool_rmon_ranges) - 1;
-@@ -2281,7 +2290,7 @@ airoha_ethtool_get_rmon_stats(struct net
+@@ -2291,7 +2300,7 @@ airoha_ethtool_get_rmon_stats(struct net
  			stats->hist[i] = hw_stats->rx_len[i];
  			stats->hist_tx[i] = hw_stats->tx_len[i];
  		}
@@ -336,7 +336,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  }
  
  static int airoha_ethtool_set_priv_flags(struct net_device *netdev, u32 flags)
-@@ -3295,6 +3304,8 @@ static int airoha_alloc_gdm_device(struc
+@@ -3279,6 +3288,8 @@ static int airoha_alloc_gdm_device(struc
  	dev->port = port;
  	dev->eth = eth;
  	dev->nbq = nbq;
@@ -345,7 +345,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	port->devs[index] = dev;
  
  #if defined(CONFIG_PCS_AIROHA)
-@@ -3339,8 +3350,6 @@ static int airoha_alloc_gdm_port(struct
+@@ -3323,8 +3334,6 @@ static int airoha_alloc_gdm_port(struct
  	if (!port)
  		return -ENOMEM;
  

--- a/target/linux/airoha/patches-6.12/930-airoha-ethtool-link.patch
+++ b/target/linux/airoha/patches-6.12/930-airoha-ethtool-link.patch
@@ -1,7 +1,7 @@
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2292,6 +2292,30 @@ airoha_ethtool_get_rmon_stats(struct net
- 	} while (u64_stats_fetch_retry(&dev->stats.syncp, start));
+@@ -2328,6 +2328,30 @@ static u32 airoha_ethtool_get_priv_flags
+ 	return dev->flags;
  }
  
 +static int
@@ -31,7 +31,7 @@
  static int airoha_ethtool_get_sset_count(struct net_device *netdev, int sset)
  {
  	switch (sset) {
-@@ -2991,6 +3015,8 @@ static const struct ethtool_ops airoha_e
+@@ -3058,6 +3082,8 @@ static const struct ethtool_ops airoha_e
  	.get_eth_mac_stats      = airoha_ethtool_get_mac_stats,
  	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
  	.get_link		= ethtool_op_get_link,

--- a/target/linux/airoha/patches-6.12/931-net-airoha-fix-wrong-airoha_get_fe_port.patch
+++ b/target/linux/airoha/patches-6.12/931-net-airoha-fix-wrong-airoha_get_fe_port.patch
@@ -18,7 +18,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2003,17 +2003,9 @@ static u32 airoha_get_dsa_tag(struct sk_
+@@ -2013,17 +2013,9 @@ static u32 airoha_get_dsa_tag(struct sk_
  int airoha_get_fe_port(struct airoha_gdm_dev *dev)
  {
  	struct airoha_gdm_port *port = dev->port;


### PR DESCRIPTION
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
